### PR TITLE
Add option for --data-binary flag in curl

### DIFF
--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -17,7 +17,8 @@ var CodeBuilder = require('../../helpers/code-builder')
 module.exports = function (source, options) {
   var opts = util._extend({
     indent: '  ',
-    short: false
+    short: false,
+    binary: false
   }, options)
 
   var code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
@@ -56,7 +57,10 @@ module.exports = function (source, options) {
     default:
       // raw request body
       if (source.postData.text) {
-        code.push('%s %s', opts.short ? '-d' : '--data', helpers.escape(helpers.quote(source.postData.text)))
+        code.push(
+          '%s %s', opts.binary ? '--data-binary' : (opts.short ? '-d' : '--data'),
+          helpers.escape(helpers.quote(source.postData.text))
+        )
       }
   }
 


### PR DESCRIPTION
There is currently no way to generate a `--data-binary` flag for curl. My PR has a simple proof of concept for implementing it, but there are probably other ways it could be done as well. Is this functionality you would be willing to include in the codebase?
