### PR TITLE
require openssl if url is https

### DIFF
--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -7,7 +7,13 @@ module.exports = function (source, options) {
 
   code.push('require \'uri\'')
       .push('require \'net/http\'')
-      .blank()
+
+  if (source.uriObj.protocol === 'https:') {
+    code.push('require \'openssl\'')
+  }
+
+  code.blank()
+
 
   // To support custom methods we check for the supported methods
   // and if doesn't exist then we build a custom class for it

--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -14,7 +14,6 @@ module.exports = function (source, options) {
 
   code.blank()
 
-
   // To support custom methods we check for the supported methods
   // and if doesn't exist then we build a custom class for it
   var method = source.method.toUpperCase()

--- a/test/fixtures/output/ruby/native/https.rb
+++ b/test/fixtures/output/ruby/native/https.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'net/http'
+require 'openssl'
 
 url = URI("https://mockbin.com/har")
 


### PR DESCRIPTION
Prior to this change, the generated code would throw
`uninitialized constant OpenSSL NameError`

closes #97 

The CI tests will fail because of unrelated errors out of scope of this PR.