### PR TITLE
refactor: objc/native enhancements

### DIFF
--- a/src/targets/objc/helpers.js
+++ b/src/targets/objc/helpers.js
@@ -14,37 +14,28 @@ module.exports = {
   },
 
   /**
-   * Create a string corresponding to a valid NSDictionary declaration and initialization for Objective-C.
+   * Create a string corresponding to a valid declaration and initialization of an Objective-C object litteral.
    *
-   * @param {string} name Desired name of the NSDictionary instance
-   * @param {Object} parameters Key-value object of parameters to translate to an Objective-C NSDictionary litearal
-   * @param {boolean} indent If true, will declare the NSDictionary litteral by indenting each new key/value pair.
-   * @return {string} A valid Objective-C declaration and initialization of an NSDictionary.
+   * @param {string} nsClass Class of the litteral
+   * @param {string} name Desired name of the instance
+   * @param {Object} parameters Key-value object of parameters to translate to an Objective-C object litearal
+   * @param {boolean} indent If true, will declare the litteral by indenting each new key/value pair.
+   * @return {string} A valid Objective-C declaration and initialization of an Objective-C object litteral.
    *
    * @example
-   *   nsDictionaryBuilder('params', {a: 'b', c: 'd'}, true)
+   *   nsDeclarationBuilder('NSDictionary', 'params', {a: 'b', c: 'd'}, true)
    *   // returns:
    *   NSDictionary *params = @{ @"a": @"b",
    *                             @"c": @"d" };
    *
-   *   nsDictionaryBuilder('params', {a: 'b', c: 'd'})
+   *   nsDeclarationBuilder('NSDictionary', 'params', {a: 'b', c: 'd'})
    *   // returns:
    *   NSDictionary *params = @{ @"a": @"b", @"c": @"d" };
    */
-  nsDictionaryBuilder: function (name, parameters, indent) {
-    var dicOpening = 'NSDictionary *' + name + ' = '
-    var dicLiteral = this.literalRepresentation(parameters, indent ? dicOpening.length : undefined)
-    return dicOpening + dicLiteral + ';'
-  },
-
-  /**
-   * Similar to nsDictionaryBuilder but for NSArray literals.
-   * @see nsDictionaryBuilder
-   */
-  nsArrayBuilder: function (name, parameters, indent) {
-    var arrOpening = 'NSArray *' + name + ' = '
-    var arrLiteral = this.literalRepresentation(parameters, indent ? arrOpening.length : undefined)
-    return arrOpening + arrLiteral + ';'
+  nsDeclarationBuilder: function (nsClass, name, parameters, indent) {
+    var opening = nsClass + ' *' + name + ' = '
+    var literal = this.literalRepresentation(parameters, indent ? opening.length : undefined)
+    return opening + literal + ';'
   },
 
   /**

--- a/src/targets/objc/native.js
+++ b/src/targets/objc/native.js
@@ -1,3 +1,16 @@
+/**
+ * This file is part of the httpsnippet project (https://github.com/Mashape/httpsnippet)
+ * If you have questions or issues regarding its implementation, please open an issue.
+ * If you have questions or issues regarding the generated code snippet, please open an issue mentioning its author/contributors.
+ *
+ * @description
+ * HTTP code snippet generator for Objective-C using NSURLSession.
+ * This file tries to generate a flexible snippet than can easily be edited once pasted by the user.
+ *
+ * @author
+ * @thibaultCha
+ */
+
 'use strict'
 
 var util = require('util')
@@ -10,21 +23,21 @@ module.exports = function (source, options) {
     pretty: true
   }, options)
 
+  var indent = opts.indent
   var code = []
-
+  // Markers for headers to be created as litteral objects and later be set on the NSURLRequest if exist
   var req = {
     hasHeaders: false,
     hasBody: false
   }
 
-  var indent = opts.indent
-
+  // We just want to make sure people understand that is the only dependency
   code.push('#import <Foundation/Foundation.h>')
 
   if (Object.keys(source.allHeaders).length) {
     req.hasHeaders = true
     code.push(null)
-    code.push(objcHelpers.nsDictionaryBuilder('headers', source.allHeaders, opts.pretty))
+    code.push(objcHelpers.nsDeclarationBuilder('NSDictionary', 'headers', source.allHeaders, opts.pretty))
   }
 
   if (source.postData.text || source.postData.jsonObj || source.postData.params) {
@@ -33,23 +46,30 @@ module.exports = function (source, options) {
     switch (source.postData.mimeType) {
       case 'application/x-www-form-urlencoded':
         code.push(null)
-        // Makes it easier to implement logice than just putting the entire body string
-        code.push(util.format('NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];', source.postData.params[0].name, source.postData.params[0].value))
+        // By appending parameters one by one in the resulting snippet,
+        // we make it easier for the user to edit it according to his or her needs after pasting.
+        // The user can just add/remove lines adding/removing body parameters.
+        code.push(util.format('NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
+          source.postData.params[0].name, source.postData.params[0].value))
         for (var i = 1, len = source.postData.params.length; i < len; i++) {
-          code.push(util.format('[postData appendData:[@"&%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];', source.postData.params[i].name, source.postData.params[i].value))
+          code.push(util.format('[postData appendData:[@"&%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
+            source.postData.params[i].name, source.postData.params[i].value))
         }
         break
 
       case 'application/json':
         if (source.postData.jsonObj) {
-          code.push(objcHelpers.nsDictionaryBuilder('parameters', source.postData.jsonObj, opts.pretty))
+          code.push(objcHelpers.nsDeclarationBuilder('NSDictionary', 'parameters', source.postData.jsonObj, opts.pretty))
           code.push(null)
           code.push('NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];')
         }
         break
 
       case 'multipart/form-data':
-        code.push(objcHelpers.nsArrayBuilder('parameters', source.postData.params, opts.pretty))
+        // By appending multipart parameters one by one in the resulting snippet,
+        // we make it easier for the user to edit it according to his or her needs after pasting.
+        // The user can just edit the parameters NSDictionary or put this part of a snippet in a multipart builder method.
+        code.push(objcHelpers.nsDeclarationBuilder('NSArray', 'parameters', source.postData.params, opts.pretty))
         code.push(util.format('NSString *boundary = @"%s";', source.postData.boundary))
         code.push(null)
         code.push('NSError *error;')
@@ -59,8 +79,7 @@ module.exports = function (source, options) {
         code.push(indent + 'if (param[@"fileName"]) {')
         code.push(indent + indent + '[body appendFormat:@"Content-Disposition:form-data; name=\\"%@\\"; filename=\\"%@\\"\\r\\n", param[@"name"], param[@"fileName"]];')
         code.push(indent + indent + '[body appendFormat:@"Content-Type: %@\\r\\n\\r\\n", param[@"contentType"]];')
-        code.push(indent + indent + '[body appendFormat:@"%@", [[NSString alloc] initWithContentsOfFile:param[@"fileName"]')
-        code.push(indent + indent + '                                                          encoding:NSUTF8StringEncoding error:&error]];')
+        code.push(indent + indent + '[body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];')
         code.push(indent + indent + 'if (error) {')
         code.push(indent + indent + indent + 'NSLog(@"%@", error);')
         code.push(indent + indent + '}')
@@ -70,7 +89,7 @@ module.exports = function (source, options) {
         code.push(indent + '}')
         code.push('}')
         code.push('[body appendFormat:@"\\r\\n--%@--\\r\\n", boundary];')
-        code.push('NSData *postData = [[NSData alloc] initWithData:[body dataUsingEncoding:NSUTF8StringEncoding]];')
+        code.push('NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];')
         break
 
       default:
@@ -81,6 +100,7 @@ module.exports = function (source, options) {
 
   code.push(null)
   code.push('NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"' + source.fullUrl + '"]')
+  // NSURLRequestUseProtocolCachePolicy is the default policy, let's just always set it to avoid confusion.
   code.push('                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy')
   code.push('                                                   timeoutInterval:' + parseInt(opts.timeout, 10).toFixed(1) + '];')
   code.push('[request setHTTPMethod:@"' + source.method + '"];')
@@ -94,12 +114,14 @@ module.exports = function (source, options) {
   }
 
   code.push(null)
-  code.push('NSURLSession *session = [NSURLSession sharedSession];') // Retrieve shared session for simplicity
+  // Retrieving the shared session will be less verbose than creating a new one.
+  code.push('NSURLSession *session = [NSURLSession sharedSession];')
   code.push('NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request')
   code.push('                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {')
   code.push('                                            ' + indent + 'if (error) {')
   code.push('                                            ' + indent + indent + 'NSLog(@"%@", error);')
   code.push('                                            ' + indent + '} else {')
+  // Casting the NSURLResponse to NSHTTPURLResponse so the user can see the status code.
   code.push('                                            ' + indent + indent + 'NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;')
   code.push('                                            ' + indent + indent + 'NSLog(@"%@", httpResponse);')
   code.push('                                            ' + indent + '}')

--- a/test/fixtures/output/objc/native/multipart-data.m
+++ b/test/fixtures/output/objc/native/multipart-data.m
@@ -11,8 +11,7 @@ for (NSDictionary *param in parameters) {
     if (param[@"fileName"]) {
         [body appendFormat:@"Content-Disposition:form-data; name=\"%@\"; filename=\"%@\"\r\n", param[@"name"], param[@"fileName"]];
         [body appendFormat:@"Content-Type: %@\r\n\r\n", param[@"contentType"]];
-        [body appendFormat:@"%@", [[NSString alloc] initWithContentsOfFile:param[@"fileName"]
-                                                                  encoding:NSUTF8StringEncoding error:&error]];
+        [body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];
         if (error) {
             NSLog(@"%@", error);
         }
@@ -22,7 +21,7 @@ for (NSDictionary *param in parameters) {
     }
 }
 [body appendFormat:@"\r\n--%@--\r\n", boundary];
-NSData *postData = [[NSData alloc] initWithData:[body dataUsingEncoding:NSUTF8StringEncoding]];
+NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];
 
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
                                                        cachePolicy:NSURLRequestUseProtocolCachePolicy

--- a/test/fixtures/output/objc/native/multipart-file.m
+++ b/test/fixtures/output/objc/native/multipart-file.m
@@ -11,8 +11,7 @@ for (NSDictionary *param in parameters) {
     if (param[@"fileName"]) {
         [body appendFormat:@"Content-Disposition:form-data; name=\"%@\"; filename=\"%@\"\r\n", param[@"name"], param[@"fileName"]];
         [body appendFormat:@"Content-Type: %@\r\n\r\n", param[@"contentType"]];
-        [body appendFormat:@"%@", [[NSString alloc] initWithContentsOfFile:param[@"fileName"]
-                                                                  encoding:NSUTF8StringEncoding error:&error]];
+        [body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];
         if (error) {
             NSLog(@"%@", error);
         }
@@ -22,7 +21,7 @@ for (NSDictionary *param in parameters) {
     }
 }
 [body appendFormat:@"\r\n--%@--\r\n", boundary];
-NSData *postData = [[NSData alloc] initWithData:[body dataUsingEncoding:NSUTF8StringEncoding]];
+NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];
 
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
                                                        cachePolicy:NSURLRequestUseProtocolCachePolicy

--- a/test/fixtures/output/objc/native/multipart-form-data.m
+++ b/test/fixtures/output/objc/native/multipart-form-data.m
@@ -11,8 +11,7 @@ for (NSDictionary *param in parameters) {
     if (param[@"fileName"]) {
         [body appendFormat:@"Content-Disposition:form-data; name=\"%@\"; filename=\"%@\"\r\n", param[@"name"], param[@"fileName"]];
         [body appendFormat:@"Content-Type: %@\r\n\r\n", param[@"contentType"]];
-        [body appendFormat:@"%@", [[NSString alloc] initWithContentsOfFile:param[@"fileName"]
-                                                                  encoding:NSUTF8StringEncoding error:&error]];
+        [body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];
         if (error) {
             NSLog(@"%@", error);
         }
@@ -22,7 +21,7 @@ for (NSDictionary *param in parameters) {
     }
 }
 [body appendFormat:@"\r\n--%@--\r\n", boundary];
-NSData *postData = [[NSData alloc] initWithData:[body dataUsingEncoding:NSUTF8StringEncoding]];
+NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];
 
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
                                                        cachePolicy:NSURLRequestUseProtocolCachePolicy


### PR DESCRIPTION
Regarding #28:
- snippet now uses a less verbose NSString -> NSData encoding
- snippet now uses a less verbose way of reading the content of a file
  for multipart requests
- helpers: merge 'nsArrayBuilder' and 'nsDictionaryBuilder' into
  'nsDeclarationBuilder'
- target: header comment with general infos and author + explanatory
  comments about the snippet

Mainly pushing this so soon to see if there is any change from Code Climate. Merge can wait until a few more boxes are checked.

Update:
- Improved `helpers.js` Code Climate rating B -> A
