### PR TITLE
Use multiple --data flags in Curl target

### DIFF
--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -54,6 +54,22 @@ module.exports = function (source, options) {
       })
       break
 
+    case 'application/x-www-form-urlencoded':
+      if (source.postData.params) {
+        source.postData.params.map(function (param) {
+          code.push(
+            '%s %s', opts.binary ? '--data-binary' : (opts.short ? '-d' : '--data'),
+            helpers.quote(util.format('%s=%s', param.name, param.value))
+          )
+        })
+      } else {
+        code.push(
+          '%s %s', opts.binary ? '--data-binary' : (opts.short ? '-d' : '--data'),
+          helpers.escape(helpers.quote(source.postData.text))
+        )
+      }
+      break
+
     default:
       // raw request body
       if (source.postData.text) {

--- a/test/fixtures/output/shell/curl/application-form-encoded.sh
+++ b/test/fixtures/output/shell/curl/application-form-encoded.sh
@@ -1,4 +1,5 @@
 curl --request POST \
   --url http://mockbin.com/har \
   --header 'content-type: application/x-www-form-urlencoded' \
-  --data 'foo=bar&hello=world'
+  --data foo=bar \
+  --data hello=world


### PR DESCRIPTION
Curl support multiple `--data` flags for `application/x-www-form-urlencoded`. Here's an example:

```shell
# Before
curl -X POST http://foo.com \
  --data 'foo=bar&baz=qux'

# After
curl -X POST http://foo.com \
  --data foo=bar \
  --data baz=qux
```

From the [Curl docs](https://curl.haxx.se/docs/manpage.html#-d):

> If any of these options is used more than once on the same command line, the data pieces specified will be merged together with a separating &-symbol. Thus, using '-d name=daniel -d skill=lousy' would generate a post chunk that looks like 'name=daniel&skill=lousy'.

This pull request adds a new condition to the Curl target to handle `application/x-www-form-urlencoded` and append the appropriate `--data` flags.
