### PR TITLE
fix(obj-c + swift) handling boolean literal values

### DIFF
--- a/src/targets/objc/helpers.js
+++ b/src/targets/objc/helpers.js
@@ -61,8 +61,10 @@ module.exports = {
           keyValuePairs.push(util.format('@"%s": %s', k, this.literalRepresentation(value[k])))
         }
         return '@{ ' + keyValuePairs.join(join) + ' }'
+      case '[object Boolean]':
+        return value ? '@YES' : '@NO'
       default:
-        return '@"' + value.replace(/"/g, '\\"') + '"'
+        return '@"' + value.toString().replace(/"/g, '\\"') + '"'
     }
   }
 }

--- a/src/targets/swift/helpers.js
+++ b/src/targets/swift/helpers.js
@@ -71,8 +71,10 @@ module.exports = {
           keyValuePairs.push(util.format('"%s": %s', k, this.literalRepresentation(value[k], opts, indentLevel)))
         }
         return concatArray(keyValuePairs, opts.pretty && keyValuePairs.length > 1, opts.indent, indentLevel)
+      case '[object Boolean]':
+        return value.toString()
       default:
-        return '"' + value.replace(/"/g, '\\"') + '"'
+        return '"' + value.toString().replace(/"/g, '\\"') + '"'
     }
   }
 }

--- a/test/fixtures/output/c/libcurl/application-json.c
+++ b/test/fixtures/output/c/libcurl/application-json.c
@@ -7,6 +7,6 @@ struct curl_slist *headers = NULL;
 headers = curl_slist_append(headers, "content-type: application/json");
 curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}");
+curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}");
 
 CURLcode ret = curl_easy_perform(hnd);

--- a/test/fixtures/output/csharp/restsharp/application-json.cs
+++ b/test/fixtures/output/csharp/restsharp/application-json.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
 var request = new RestRequest(Method.POST);
 request.AddHeader("content-type", "application/json");
-request.AddParameter("application/json", "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}", ParameterType.RequestBody);
+request.AddParameter("application/json", "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}", ParameterType.RequestBody);
 IRestResponse response = client.Execute(request);

--- a/test/fixtures/output/go/native/application-json.go
+++ b/test/fixtures/output/go/native/application-json.go
@@ -11,7 +11,7 @@ func main() {
 
 	url := "http://mockbin.com/har"
 
-	payload := strings.NewReader("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}")
+	payload := strings.NewReader("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}")
 
 	req, _ := http.NewRequest("POST", url, payload)
 

--- a/test/fixtures/output/java/okhttp/application-json.java
+++ b/test/fixtures/output/java/okhttp/application-json.java
@@ -1,7 +1,7 @@
 OkHttpClient client = new OkHttpClient();
 
 MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}");
+RequestBody body = RequestBody.create(mediaType, "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}");
 Request request = new Request.Builder()
   .url("http://mockbin.com/har")
   .post(body)

--- a/test/fixtures/output/java/unirest/application-json.java
+++ b/test/fixtures/output/java/unirest/application-json.java
@@ -1,4 +1,4 @@
 HttpResponse<String> response = Unirest.post("http://mockbin.com/har")
   .header("content-type", "application/json")
-  .body("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}")
+  .body("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}")
   .asString();

--- a/test/fixtures/output/javascript/jquery/application-json.js
+++ b/test/fixtures/output/javascript/jquery/application-json.js
@@ -7,7 +7,7 @@ var settings = {
     "content-type": "application/json"
   },
   "processData": false,
-  "data": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}"
+  "data": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}"
 }
 
 $.ajax(settings).done(function (response) {

--- a/test/fixtures/output/javascript/xhr/application-json.js
+++ b/test/fixtures/output/javascript/xhr/application-json.js
@@ -15,7 +15,8 @@ var data = JSON.stringify({
     {
       "arr_mix_nested": {}
     }
-  ]
+  ],
+  "boolean": false
 });
 
 var xhr = new XMLHttpRequest();

--- a/test/fixtures/output/node/native/application-json.js
+++ b/test/fixtures/output/node/native/application-json.js
@@ -27,5 +27,6 @@ req.write(JSON.stringify({ number: 1,
   string: 'f"oo',
   arr: [ 1, 2, 3 ],
   nested: { a: 'b' },
-  arr_mix: [ 1, 'a', { arr_mix_nested: {} } ] }));
+  arr_mix: [ 1, 'a', { arr_mix_nested: {} } ],
+  boolean: false }));
 req.end();

--- a/test/fixtures/output/node/request/application-json.js
+++ b/test/fixtures/output/node/request/application-json.js
@@ -8,7 +8,8 @@ var options = { method: 'POST',
      string: 'f"oo',
      arr: [ 1, 2, 3 ],
      nested: { a: 'b' },
-     arr_mix: [ 1, 'a', { arr_mix_nested: {} } ] },
+     arr_mix: [ 1, 'a', { arr_mix_nested: {} } ],
+     boolean: false },
   json: true };
 
 request(options, function (error, response, body) {

--- a/test/fixtures/output/node/unirest/application-json.js
+++ b/test/fixtures/output/node/unirest/application-json.js
@@ -24,7 +24,8 @@ req.send({
     {
       "arr_mix_nested": {}
     }
-  ]
+  ],
+  "boolean": false
 });
 
 req.end(function (res) {

--- a/test/fixtures/output/objc/nsurlsession/application-json.m
+++ b/test/fixtures/output/objc/nsurlsession/application-json.m
@@ -5,7 +5,8 @@ NSDictionary *parameters = @{ @"number": @1,
                               @"string": @"f\"oo",
                               @"arr": @[ @1, @2, @3 ],
                               @"nested": @{ @"a": @"b" },
-                              @"arr_mix": @[ @1, @"a", @{ @"arr_mix_nested": @{  } } ] };
+                              @"arr_mix": @[ @1, @"a", @{ @"arr_mix_nested": @{  } } ],
+                              @"boolean": @NO };
 
 NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
 

--- a/test/fixtures/output/ocaml/cohttp/application-json.ml
+++ b/test/fixtures/output/ocaml/cohttp/application-json.ml
@@ -4,7 +4,7 @@ open Lwt
 
 let uri = Uri.of_string "http://mockbin.com/har" in
 let headers = Header.add (Header.init ()) "content-type" "application/json" in
-let body = Cohttp_lwt_body.of_string "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}" in
+let body = Cohttp_lwt_body.of_string "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}" in
 
 Client.call ~headers ~body `POST uri
 >>= fun (res, body_stream) ->

--- a/test/fixtures/output/php/curl/application-json.php
+++ b/test/fixtures/output/php/curl/application-json.php
@@ -10,7 +10,7 @@ curl_setopt_array($curl, array(
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
-  CURLOPT_POSTFIELDS => "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}",
+  CURLOPT_POSTFIELDS => "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}",
   CURLOPT_HTTPHEADER => array(
     "content-type: application/json"
   ),

--- a/test/fixtures/output/php/http1/application-json.php
+++ b/test/fixtures/output/php/http1/application-json.php
@@ -8,7 +8,7 @@ $request->setHeaders(array(
   'content-type' => 'application/json'
 ));
 
-$request->setBody('{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}]}');
+$request->setBody('{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}], "boolean": false}');
 
 try {
   $response = $request->send();

--- a/test/fixtures/output/php/http2/application-json.php
+++ b/test/fixtures/output/php/http2/application-json.php
@@ -4,7 +4,7 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append('{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}]}');
+$body->append('{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}], "boolean": false}');
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');

--- a/test/fixtures/output/python/python3/application-json.py
+++ b/test/fixtures/output/python/python3/application-json.py
@@ -2,7 +2,7 @@ import http.client
 
 conn = http.client.HTTPConnection("mockbin.com")
 
-payload = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}"
+payload = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}"
 
 headers = { 'content-type': "application/json" }
 

--- a/test/fixtures/output/python/requests/application-json.py
+++ b/test/fixtures/output/python/requests/application-json.py
@@ -2,7 +2,7 @@ import requests
 
 url = "http://mockbin.com/har"
 
-payload = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}"
+payload = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}"
 headers = {'content-type': 'application/json'}
 
 response = requests.request("POST", url, data=payload, headers=headers)

--- a/test/fixtures/output/ruby/native/application-json.rb
+++ b/test/fixtures/output/ruby/native/application-json.rb
@@ -7,7 +7,7 @@ http = Net::HTTP.new(url.host, url.port)
 
 request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
-request.body = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}"
+request.body = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}"
 
 response = http.request(request)
 puts response.read_body

--- a/test/fixtures/output/shell/curl/application-json.sh
+++ b/test/fixtures/output/shell/curl/application-json.sh
@@ -1,4 +1,4 @@
 curl --request POST \
   --url http://mockbin.com/har \
   --header 'content-type: application/json' \
-  --data '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}]}'
+  --data '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}], "boolean": false}'

--- a/test/fixtures/output/shell/httpie/application-json.sh
+++ b/test/fixtures/output/shell/httpie/application-json.sh
@@ -1,3 +1,3 @@
-echo '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}]}' |  \
+echo '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}], "boolean": false}' |  \
   http POST http://mockbin.com/har \
   content-type:application/json

--- a/test/fixtures/output/shell/wget/application-json.sh
+++ b/test/fixtures/output/shell/wget/application-json.sh
@@ -1,6 +1,6 @@
 wget --quiet \
   --method POST \
   --header 'content-type: application/json' \
-  --body-data '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}]}' \
+  --body-data '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}], "boolean": false}' \
   --output-document \
   - http://mockbin.com/har

--- a/test/fixtures/output/swift/nsurlsession/application-json.swift
+++ b/test/fixtures/output/swift/nsurlsession/application-json.swift
@@ -6,7 +6,8 @@ let parameters = [
   "string": "f\"oo",
   "arr": [1, 2, 3],
   "nested": ["a": "b"],
-  "arr_mix": [1, "a", ["arr_mix_nested": []]]
+  "arr_mix": [1, "a", ["arr_mix_nested": []]],
+  "boolean": false
 ]
 
 let postData = NSJSONSerialization.dataWithJSONObject(parameters, options: nil, error: nil)

--- a/test/fixtures/requests/application-json.json
+++ b/test/fixtures/requests/application-json.json
@@ -9,6 +9,6 @@
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}"
+    "text": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}], \"boolean\": false}"
   }
 }


### PR DESCRIPTION
obj-c and swift used to not handle converting boolean values to their
respective literal notation.

Fix #65
