### PR TITLE
tests: stronger application-json.json fixture

### DIFF
--- a/test/fixtures/output/curl/application-json.sh
+++ b/test/fixtures/output/curl/application-json.sh
@@ -1,4 +1,4 @@
 curl --request POST \
   --url "http://mockbin.com/har" \
   --header "content-type: application/json" \
-  --data "{\"foo\": \"bar\"}"
+  --data "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }"

--- a/test/fixtures/output/go/native/application-json.go
+++ b/test/fixtures/output/go/native/application-json.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	client := &http.Client{}
 	url := "http://mockbin.com/har"
-	payload := "{\"foo\": \"bar\"}"
+	payload := "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }"
 	req, _ := http.NewRequest("POST", url, strings.NewReader(payload))
 	req.Header.Add("content-type", "application/json")
 	res, _ := client.Do(req)

--- a/test/fixtures/output/httpie/application-json.sh
+++ b/test/fixtures/output/httpie/application-json.sh
@@ -1,3 +1,3 @@
-echo "{\"foo\": \"bar\"}" |  \
+echo "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }" |  \
   http POST http://mockbin.com/har \
   content-type:application/json

--- a/test/fixtures/output/node/native/application-json.js
+++ b/test/fixtures/output/node/native/application-json.js
@@ -23,5 +23,5 @@ var req = http.request(options, function (res) {
   });
 });
 
-req.write("{\"foo\": \"bar\"}");
+req.write("{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }");
 req.end();

--- a/test/fixtures/output/node/request/application-json.js
+++ b/test/fixtures/output/node/request/application-json.js
@@ -7,7 +7,23 @@ request({
     "content-type": "application/json"
   },
   "body": {
-    "foo": "bar"
+    "number": 1,
+    "string": "f\"oo",
+    "arr": [
+      1,
+      2,
+      3
+    ],
+    "nested": {
+      "a": "b"
+    },
+    "arr_mix": [
+      1,
+      "a",
+      {
+        "arr_mix_nested": {}
+      }
+    ]
   },
   "json": true
 }, function (error, response, body) {

--- a/test/fixtures/output/node/unirest/application-json.js
+++ b/test/fixtures/output/node/unirest/application-json.js
@@ -8,7 +8,23 @@ req.headers({
 
 req.type("json");
 req.send({
-  "foo": "bar"
+  "number": 1,
+  "string": "f\"oo",
+  "arr": [
+    1,
+    2,
+    3
+  ],
+  "nested": {
+    "a": "b"
+  },
+  "arr_mix": [
+    1,
+    "a",
+    {
+      "arr_mix_nested": {}
+    }
+  ]
 });
 
 req.end(function (res) {

--- a/test/fixtures/output/objc/native/application-json.m
+++ b/test/fixtures/output/objc/native/application-json.m
@@ -8,7 +8,7 @@ NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWit
 [request setHTTPMethod:@"POST"];
 [request setValue:@"application/json" forHTTPHeaderField:@"content-type"];
 
-NSData *postData = [[NSData alloc] initWithData:[@"{\"foo\": \"bar\"}" dataUsingEncoding:NSUTF8StringEncoding]];
+NSData *postData = [[NSData alloc] initWithData:[@"{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }" dataUsingEncoding:NSUTF8StringEncoding]];
 [request setHTTPBody:postData];
 
 NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request

--- a/test/fixtures/output/ocaml/cohttp/application-json.ml
+++ b/test/fixtures/output/ocaml/cohttp/application-json.ml
@@ -5,7 +5,7 @@ let uri = Uri.of_string "http://mockbin.com/har" in
 let headers = Header.init ()
   |> fun h -> Header.add h "content-type" "application/json"
 in
-let body = "{\"foo\": \"bar\"}" in
+let body = "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }" in
 
 Client.call ~headers ~body (Code.method_of_string "POST") uri
 >>= fun (res, body_stream) ->

--- a/test/fixtures/output/php/curl/application-json.php
+++ b/test/fixtures/output/php/curl/application-json.php
@@ -10,7 +10,7 @@ curl_setopt_array($curl, array(
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
-  CURLOPT_POSTFIELDS => "{\"foo\": \"bar\"}",
+  CURLOPT_POSTFIELDS => "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }",
   CURLOPT_HTTPHEADER => array(
     "content-type: application/json"
   ),

--- a/test/fixtures/output/wget/application-json.sh
+++ b/test/fixtures/output/wget/application-json.sh
@@ -1,6 +1,6 @@
 wget --quiet \
   --method POST \
   --header "content-type: application/json" \
-  --body-data "{\"foo\": \"bar\"}" \
+  --body-data "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }" \
   --output-document \
   - "http://mockbin.com/har"

--- a/test/fixtures/requests/application-json.json
+++ b/test/fixtures/requests/application-json.json
@@ -9,6 +9,6 @@
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"foo\": \"bar\"}"
+    "text": "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }"
   }
 }


### PR DESCRIPTION
Losing my mind on every rebase I'm doing with that, so here's a PR just for this.

This allows languages willing to parse the JSON object to test the behaviour against a nastier JSON object. Targets sending a string should see no difference.
