### PR TITLE
Removed toLowerCase for headers, keeping the specified casing 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ HTTPSnippet.prototype.prepare = function (request) {
   if (request.headers && request.headers.length) {
     // loweCase header keys
     request.headersObj = request.headers.reduceRight(function (headers, header) {
-      headers[header.name.toLowerCase()] = header.value
+      headers[header.name] = header.value
       return headers
     }, {})
   }


### PR DESCRIPTION
Small PR to fix #74 

Keep preventing duplication of headers a responsibility of the user.
