### PR TITLE
Don't escape newlines in curl bodies

### DIFF
--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -75,7 +75,7 @@ module.exports = function (source, options) {
       if (source.postData.text) {
         code.push(
           '%s %s', opts.binary ? '--data-binary' : (opts.short ? '-d' : '--data'),
-          helpers.escape(helpers.quote(source.postData.text))
+          helpers.quote(source.postData.text)
         )
       }
   }

--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -65,7 +65,7 @@ module.exports = function (source, options) {
       } else {
         code.push(
           '%s %s', opts.binary ? '--data-binary' : (opts.short ? '-d' : '--data'),
-          helpers.escape(helpers.quote(source.postData.text))
+          helpers.quote(source.postData.text)
         )
       }
       break

--- a/test/fixtures/output/c/libcurl/jsonObj-multiline.c
+++ b/test/fixtures/output/c/libcurl/jsonObj-multiline.c
@@ -1,0 +1,12 @@
+CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
+curl_easy_setopt(hnd, CURLOPT_URL, "http://mockbin.com/har");
+
+struct curl_slist *headers = NULL;
+headers = curl_slist_append(headers, "content-type: application/json");
+curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
+
+curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\n  \"foo\": \"bar\"\n}");
+
+CURLcode ret = curl_easy_perform(hnd);

--- a/test/fixtures/output/csharp/restsharp/jsonObj-multiline.cs
+++ b/test/fixtures/output/csharp/restsharp/jsonObj-multiline.cs
@@ -1,0 +1,5 @@
+var client = new RestClient("http://mockbin.com/har");
+var request = new RestRequest(Method.POST);
+request.AddHeader("content-type", "application/json");
+request.AddParameter("application/json", "{\n  \"foo\": \"bar\"\n}", ParameterType.RequestBody);
+IRestResponse response = client.Execute(request);

--- a/test/fixtures/output/go/native/jsonObj-multiline.go
+++ b/test/fixtures/output/go/native/jsonObj-multiline.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"net/http"
+	"io/ioutil"
+)
+
+func main() {
+
+	url := "http://mockbin.com/har"
+
+	payload := strings.NewReader("{\n  \"foo\": \"bar\"\n}")
+
+	req, _ := http.NewRequest("POST", url, payload)
+
+	req.Header.Add("content-type", "application/json")
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}

--- a/test/fixtures/output/java/okhttp/jsonObj-multiline.java
+++ b/test/fixtures/output/java/okhttp/jsonObj-multiline.java
@@ -1,0 +1,11 @@
+OkHttpClient client = new OkHttpClient();
+
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{\n  \"foo\": \"bar\"\n}");
+Request request = new Request.Builder()
+  .url("http://mockbin.com/har")
+  .post(body)
+  .addHeader("content-type", "application/json")
+  .build();
+
+Response response = client.newCall(request).execute();

--- a/test/fixtures/output/java/unirest/jsonObj-multiline.java
+++ b/test/fixtures/output/java/unirest/jsonObj-multiline.java
@@ -1,0 +1,4 @@
+HttpResponse<String> response = Unirest.post("http://mockbin.com/har")
+  .header("content-type", "application/json")
+  .body("{\n  \"foo\": \"bar\"\n}")
+  .asString();

--- a/test/fixtures/output/javascript/jquery/jsonObj-multiline.js
+++ b/test/fixtures/output/javascript/jquery/jsonObj-multiline.js
@@ -1,0 +1,15 @@
+var settings = {
+  "async": true,
+  "crossDomain": true,
+  "url": "http://mockbin.com/har",
+  "method": "POST",
+  "headers": {
+    "content-type": "application/json"
+  },
+  "processData": false,
+  "data": "{\n  \"foo\": \"bar\"\n}"
+}
+
+$.ajax(settings).done(function (response) {
+  console.log(response);
+});

--- a/test/fixtures/output/javascript/xhr/jsonObj-multiline.js
+++ b/test/fixtures/output/javascript/xhr/jsonObj-multiline.js
@@ -1,0 +1,17 @@
+var data = JSON.stringify({
+  "foo": "bar"
+});
+
+var xhr = new XMLHttpRequest();
+xhr.withCredentials = true;
+
+xhr.addEventListener("readystatechange", function () {
+  if (this.readyState === this.DONE) {
+    console.log(this.responseText);
+  }
+});
+
+xhr.open("POST", "http://mockbin.com/har");
+xhr.setRequestHeader("content-type", "application/json");
+
+xhr.send(data);

--- a/test/fixtures/output/node/native/jsonObj-multiline.js
+++ b/test/fixtures/output/node/native/jsonObj-multiline.js
@@ -1,0 +1,27 @@
+var http = require("http");
+
+var options = {
+  "method": "POST",
+  "hostname": "mockbin.com",
+  "port": null,
+  "path": "/har",
+  "headers": {
+    "content-type": "application/json"
+  }
+};
+
+var req = http.request(options, function (res) {
+  var chunks = [];
+
+  res.on("data", function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on("end", function () {
+    var body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.write(JSON.stringify({foo: 'bar'}));
+req.end();

--- a/test/fixtures/output/node/request/jsonObj-multiline.js
+++ b/test/fixtures/output/node/request/jsonObj-multiline.js
@@ -1,0 +1,16 @@
+var request = require("request");
+
+var options = {
+  method: 'POST',
+  url: 'http://mockbin.com/har',
+  headers: {'content-type': 'application/json'},
+  body: {foo: 'bar'},
+  json: true
+};
+
+request(options, function (error, response, body) {
+  if (error) throw new Error(error);
+
+  console.log(body);
+});
+

--- a/test/fixtures/output/node/unirest/jsonObj-multiline.js
+++ b/test/fixtures/output/node/unirest/jsonObj-multiline.js
@@ -1,0 +1,19 @@
+var unirest = require("unirest");
+
+var req = unirest("POST", "http://mockbin.com/har");
+
+req.headers({
+  "content-type": "application/json"
+});
+
+req.type("json");
+req.send({
+  "foo": "bar"
+});
+
+req.end(function (res) {
+  if (res.error) throw new Error(res.error);
+
+  console.log(res.body);
+});
+

--- a/test/fixtures/output/objc/nsurlsession/jsonObj-multiline.m
+++ b/test/fixtures/output/objc/nsurlsession/jsonObj-multiline.m
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+
+NSDictionary *headers = @{ @"content-type": @"application/json" };
+NSDictionary *parameters = @{ @"foo": @"bar" };
+
+NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"POST"];
+[request setAllHTTPHeaderFields:headers];
+[request setHTTPBody:postData];
+
+NSURLSession *session = [NSURLSession sharedSession];
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                                if (error) {
+                                                    NSLog(@"%@", error);
+                                                } else {
+                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+                                                    NSLog(@"%@", httpResponse);
+                                                }
+                                            }];
+[dataTask resume];

--- a/test/fixtures/output/ocaml/cohttp/jsonObj-multiline.ml
+++ b/test/fixtures/output/ocaml/cohttp/jsonObj-multiline.ml
@@ -1,0 +1,11 @@
+open Cohttp_lwt_unix
+open Cohttp
+open Lwt
+
+let uri = Uri.of_string "http://mockbin.com/har" in
+let headers = Header.add (Header.init ()) "content-type" "application/json" in
+let body = Cohttp_lwt_body.of_string "{\n  \"foo\": \"bar\"\n}" in
+
+Client.call ~headers ~body `POST uri
+>>= fun (res, body_stream) ->
+  (* Do stuff with the result *)

--- a/test/fixtures/output/php/curl/jsonObj-multiline.php
+++ b/test/fixtures/output/php/curl/jsonObj-multiline.php
@@ -1,0 +1,28 @@
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, array(
+  CURLOPT_URL => "http://mockbin.com/har",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => "",
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 30,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => "POST",
+  CURLOPT_POSTFIELDS => "{\n  \"foo\": \"bar\"\n}",
+  CURLOPT_HTTPHEADER => array(
+    "content-type: application/json"
+  ),
+));
+
+$response = curl_exec($curl);
+$err = curl_error($curl);
+
+curl_close($curl);
+
+if ($err) {
+  echo "cURL Error #:" . $err;
+} else {
+  echo $response;
+}

--- a/test/fixtures/output/php/http1/jsonObj-multiline.php
+++ b/test/fixtures/output/php/http1/jsonObj-multiline.php
@@ -1,0 +1,21 @@
+<?php
+
+$request = new HttpRequest();
+$request->setUrl('http://mockbin.com/har');
+$request->setMethod(HTTP_METH_POST);
+
+$request->setHeaders(array(
+  'content-type' => 'application/json'
+));
+
+$request->setBody('{
+  "foo": "bar"
+}');
+
+try {
+  $response = $request->send();
+
+  echo $response->getBody();
+} catch (HttpException $ex) {
+  echo $ex;
+}

--- a/test/fixtures/output/php/http2/jsonObj-multiline.php
+++ b/test/fixtures/output/php/http2/jsonObj-multiline.php
@@ -1,0 +1,22 @@
+<?php
+
+$client = new http\Client;
+$request = new http\Client\Request;
+
+$body = new http\Message\Body;
+$body->append('{
+  "foo": "bar"
+}');
+
+$request->setRequestUrl('http://mockbin.com/har');
+$request->setRequestMethod('POST');
+$request->setBody($body);
+
+$request->setHeaders(array(
+  'content-type' => 'application/json'
+));
+
+$client->enqueue($request)->send();
+$response = $client->getResponse();
+
+echo $response->getBody();

--- a/test/fixtures/output/powershell/webrequest/jsonObj-multiline.ps1
+++ b/test/fixtures/output/powershell/webrequest/jsonObj-multiline.ps1
@@ -1,0 +1,5 @@
+$headers=@{}
+$headers.Add("content-type", "application/json")
+$response = Invoke-WebRequest -Uri 'http://mockbin.com/har' -Method POST -Headers $headers -ContentType 'application/json' -Body '{
+  "foo": "bar"
+}'

--- a/test/fixtures/output/python/python3/jsonObj-multiline.py
+++ b/test/fixtures/output/python/python3/jsonObj-multiline.py
@@ -1,0 +1,14 @@
+import http.client
+
+conn = http.client.HTTPConnection("mockbin.com")
+
+payload = "{\n  \"foo\": \"bar\"\n}"
+
+headers = { 'content-type': "application/json" }
+
+conn.request("POST", "/har", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))

--- a/test/fixtures/output/python/requests/jsonObj-multiline.py
+++ b/test/fixtures/output/python/requests/jsonObj-multiline.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+payload = "{\n  \"foo\": \"bar\"\n}"
+headers = {'content-type': 'application/json'}
+
+response = requests.request("POST", url, data=payload, headers=headers)
+
+print(response.text)

--- a/test/fixtures/output/ruby/native/jsonObj-multiline.rb
+++ b/test/fixtures/output/ruby/native/jsonObj-multiline.rb
@@ -1,0 +1,13 @@
+require 'uri'
+require 'net/http'
+
+url = URI("http://mockbin.com/har")
+
+http = Net::HTTP.new(url.host, url.port)
+
+request = Net::HTTP::Post.new(url)
+request["content-type"] = 'application/json'
+request.body = "{\n  \"foo\": \"bar\"\n}"
+
+response = http.request(request)
+puts response.read_body

--- a/test/fixtures/output/shell/curl/jsonObj-multiline.sh
+++ b/test/fixtures/output/shell/curl/jsonObj-multiline.sh
@@ -1,0 +1,6 @@
+curl --request POST \
+  --url http://mockbin.com/har \
+  --header 'content-type: application/json' \
+  --data '{
+  "foo": "bar"
+}'

--- a/test/fixtures/output/shell/httpie/jsonObj-multiline.sh
+++ b/test/fixtures/output/shell/httpie/jsonObj-multiline.sh
@@ -1,0 +1,5 @@
+echo '{
+  "foo": "bar"
+}' |  \
+  http POST http://mockbin.com/har \
+  content-type:application/json

--- a/test/fixtures/output/shell/wget/jsonObj-multiline.sh
+++ b/test/fixtures/output/shell/wget/jsonObj-multiline.sh
@@ -1,0 +1,6 @@
+wget --quiet \
+  --method POST \
+  --header 'content-type: application/json' \
+  --body-data '{\n  "foo": "bar"\n}' \
+  --output-document \
+  - http://mockbin.com/har

--- a/test/fixtures/output/swift/nsurlsession/jsonObj-multiline.swift
+++ b/test/fixtures/output/swift/nsurlsession/jsonObj-multiline.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+let headers = ["content-type": "application/json"]
+let parameters = ["foo": "bar"] as [String : Any]
+
+let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
+
+let request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har")! as URL,
+                                        cachePolicy: .useProtocolCachePolicy,
+                                    timeoutInterval: 10.0)
+request.httpMethod = "POST"
+request.allHTTPHeaderFields = headers
+request.httpBody = postData as Data
+
+let session = URLSession.shared
+let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
+  if (error != nil) {
+    print(error)
+  } else {
+    let httpResponse = response as? HTTPURLResponse
+    print(httpResponse)
+  }
+})
+
+dataTask.resume()

--- a/test/fixtures/requests/jsonObj-multiline.json
+++ b/test/fixtures/requests/jsonObj-multiline.json
@@ -1,0 +1,12 @@
+{
+  "url": "http://mockbin.com/har",
+  "method": "POST",
+  "headers": [{
+    "name": "content-type",
+    "value": "application/json"
+  }],
+  "postData": {
+    "text": "{\n  \"foo\": \"bar\"\n}",
+    "mimeType": "application/json"
+  }
+}

--- a/test/targets.js
+++ b/test/targets.js
@@ -44,7 +44,7 @@ var itShouldHaveInfo = function (name, obj) {
 // TODO: investigate issues with these fixtures
 const skipMe = {
   'clojure': {
-    'clj_http': ['jsonObj-null-value']
+    'clj_http': ['jsonObj-null-value', 'jsonObj-multiline']
   },
   '*': {
     '*': ['multipart-data', 'multipart-file', 'multipart-form-data']


### PR DESCRIPTION
Fixes #96 

This PR removes the improper newline escaping that was done on generated Curl request bodies.

