### PR TITLE
Use proper quoting in HTTPie shell commands

### DIFF
--- a/src/targets/httpie.js
+++ b/src/targets/httpie.js
@@ -2,6 +2,18 @@
 
 var util = require('util')
 
+var shellQuote = function (value) {
+  // Unless `value` is a simple shell-safe string, quote it.
+  var shellSafe = /^[a-z0-9-_/.@%^=:]+$/i
+  if (!shellSafe.test(value)) {
+    // Use "strong quoting" using single quotes so that we only need
+    // to deal with nested single quote characters.
+    // <http://wiki.bash-hackers.org/syntax/quoting#strong_quoting>
+    return util.format("'%s'", value.replace(/'/g, "'\\''"))
+  }
+  return value
+}
+
 module.exports = function (source, options) {
   var opts = util._extend({
     queryParams: false,
@@ -22,7 +34,7 @@ module.exports = function (source, options) {
 
   // start with body pipe
   if (source.postData && source.postData.text) {
-    code.push(util.format('echo %s | ', JSON.stringify(source.postData.text)))
+    code.push(util.format('echo %s | ', shellQuote(source.postData.text)))
   }
 
   var flags = []
@@ -63,7 +75,7 @@ module.exports = function (source, options) {
     flags.push(util.format('--timeout=%s', opts.timeout))
   }
 
-  code.push(util.format('http %s%s %s', flags.length ? flags.join(' ') + ' ' : '', source.method, opts.queryParams ? source.url : source.fullUrl))
+  code.push(util.format('http %s%s %s', flags.length ? flags.join(' ') + ' ' : '', source.method, shellQuote(opts.queryParams ? source.url : source.fullUrl)))
 
   // construct query params
   if (opts.queryParams) {
@@ -74,23 +86,23 @@ module.exports = function (source, options) {
 
       if (util.isArray(value)) {
         value.map(function (val) {
-          code.push(util.format('%s==%s', name, val))
+          code.push(util.format('%s==%s', name, shellQuote(val)))
         })
       } else {
-        code.push(util.format('%s==%s', name, value))
+        code.push(util.format('%s==%s', name, shellQuote(value)))
       }
     })
   }
 
   // construct headers
   Object.keys(source.allHeaders).sort().map(function (key) {
-    code.push(util.format('%s:%s', key, source.allHeaders[key]))
+    code.push(util.format('%s:%s', key, shellQuote(source.allHeaders[key])))
   })
 
   // construct post params
   if (!source.postData.text && source.postData.params && source.postData.params.length) {
     source.postData.params.map(function (param) {
-      code.push(util.format('%s:%s', param.name, param.value))
+      code.push(util.format('%s:%s', param.name, shellQuote(param.value)))
     })
   }
 

--- a/test/fixtures/output/httpie/application-form-encoded.sh
+++ b/test/fixtures/output/httpie/application-form-encoded.sh
@@ -1,3 +1,3 @@
-echo "foo=bar&hello=world" |  \
+echo 'foo=bar&hello=world' |  \
   http POST http://mockbin.com/har \
   content-type:application/x-www-form-urlencoded

--- a/test/fixtures/output/httpie/application-json.sh
+++ b/test/fixtures/output/httpie/application-json.sh
@@ -1,3 +1,3 @@
-echo "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }" |  \
+echo '{"number": 1, "string": "f\"oo", "arr": [1, 2, 3], "nested": {"a": "b"}, "arr_mix": [1, "a", {"arr_mix_nested": {}}] }' |  \
   http POST http://mockbin.com/har \
   content-type:application/json

--- a/test/fixtures/output/httpie/cookies.sh
+++ b/test/fixtures/output/httpie/cookies.sh
@@ -1,2 +1,2 @@
 http POST http://mockbin.com/har \
-  cookie:foo=bar; bar=baz
+  cookie:'foo=bar; bar=baz'

--- a/test/fixtures/output/httpie/full.sh
+++ b/test/fixtures/output/httpie/full.sh
@@ -1,5 +1,5 @@
-echo "foo=bar" |  \
-  http POST http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value \
+echo foo=bar |  \
+  http POST 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value' \
   accept:application/json \
   content-type:application/x-www-form-urlencoded \
-  cookie:foo=bar; bar=baz
+  cookie:'foo=bar; bar=baz'

--- a/test/fixtures/output/httpie/multipart-data.sh
+++ b/test/fixtures/output/httpie/multipart-data.sh
@@ -1,3 +1,8 @@
-echo "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--" |  \
+echo '-----011000010111000001101001
+Content-Disposition: form-data; name="foo"; filename="hello.txt"
+Content-Type: text/plain
+
+Hello World
+-----011000010111000001101001--' |  \
   http POST http://mockbin.com/har \
-  content-type:multipart/form-data; boundary=---011000010111000001101001
+  content-type:'multipart/form-data; boundary=---011000010111000001101001'

--- a/test/fixtures/output/httpie/multipart-file.sh
+++ b/test/fixtures/output/httpie/multipart-file.sh
@@ -1,3 +1,8 @@
-echo "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--" |  \
+echo '-----011000010111000001101001
+Content-Disposition: form-data; name="foo"; filename="hello.txt"
+Content-Type: text/plain
+
+
+-----011000010111000001101001--' |  \
   http POST http://mockbin.com/har \
-  content-type:multipart/form-data; boundary=---011000010111000001101001
+  content-type:'multipart/form-data; boundary=---011000010111000001101001'

--- a/test/fixtures/output/httpie/multipart-form-data.sh
+++ b/test/fixtures/output/httpie/multipart-form-data.sh
@@ -1,3 +1,7 @@
-echo "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--" |  \
+echo '-----011000010111000001101001
+Content-Disposition: form-data; name="foo"
+
+bar
+-----011000010111000001101001--' |  \
   http POST http://mockbin.com/har \
-  content-type:multipart/form-data; boundary=---011000010111000001101001
+  content-type:'multipart/form-data; boundary=---011000010111000001101001'

--- a/test/fixtures/output/httpie/query.sh
+++ b/test/fixtures/output/httpie/query.sh
@@ -1,1 +1,1 @@
-http GET http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value
+http GET 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value'

--- a/test/tests/httpie.js
+++ b/test/tests/httpie.js
@@ -32,7 +32,7 @@ module.exports = function (HTTPSnippet, fixtures) {
     })
 
     result.should.be.a.String
-    result.replace(/\\\n/g, '').should.eql('echo "foo=bar" |  @http POST http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value @accept:application/json @content-type:application/x-www-form-urlencoded @cookie:foo=bar; bar=baz')
+    result.replace(/\\\n/g, '').should.eql("echo foo=bar |  @http POST 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value' @accept:application/json @content-type:application/x-www-form-urlencoded @cookie:'foo=bar; bar=baz'")
   })
 
   it('should use queryString parameters', function () {


### PR DESCRIPTION
This looks like an interesting project :+1: I've noticed a problem with quoting of the shell commands and this pull request fixes that for HTTPie:

Before, the resultant shell command was completely unquoted. This change introduces proper quoting of values and the URL - when necessary.

 It uses single quotes which provide "[strong quoting](http://wiki.bash-hackers.org/syntax/quoting#strong_quoting)" (only nested single quote characters need to be taken care of)  and  also make the output more readable as double quotes, ubiquitous in JSON, don't require escaping.

Before:

``` bash
 echo "{\"foo\": \"bar\"}" |  \ 
  http POST http://mockbin.com/request?foo=bar&foo=baz \
  accept:application/json \
  content-type:application/json \
  cookie:foo=bar; bar=baz
```

After:

``` bash
  echo '{"foo": "bar"}' |  \                                  # Improved readability
    http POST 'http://mockbin.com/request?foo=bar&foo=baz' \  # Quoted "&"
    accept:application/json \                                 # No quoting necessary
    content-type:application/json \                           # No quoting necessary
    cookie:'foo=bar; bar=baz'                                 # Quoted ";"
```

---

The cURL command (and possible also Wget) most likely suffer from improper quoting as well. It's not completely missing, as was the case of HTTPie, but it uses double quotes so literals like `"foo bar $HOME baz"` might get expanded by the shell. I think the same quoting mechanism should be used there as well.
