### PR TITLE
Add Python Requests library

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Currently the following output [targets](/src/targets) are supported:
   - [pecl/http v2](http://devel-m6w6.rhcloud.com/mdref/http)
 - Python
   - [Python 3](https://docs.python.org/3/library/http.client.html)
+  - [Requests](http://docs.python-requests.org/en/latest/api/#requests.request)
 - Objective-C
   - [NSURLSession](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLSession_class/index.html)
 - Go

--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -83,7 +83,6 @@ module.exports = function (source, options) {
   if (source.cookies.length) {
     reqOpts.jar = 'JAR'
 
-    code.push(null)
     code.push('var jar = request.jar();')
 
     var url = source.url

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -1,0 +1,90 @@
+/**
+ * @description
+ * HTTP code snippet generator for Requests
+ *
+ * @author
+ * @montanaflynn
+ *
+ * for any questions or issues regarding the generated code snippet, please open an issue mentioning the author.
+ */
+
+'use strict'
+
+var util = require('util')
+
+module.exports = function (source, options) {
+  // Start snippet
+  var code = []
+
+  // Import requests
+  code.push('import requests\n')
+
+  // Set URL
+  code.push(util.format('url = "%s"\n', source.url))
+
+  // Construct query string
+  if (source.queryString.length) {
+    var qs = 'querystring = {'
+    for (var i = 0; i < source.queryString.length; i++) {
+      for (var key in source.queryString[i]) {
+        qs += "'" + key + "':" + "'" + source.queryString[i][key] + "',"
+      }
+    }
+    qs = qs.substring(0, qs.length - 1)
+    qs += '}\n'
+    code.push(qs)
+  }
+
+  // Construct payload
+  var payload = JSON.stringify(source.postData.text)
+  if (payload) {
+    code.push(util.format('payload = %s', payload))
+  }
+
+  // Construct headers
+  var header
+  var headers = source.allHeaders
+  var headerCount = Object.keys(headers).length
+  if (headerCount === 1) {
+    for (header in headers) {
+      code.push(util.format('headers = {\'%s\': \'%s\'}\n', header, headers[header]))
+    }
+  } else if (headerCount > 1) {
+    var headerLine
+    var count = 1
+    code.push('headers = {')
+    for (header in headers) {
+      if (count++ !== headerCount) {
+        headerLine = util.format('    \'%s\': "%s",', header, headers[header])
+      } else {
+        headerLine = util.format('    \'%s\': "%s"', header, headers[header])
+      }
+      code.push(headerLine)
+    }
+    code.push('    }\n')
+  }
+
+  // Construct request
+  var method = source.method
+  var request = util.format('response = requests.request("%s", url', method)
+  if (payload) request += ', data=payload'
+  if (headerCount > 0) request += ', headers=headers'
+  if (qs) request += ', params=querystring'
+  request += ')\n'
+  code.push(request)
+
+  // Print response
+  code.push('print(response.text)')
+
+  console.log(code.join('\n'))
+  return code.join('\n')
+}
+
+module.exports.info = {
+  key: 'requests',
+  title: 'Requests',
+  link: 'http://docs.python-requests.org/en/latest/api/#requests.request',
+  description: 'Requests HTTP library'
+}
+
+// response = requests.request("POST", url, data=payload, headers=headers, params=querystring)

--- a/test/fixtures/available-targets.json
+++ b/test/fixtures/available-targets.json
@@ -122,6 +122,12 @@
         "title": "http.client",
         "link": "https://docs.python.org/3/library/http.client.html",
         "description": "Python3 HTTP Client"
+      },
+      {
+        "key": "requests",
+        "title": "Requests",
+        "link": "http://docs.python-requests.org/en/latest/api/#requests.request",
+        "description": "Requests HTTP library"
       }
     ]
   },

--- a/test/fixtures/output/node/request/cookies.js
+++ b/test/fixtures/output/node/request/cookies.js
@@ -1,6 +1,5 @@
 var request = require("request");
 
-
 var jar = request.jar();
 jar.setCookie(request.cookie("foo=bar"), "http://mockbin.com/har");
 jar.setCookie(request.cookie("bar=baz"), "http://mockbin.com/har");

--- a/test/fixtures/output/node/request/full.js
+++ b/test/fixtures/output/node/request/full.js
@@ -1,6 +1,5 @@
 var request = require("request");
 
-
 var jar = request.jar();
 jar.setCookie(request.cookie("foo=bar"), "http://mockbin.com/har");
 jar.setCookie(request.cookie("bar=baz"), "http://mockbin.com/har");

--- a/test/fixtures/output/python/requests/application-form-encoded.py
+++ b/test/fixtures/output/python/requests/application-form-encoded.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+payload = "foo=bar&hello=world"
+headers = {'content-type': 'application/x-www-form-urlencoded'}
+
+response = requests.request("POST", url, data=payload, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/application-json.py
+++ b/test/fixtures/output/python/requests/application-json.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+payload = "{\"number\": 1, \"string\": \"f\\\"oo\", \"arr\": [1, 2, 3], \"nested\": {\"a\": \"b\"}, \"arr_mix\": [1, \"a\", {\"arr_mix_nested\": {}}] }"
+headers = {'content-type': 'application/json'}
+
+response = requests.request("POST", url, data=payload, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/cookies.py
+++ b/test/fixtures/output/python/requests/cookies.py
@@ -1,0 +1,9 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+headers = {'cookie': 'foo=bar; bar=baz'}
+
+response = requests.request("POST", url, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/custom-method.py
+++ b/test/fixtures/output/python/requests/custom-method.py
@@ -1,0 +1,7 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+response = requests.request("PROPFIND", url)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/full.py
+++ b/test/fixtures/output/python/requests/full.py
@@ -1,0 +1,16 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+querystring = {'name':'foo','value':'bar','name':'foo','value':'baz','name':'baz','value':'abc'}
+
+payload = "foo=bar"
+headers = {
+    'cookie': "foo=bar; bar=baz",
+    'accept': "application/json",
+    'content-type': "application/x-www-form-urlencoded"
+    }
+
+response = requests.request("POST", url, data=payload, headers=headers, params=querystring)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/headers.py
+++ b/test/fixtures/output/python/requests/headers.py
@@ -1,0 +1,12 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+headers = {
+    'accept': "application/json",
+    'x-foo': "Bar"
+    }
+
+response = requests.request("GET", url, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/https.py
+++ b/test/fixtures/output/python/requests/https.py
@@ -1,0 +1,7 @@
+import requests
+
+url = "https://mockbin.com/har"
+
+response = requests.request("GET", url)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/multipart-data.py
+++ b/test/fixtures/output/python/requests/multipart-data.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--"
+headers = {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+
+response = requests.request("POST", url, data=payload, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/multipart-file.py
+++ b/test/fixtures/output/python/requests/multipart-file.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--"
+headers = {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+
+response = requests.request("POST", url, data=payload, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/multipart-form-data.py
+++ b/test/fixtures/output/python/requests/multipart-form-data.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--"
+headers = {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+
+response = requests.request("POST", url, data=payload, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/query.py
+++ b/test/fixtures/output/python/requests/query.py
@@ -1,0 +1,9 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+querystring = {'name':'foo','value':'bar','name':'foo','value':'baz','name':'baz','value':'abc'}
+
+response = requests.request("GET", url, params=querystring)
+
+print(response.text)

--- a/test/fixtures/output/python/requests/short.py
+++ b/test/fixtures/output/python/requests/short.py
@@ -1,0 +1,7 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+response = requests.request("GET", url)
+
+print(response.text)

--- a/test/tests/python/requests.js
+++ b/test/tests/python/requests.js
@@ -1,0 +1,6 @@
+'use strict'
+
+require('should')
+
+module.exports = function (snippet, fixtures) {
+}


### PR DESCRIPTION
Added Python's Requests library and fixed a small bug in the node requests library as well.

Things that didn't make it in:
- Multipart file upload could be like this:

```
import requests

url = "http://mockbin.com/har"

files = {'file': open('test/fixtures/files/hello.txt', 'rb')}
response = requests.request("POST", url, files=files)

print(response.text)
```
- Use cookie arg like this:

```
import requests

url = "http://mockbin.com/har"

cookies = {'foo': 'bar', 'bar': 'baz'}

response = requests.request("GET", url, cookies=cookies)

print(response.text)
```
- Use payload dict for form encoded payload like this:

```
import requests

url = "http://mockbin.com/har"

payload = {'foo': 'bar', 'hello': 'world'}
headers = {'content-type': 'application/x-www-form-urlencoded'}

response = requests.request("POST", url, data=payload, headers=headers)

print(response.text)
```
