### PR TITLE
Fix: objc/native tests + enhancements

### DIFF
--- a/src/targets/objc/native.js
+++ b/src/targets/objc/native.js
@@ -28,7 +28,7 @@ module.exports = function (options) {
   }
 
   // Set request body
-  if (this.source.postData && this.source.postData.params || this.source.postData.text) {
+  if (this.source.postData && (this.source.postData.params || this.source.postData.text)) {
     code.push(null);
 
     if (this.source.postData.mimeType === 'application/x-www-form-urlencoded' && this.source.postData.params) {

--- a/src/targets/objc/native.js
+++ b/src/targets/objc/native.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = function (options) {
+  var opts = util._extend({
+    timeout: '10'
+  }, options);
+
   var code = [];
 
   // Dependencies
@@ -11,7 +15,7 @@ module.exports = function (options) {
   // Create request object
   code.push('NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"' + this.source.fullUrl + '"]');
   code.push('                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy');
-  code.push('                                                   timeoutInterval:10.0];');
+  code.push('                                                   timeoutInterval:' + parseInt(opts.timeout, 10).toFixed(1) + '];');
   code.push('[request setHTTPMethod:@"' + this.source.method + '"];');
 
   // Set headers

--- a/src/targets/objc/native.js
+++ b/src/targets/objc/native.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var util = require('util');
+
 module.exports = function (options) {
   var opts = util._extend({
     timeout: '10'

--- a/test/fixtures/output/curl/application-form-encoded.sh
+++ b/test/fixtures/output/curl/application-form-encoded.sh
@@ -1,4 +1,5 @@
 curl --request POST \
   --url "http://mockbin.com/har" \
   --header "Content-Type: application/x-www-form-urlencoded" \
-  --form "foo=bar"
+  --form "foo=bar" \
+  --form "hello=world"

--- a/test/fixtures/output/curl/http1.sh
+++ b/test/fixtures/output/curl/http1.sh
@@ -1,0 +1,3 @@
+curl --request GET \
+  --url "http://mockbin.com/request" \
+  --http1.0

--- a/test/fixtures/output/httpie/application-form-encoded.sh
+++ b/test/fixtures/output/httpie/application-form-encoded.sh
@@ -1,3 +1,4 @@
 http POST http://mockbin.com/har \
   Content-Type:application/x-www-form-urlencoded \
-  foo:bar
+  foo:bar \
+  hello:world

--- a/test/fixtures/output/httpie/http1.sh
+++ b/test/fixtures/output/httpie/http1.sh
@@ -1,0 +1,1 @@
+http GET http://mockbin.com/request

--- a/test/fixtures/output/node/native/http1.js
+++ b/test/fixtures/output/node/native/http1.js
@@ -1,14 +1,11 @@
 var http = require("http");
-var querystring = require("querystring");
 
 var options = {
-  "method": "POST",
+  "method": "GET",
   "hostname": "mockbin.com",
   "port": null,
-  "path": "/har?",
-  "headers": {
-    "Content-Type": "application/x-www-form-urlencoded"
-  }
+  "path": "/request?",
+  "headers": {}
 };
 
 var req = http.request(options, function (res) {
@@ -23,6 +20,4 @@ var req = http.request(options, function (res) {
   });
 });
 
-var postData = querystring.stringify({"foo":"bar","hello":"world"});
-req.write(postData);
 req.end();

--- a/test/fixtures/output/objc/native/application-form-encoded.m
+++ b/test/fixtures/output/objc/native/application-form-encoded.m
@@ -1,0 +1,20 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"POST"];
+[request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+
+NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"foo=bar" dataUsingEncoding:NSUTF8StringEncoding]];
+[postData appendData:[@"&hello=world" dataUsingEncoding:NSUTF8StringEncoding]];
+[request setHTTPBody:postData];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/objc/native/application-json.m
+++ b/test/fixtures/output/objc/native/application-json.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"POST"];
+[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+
+NSData *postData = [[NSData alloc] initWithData:[@"{\"foo\": \"bar\"}" dataUsingEncoding:NSUTF8StringEncoding]];
+[request setHTTPBody:postData];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/objc/native/cookies.m
+++ b/test/fixtures/output/objc/native/cookies.m
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"POST"];
+[request setValue:@"foo=bar; bar=baz" forHTTPHeaderField:@"Cookie"];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/objc/native/full.m
+++ b/test/fixtures/output/objc/native/full.m
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har?baz=abc&foo=bar&foo=baz"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"POST"];
+[request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+[request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+[request setValue:@"foo=bar; bar=baz" forHTTPHeaderField:@"Cookie"];
+
+NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"foo=bar" dataUsingEncoding:NSUTF8StringEncoding]];
+[request setHTTPBody:postData];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/objc/native/headers.m
+++ b/test/fixtures/output/objc/native/headers.m
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"GET"];
+[request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+[request setValue:@"Bar" forHTTPHeaderField:@"X-Foo"];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/objc/native/http1.m
+++ b/test/fixtures/output/objc/native/http1.m
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"GET"];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/objc/native/query.m
+++ b/test/fixtures/output/objc/native/query.m
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har?key=value&baz=abc&foo=bar&foo=baz"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"GET"];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/objc/native/short.m
+++ b/test/fixtures/output/objc/native/short.m
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+NSURLSession *session = [NSURLSession sharedSession];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"GET"];
+
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+
+}];
+
+[dataTask resume];

--- a/test/fixtures/output/ocaml/cohttp/application-form-encoded.ml
+++ b/test/fixtures/output/ocaml/cohttp/application-form-encoded.ml
@@ -5,7 +5,7 @@ let uri = Uri.of_string "http://mockbin.com/har" in
 let headers = Header.init ()
   |> fun h -> Header.add h "Content-Type" "application/x-www-form-urlencoded"
 in
-let body = "foo=bar" in
+let body = "foo=bar&hello=world" in
 
 Client.call ~headers ~body (Code.method_of_string "POST") uri
 >>= fun (res, body_stream) ->

--- a/test/fixtures/output/ocaml/cohttp/http1.ml
+++ b/test/fixtures/output/ocaml/cohttp/http1.ml
@@ -1,0 +1,8 @@
+open Cohttp_lwt_unix
+open Lwt
+
+let uri = Uri.of_string "http://mockbin.com/request" in
+
+Client.call (Code.method_of_string "GET") uri
+>>= fun (res, body_stream) ->
+  (* Do stuff with the result *)

--- a/test/fixtures/requests/application-form-encoded.json
+++ b/test/fixtures/requests/application-form-encoded.json
@@ -13,6 +13,10 @@
       {
         "name": "foo",
         "value": "bar"
+      },
+      {
+        "name": "hello",
+        "value": "world"
       }
     ]
   }

--- a/test/index.js
+++ b/test/index.js
@@ -98,7 +98,7 @@ describe('HTTPSnippet', function () {
     done();
   });
 
-  it('should parse and queryString in the url into querString object', function (done) {
+  it('should parse a queryString in the url into querString object', function (done) {
     var req = new HTTPSnippet(fixtures.requests.query).source;
 
     req.queryString.should.be.a.Obj;

--- a/test/targets.js
+++ b/test/targets.js
@@ -22,45 +22,41 @@ var clearInfo = function (key, cb) {
 };
 
 var itShouldHaveTests = function (test, func, key) {
-  it(key + ' should have tests', function (done) {
+  it(key + ' should have tests', function () {
     test.should.have.property(func);
-    done();
   });
 };
 
 var itShouldHaveInfo = function (targets, key) {
-  it(key + ' should have info method', function (done) {
+  it(key + ' should have info method', function () {
     var target = targets[key];
 
     target.should.have.property('info').and.be.an.Object;
-
     target.info.key.should.be.a.String.and.equal(key);
-
     target.info.title.should.be.a.String;
-
-    done();
   });
 };
 
 var itShouldHaveRequestTestOutputFixture = function (request, target, path) {
-  it('should have output test for ' + request, function (done) {
-    Object.keys(output).indexOf(target + '/' + path + request + snippet.extname(target)).should.be.greaterThan(-1);
+  var fixture = target + '/' + path + request + snippet.extname(target);
 
-    done();
+  it('should have output test for ' + request, function () {
+    Object.keys(output).indexOf(fixture).should.be.greaterThan(-1, 'Missing ' + fixture + ' fixture file for target: ' + target + '. Snippet tests will be skipped.');
   });
 };
 
 var itShouldGenerateOutput = function (request, path, target, client) {
   var fixture = path + request + snippet.extname(target);
 
-  it('should generate ' + request, function (done) {
+  it('should generate ' + request + ' snippet', function () {
+    if (Object.keys(output).indexOf(fixture) === -1) {
+      this.skip();
+    }
     var instance = new snippet(fixtures.requests[request]);
     var result = instance.convert(target, client) + '\n';
 
     result.should.be.a.String;
     result.should.equal(output[fixture].toString());
-
-    done();
   });
 };
 
@@ -68,9 +64,8 @@ describe('Available Targets', function () {
   var targets = snippet.availableTargets();
 
   targets.map(function (target) {
-    it('available-targets.json should include ' + target.title, function (done) {
+    it('available-targets.json should include ' + target.title, function () {
       fixtures['available-targets'].should.containEql(target);
-      done();
     });
   });
 });
@@ -87,7 +82,7 @@ async.each(Object.keys(targets), function (target) {
     }
 
     if (!targets[target].index) {
-      describe('requests', function () {
+      describe('snippets', function () {
         async.filter(Object.keys(fixtures.requests), clearInfo, function (requests) {
           async.each(requests, function (request) {
             itShouldHaveRequestTestOutputFixture(request, target, '');
@@ -109,7 +104,7 @@ async.each(Object.keys(targets), function (target) {
             tests[target][client](snippet, fixtures);
           }
 
-          describe('requests', function () {
+          describe('snippets', function () {
             async.filter(Object.keys(fixtures.requests), clearInfo, function (requests) {
               async.each(requests, function (request) {
                 itShouldHaveRequestTestOutputFixture(request, target, client + '/');

--- a/test/tests/curl.js
+++ b/test/tests/curl.js
@@ -3,7 +3,7 @@
 require('should');
 
 module.exports = function (snippet, fixtures) {
-  it('should use short options', function (done) {
+  it('should use short options', function () {
     var result = new snippet(fixtures.requests.full).convert('curl', {
       short: true,
       indent: false
@@ -11,29 +11,23 @@ module.exports = function (snippet, fixtures) {
 
     result.should.be.a.String;
     // result.should.eql('curl -X POST "http://mockbin.com/request?foo=bar" -H "Content-Type: application/json" -b "bar=baz" -d "{\\"foo\\": \\"bar\\"}"');
-
-    done();
   });
 
-  it('should use --http1.0 for HTTP/1.0', function (done) {
+  it('should use --http1.0 for HTTP/1.0', function () {
     var result = new snippet(fixtures.curl.http1).convert('curl', {
       indent: false
     });
 
     result.should.be.a.String;
     result.should.eql('curl --request GET --url "http://mockbin.com/request" --http1.0');
-
-    done();
   });
 
-  it('should use custom indentation', function (done) {
+  it('should use custom indentation', function () {
     var result = new snippet(fixtures.requests.full).convert('curl', {
       indent: '@'
     });
 
     result.should.be.a.String;
     // result.replace(/\\\n/g, '').should.eql('curl --request POST @--url "http://mockbin.com/request?foo=bar" @--header "Content-Type: application/json" @--cookie "bar=baz" @--data "{\\"foo\\": \\"bar\\"}"');
-
-    done();
   });
 };

--- a/test/tests/httpie.js
+++ b/test/tests/httpie.js
@@ -3,7 +3,7 @@
 require('should');
 
 module.exports = function (snippet, fixtures) {
-  it('should ask for verbose output', function (done) {
+  it('should ask for verbose output', function () {
     var result = new snippet(fixtures.requests.short).convert('httpie', {
       indent: false,
       verbose: true
@@ -11,11 +11,9 @@ module.exports = function (snippet, fixtures) {
 
     result.should.be.a.String;
     result.should.eql('http --verbose GET http://mockbin.com/har');
-
-    done();
   });
 
-  it('should add flags', function (done) {
+  it('should add flags', function () {
     var result = new snippet(fixtures.requests.short).convert('httpie', {
       indent: false,
       cert: 'foo',
@@ -24,22 +22,18 @@ module.exports = function (snippet, fixtures) {
 
     result.should.be.a.String;
     result.should.eql('http --verbose --cert=foo GET http://mockbin.com/har');
-
-    done();
   });
 
-  it('should use custom indentation', function (done) {
+  it('should use custom indentation', function () {
     var result = new snippet(fixtures.requests.full).convert('httpie', {
       indent: '@'
     });
 
     result.should.be.a.String;
     // result.replace(/\\\n/g, '').should.eql('echo "{\\"foo\\": \\"bar\\"}" |  @http POST http://mockbin.com/request?foo=bar @Content-Type:application/json @Cookie:bar=baz');
-
-    done();
   });
 
-  it('should use queryString parameters', function (done) {
+  it('should use queryString parameters', function () {
     var result = new snippet(fixtures.requests.query).convert('httpie', {
       indent: false,
       queryParams: true
@@ -47,7 +41,5 @@ module.exports = function (snippet, fixtures) {
 
     result.should.be.a.String;
     result.replace(/\\\n/g, '').should.eql('http GET http://mockbin.com/har key==value baz==abc foo==bar foo==baz');
-
-    done();
   });
 };

--- a/test/tests/objc/index.js
+++ b/test/tests/objc/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('require-directory')(module);

--- a/test/tests/objc/native.js
+++ b/test/tests/objc/native.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var fixtures = require('../../fixtures');
+var HTTPSnippet = require('../../../src');
+var should = require('should');
+
+describe('Objective-C', function () {
+  it('should convert full request to a native Objective-c snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.full).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?baz=abc&foo=bar&foo=baz"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setValue:@"text/plain" forHTTPHeaderField:@"Accept"];[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];[request setValue:@"2" forHTTPHeaderField:@"X-Pretty-Print"];[request setValue:@"foo=bar; bar=baz" forHTTPHeaderField:@"Cookie"];NSData *postData = [[NSData alloc] initWithData:[@"{\\"foo\\": \\"bar\\"}" dataUsingEncoding:NSUTF8StringEncoding]];[request setHTTPBody:postData];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert query request to a native Objective-C snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.query).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?key=value&baz=abc&foo=bar&foo=baz"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert simple request to a native Objective-C snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.simple).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?foo=bar"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];[request setValue:@"bar=baz" forHTTPHeaderField:@"Cookie"];NSData *postData = [[NSData alloc] initWithData:[@"{\\"foo\\": \\"bar\\"}" dataUsingEncoding:NSUTF8StringEncoding]];[request setHTTPBody:postData];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert short request to a native Objective-C snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.short).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/echo"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+
+  it('should convert http1 request to a native Objective-C snippet', function (done) {
+    var result = new HTTPSnippet(fixtures.http1).convert('objc', 'native');
+
+    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
+
+    done();
+  });
+});

--- a/test/tests/objc/native.js
+++ b/test/tests/objc/native.js
@@ -1,47 +1,6 @@
 'use strict';
 
-var fixtures = require('../../fixtures');
-var HTTPSnippet = require('../../../src');
-var should = require('should');
+require('should');
 
-describe('Objective-C', function () {
-  it('should convert full request to a native Objective-c snippet', function (done) {
-    var result = new HTTPSnippet(fixtures.full).convert('objc', 'native');
-
-    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?baz=abc&foo=bar&foo=baz"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setValue:@"text/plain" forHTTPHeaderField:@"Accept"];[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];[request setValue:@"2" forHTTPHeaderField:@"X-Pretty-Print"];[request setValue:@"foo=bar; bar=baz" forHTTPHeaderField:@"Cookie"];NSData *postData = [[NSData alloc] initWithData:[@"{\\"foo\\": \\"bar\\"}" dataUsingEncoding:NSUTF8StringEncoding]];[request setHTTPBody:postData];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
-
-    done();
-  });
-
-  it('should convert query request to a native Objective-C snippet', function (done) {
-    var result = new HTTPSnippet(fixtures.query).convert('objc', 'native');
-
-    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?key=value&baz=abc&foo=bar&foo=baz"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
-
-    done();
-  });
-
-  it('should convert simple request to a native Objective-C snippet', function (done) {
-    var result = new HTTPSnippet(fixtures.simple).convert('objc', 'native');
-
-    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request?foo=bar"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];[request setValue:@"bar=baz" forHTTPHeaderField:@"Cookie"];NSData *postData = [[NSData alloc] initWithData:[@"{\\"foo\\": \\"bar\\"}" dataUsingEncoding:NSUTF8StringEncoding]];[request setHTTPBody:postData];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
-
-    done();
-  });
-
-  it('should convert short request to a native Objective-C snippet', function (done) {
-    var result = new HTTPSnippet(fixtures.short).convert('objc', 'native');
-
-    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/echo"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
-
-    done();
-  });
-
-  it('should convert http1 request to a native Objective-C snippet', function (done) {
-    var result = new HTTPSnippet(fixtures.http1).convert('objc', 'native');
-
-    result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSURLSession *session = [NSURLSession sharedSession];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/request"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {}];[dataTask resume];');
-
-    done();
-  });
-});
+module.exports = function (snippet, fixtures) {
+};

--- a/test/tests/wget.js
+++ b/test/tests/wget.js
@@ -3,7 +3,7 @@
 require('should');
 
 module.exports = function (snippet, fixtures) {
-  it('should use short options', function (done) {
+  it('should use short options', function () {
     var result = new snippet(fixtures.requests.full).convert('wget', {
       short: true,
       indent: false
@@ -11,11 +11,9 @@ module.exports = function (snippet, fixtures) {
 
     result.should.be.a.String;
     // result.should.eql('wget -q --method POST --header "Cookie: bar=baz" --header "Content-Type: application/json" --body-data "{\\"foo\\": \\"bar\\"}" -O - "http://mockbin.com/request?foo=bar"');
-
-    done();
   });
 
-  it('should ask for verbose output', function (done) {
+  it('should ask for verbose output', function () {
     var result = new snippet(fixtures.requests.short).convert('wget', {
       short: true,
       indent: false,
@@ -24,18 +22,14 @@ module.exports = function (snippet, fixtures) {
 
     result.should.be.a.String;
     result.should.eql('wget -v --method GET -O - "http://mockbin.com/har"');
-
-    done();
   });
 
-  it('should use custom indentation', function (done) {
+  it('should use custom indentation', function () {
     var result = new snippet(fixtures.requests.full).convert('wget', {
       indent: '@'
     });
 
     result.should.be.a.String;
     // result.replace(/\\\n/g, '').should.eql('wget --quiet @--method POST @--header "Cookie: bar=baz" @--header "Content-Type: application/json" @--body-data "{\\"foo\\": \\"bar\\"}" @--output-document @- "http://mockbin.com/request?foo=bar"');
-
-    done();
   });
 };


### PR DESCRIPTION
- `objc/native` timeout option (will be documented soon)
- `objc/native` fixtures + fix the generation
- missing fixture file results in failing test (for the fixture) (this
  behaviour is the same as before) but prints a nicer failure message
- if the fixture file is missing, snippet test will be set to pending to
  avoid a double failure
- remove done() calls in tests, we are not testing anything asynchronous
- improved applciation-form-encoded.json fixture with a new parameter
