### PR TITLE
fix(bin) wrong path to ValidationError module

### DIFF
--- a/bin/httpsnippet
+++ b/bin/httpsnippet
@@ -10,7 +10,7 @@ var fs = Promise.promisifyAll(require('fs'))
 var HTTPSnippet = require('..')
 var path = require('path')
 var pkg = require('../package.json')
-var ValidationError = require('har-validator/src/error')
+var ValidationError = require('har-validator/lib/error')
 
 cmd
   .version(pkg.version)


### PR DESCRIPTION
Apparently this error only happens on master (not on the latest v1.16.2).

Before:

```
$ bin/httpsnippet
module.js:338
    throw err;
          ^
Error: Cannot find module 'har-validator/src/error'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/thibaultcha/Projects/mashape/httpsnippet/bin/httpsnippet:13:23)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```

After:

```
$ bin/httpsnippet

  Usage: httpsnippet [options] <files ...>

  Options:

    -h, --help                output usage information
    -V, --version             output the version number
    -t, --target <target>     target output
    -c, --client [client]     target client library
    -o, --output <directory>  write output to directory
```
