### PR TITLE
feat: objective-c support (native NSURLSession)

### DIFF
--- a/src/targets/objc/index.js
+++ b/src/targets/objc/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = require('requireindex')(__dirname);
+
+module.exports._familyInfo = function () {
+  return {
+    key: 'objc',
+    title: 'Objective-C',
+    extname: '.m',
+    default: 'native'
+  };
+};

--- a/src/targets/objc/native.js
+++ b/src/targets/objc/native.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var util = require('util');
+
+module.exports = function (options) {
+  var code = [];
+
+  // Dependencies
+  code.push('#import <Foundation/Foundation.h>');
+  code.push(null);
+  code.push('NSURLSession *session = [NSURLSession sharedSession];');
+  code.push(null);
+  // Create request object
+  code.push('NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"' + this.source.fullUrl + '"]');
+  code.push('                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy');
+  code.push('                                                   timeoutInterval:10.0];');
+  code.push('[request setHTTPMethod:@"' + this.source.method + '"];');
+
+  // Set headers
+  this.source.headers.forEach(function (header) {
+    code.push('[request setValue:@"' + header.value + '" forHTTPHeaderField:@"' + header.name + '"];');
+  });
+
+  var cookies = this.source.cookies.map(function (cookie) {
+    return encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value);
+  });
+
+  if (cookies.length) {
+    code.push('[request setValue:@"' + cookies.join('; ') + '" forHTTPHeaderField:@"Cookie"];');
+  }
+
+  // Set request body
+  if (this.source.postData && this.source.postData.params || this.source.postData.text) {
+    code.push(null);
+
+    if (this.source.postData.mimeType === 'application/x-www-form-urlencoded' && this.source.postData.params) {
+      var params = this.source.postData.params;
+      code.push('NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"' + params[0].name + '=' + params[0].value + '" dataUsingEncoding:NSUTF8StringEncoding]];');
+      for (var i = 1, len = params.length; i < len; i++) {
+        code.push('[postData appendData:[@"&' + params[i].name + '=' + params[i].value + '" dataUsingEncoding:NSUTF8StringEncoding]];');
+      }
+    } else if (this.source.postData.mimeType === 'application/json' && this.source.postData.text) {
+      code.push('NSData *postData = [[NSData alloc] initWithData:[@' +  JSON.stringify(this.source.postData.text) + ' dataUsingEncoding:NSUTF8StringEncoding]];');
+    } else if (this.source.postData.text) {
+      code.push('NSData *postData = [[NSData alloc] initWithData:[@"' + this.source.postData.text + '" dataUsingEncoding:NSUTF8StringEncoding]];');
+    }
+
+    code.push("[request setHTTPBody:postData];");
+  }
+
+  // Set completion block
+  code.push(null);
+  code.push('NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request');
+  code.push('                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {');
+  code.push(null);
+  code.push('}];');
+
+  // Start request
+  code.push(null);
+  code.push('[dataTask resume];');
+
+  return code.join('\n');
+};
+
+module.exports.info = function () {
+  return {
+    family: 'objc',
+    key: 'native',
+    title: 'NSURLSession',
+    link: 'https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLSession_class/index.html',
+    description: 'Foundation\'s NSURLSession request'
+  };
+};

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ describe('HTTPSnippet', function () {
     var targets = HTTPSnippet._targets().sort();
 
     targets.should.be.an.Array;
-    targets.should.eql(['curl', 'httpie', 'node', 'ocaml', 'php', 'wget']);
+    targets.should.eql(['curl', 'httpie', 'node', 'objc', 'ocaml', 'php', 'wget']);
 
     done();
   });

--- a/test/targets/objc/native.js
+++ b/test/targets/objc/native.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var fixtures = require('../../fixtures');
+var HTTPSnippet = require('../../../src');
+var should = require('should');
+
+describe('Objective-C', function () {
+  it('should convert full request to an Obj-c snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.full).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?baz=abc&foo=bar&foo=baz"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setValue:@"text/plain" forHTTPHeaderField:@"Accept"];[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];[request setValue:@"2" forHTTPHeaderField:@"X-Pretty-Print"];[request setValue:@"foo=bar; bar=baz" forHTTPHeaderField:@"Cookie"];NSData *postData = [[NSData alloc] initWithData:[@"{\\"foo\\": \\"bar\\"}" dataUsingEncoding:NSUTF8StringEncoding]];[request setHTTPBody:postData];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert query request to an OCaml snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.query).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?key=value&baz=abc&foo=bar&foo=baz"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert simple request to an OCaml snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.simple).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?foo=bar"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];[request setValue:@"bar=baz" forHTTPHeaderField:@"Cookie"];NSData *postData = [[NSData alloc] initWithData:[@"{\\"foo\\": \\"bar\\"}" dataUsingEncoding:NSUTF8StringEncoding]];[request setHTTPBody:postData];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert short request to an OCaml snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.short).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/echo"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert http1 request to an OCaml snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.http1).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+});


### PR DESCRIPTION
Support for Foundation's NSURLSession (iOS 7/Mac OS X 10.9) and tests.

Target (language key) is 'objc'.

It doesn't support the 'indent' option since nothing is indented strictly
speaking. The only 'indentation' is  Objective-C's syntax making
some method invocations to take multiple lines.
