### PR TITLE
[Reducer] Look for already processed multidimentional value and push the data instead of assigning a new one in body params

### DIFF
--- a/src/helpers/reducer.js
+++ b/src/helpers/reducer.js
@@ -6,6 +6,12 @@ module.exports = function (obj, pair) {
     return obj
   }
 
+  // If we already have it as array just push the value
+  if (obj[pair.name] instanceof Array) {
+    obj[pair.name].push(pair.value)
+    return obj
+  }
+
   // convert to array
   var arr = [
     obj[pair.name],

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -25,13 +25,14 @@ describe('Reducer', function () {
     var query = [
       {name: 'key', value: 'value'},
       {name: 'foo', value: 'bar1'},
-      {name: 'foo', value: 'bar2'}
+      {name: 'foo', value: 'bar2'},
+      {name: 'foo', value: 'bar3'}
     ]
 
     var obj = query.reduce(reducer, {})
 
     obj.should.be.an.Object
-    obj.should.eql({key: 'value', foo: ['bar1', 'bar2']})
+    obj.should.eql({key: 'value', foo: ['bar1', 'bar2', 'bar3']})
 
     done()
   })


### PR DESCRIPTION
Issue:
If the body param has the values
```json
[
  {"name": "key", "value": "value"},
  {"name": "foo", "value": "bar1"},
  {"name": "foo", "value": "bar2"},
  {"name": "foo", "value": "bar3"}
]
```
The reducer function were generating it as, 
```json
{
  "key": "value",
  "foo": [["bar1", "bar2"], "bar3"]
}
```
 
On passing the above value to `qs` module results in `key=value&foo=&foo=bar3`

This fix ensure we are not blindly adding the query params into the array (results in nested array)

hence, the out put of reducer function would be
```json
{
  "key" : "value",
  "foo": ["bar1", "bar2", "bar3"]
} 
```

on passing to `qs` returns `key=value&foo=bar1&foo=bar2&foo=bar3`  which was the desired value.

P.S: Feel free to comment or reject the PR.