### PR TITLE
chore(fix): linting errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
  - iojs
  - 0.10
  - 0.12
+ - 8
 
 before_install:
   - sudo apt-get update -qq

--- a/package.json
+++ b/package.json
@@ -56,11 +56,13 @@
   },
   "standard": {
     "ignore": [
-      "**/test/fixtures/**"
+      "**/test/fixtures/**",
+      "node_modules/**"
     ]
   },
   "echint": {
     "ignore": [
+      "node_modules/**",
       "coverage/**",
       "CONTRIBUTING.md",
       "test/fixtures/**"

--- a/src/helpers/shell.js
+++ b/src/helpers/shell.js
@@ -13,7 +13,7 @@ module.exports = {
 
     // Unless `value` is a simple shell-safe string, quote it.
     if (!safe.test(value)) {
-      return util.format('\'%s\'', value.replace(/'/g, "\'\\'\'"))
+      return util.format('\'%s\'', value.replace(/'/g, "'\\''"))
     }
 
     return value

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,13 @@ var qs = require('querystring')
 var reducer = require('./helpers/reducer')
 var targets = require('./targets')
 var url = require('url')
-var util = require('util')
 var validate = require('har-validator/lib/async')
 
 // constructor
 var HTTPSnippet = function (data) {
   var entries
   var self = this
-  var input = util._extend({}, data)
+  var input = Object.assign({}, data)
 
   // prep the main container
   self.requests = []
@@ -156,13 +155,13 @@ HTTPSnippet.prototype.prepare = function (request) {
   }
 
   // create allHeaders object
-  request.allHeaders = util._extend(request.allHeaders, request.headersObj)
+  request.allHeaders = Object.assign(request.allHeaders, request.headersObj)
 
   // deconstruct the uri
   request.uriObj = url.parse(request.url, true, true)
 
   // merge all possible queryString values
-  request.queryObj = util._extend(request.queryObj, request.uriObj.query)
+  request.queryObj = Object.assign(request.queryObj, request.uriObj.query)
 
   // reset uriObj values for a clean url
   request.uriObj.query = null
@@ -224,7 +223,7 @@ module.exports = HTTPSnippet
 
 module.exports.availableTargets = function () {
   return Object.keys(targets).map(function (key) {
-    var target = util._extend({}, targets[key].info)
+    var target = Object.assign({}, targets[key].info)
     var clients = Object.keys(targets[key])
 
       .filter(function (prop) {

--- a/src/targets/clojure/clj_http.js
+++ b/src/targets/clojure/clj_http.js
@@ -61,7 +61,7 @@ var jsToEdn = function (js) {
     default: // 'number' 'boolean'
       return js.toString()
     case 'string':
-      return '"' + js.replace(/\"/g, '\\"') + '"'
+      return '"' + js.replace(/"/g, '\\"') + '"'
     case 'file':
       return js.toString()
     case 'keyword':
@@ -94,8 +94,7 @@ module.exports = function (source, options) {
     return code.push('Method not supported').join()
   }
 
-  var params = {headers: source.allHeaders,
-                'query-params': source.queryObj}
+  var params = {headers: source.allHeaders, 'query-params': source.queryObj}
 
   switch (source.postData.mimeType) {
     case 'application/json':
@@ -114,11 +113,9 @@ module.exports = function (source, options) {
     case 'multipart/form-data':
       params.multipart = source.postData.params.map(function (x) {
         if (x.fileName && !x.value) {
-          return {name: x.name,
-                  content: new File(x.fileName)}
+          return {name: x.name, content: new File(x.fileName)}
         } else {
-          return {name: x.name,
-                  content: x.value}
+          return {name: x.name, content: x.value}
         }
       })
       delete params.headers['content-type']

--- a/src/targets/go/native.js
+++ b/src/targets/go/native.js
@@ -10,7 +10,6 @@
 
 'use strict'
 
-var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
@@ -18,7 +17,7 @@ module.exports = function (source, options) {
   var code = new CodeBuilder('\t')
 
   // Define Options
-  var opts = util._extend({
+  var opts = Object.assign({
     showBoilerplate: true,
     checkErrors: false,
     printBody: true,

--- a/src/targets/java/okhttp.js
+++ b/src/targets/java/okhttp.js
@@ -10,11 +10,10 @@
 
 'use strict'
 
-var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  '
   }, options)
 

--- a/src/targets/java/unirest.js
+++ b/src/targets/java/unirest.js
@@ -10,11 +10,10 @@
 
 'use strict'
 
-var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  '
   }, options)
 

--- a/src/targets/javascript/jquery.js
+++ b/src/targets/javascript/jquery.js
@@ -10,11 +10,10 @@
 
 'use strict'
 
-var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  '
   }, options)
 

--- a/src/targets/javascript/xhr.js
+++ b/src/targets/javascript/xhr.js
@@ -10,11 +10,10 @@
 
 'use strict'
 
-var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  ',
     cors: true
   }, options)

--- a/src/targets/node/native.js
+++ b/src/targets/node/native.js
@@ -14,7 +14,7 @@ var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  '
   }, options)
 

--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -14,7 +14,7 @@ var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  '
   }, options)
 
@@ -114,7 +114,7 @@ module.exports = function (source, options) {
       .push('});')
       .blank()
 
-  return code.join().replace('"JAR"', 'jar').replace(/"fs\.createReadStream\(\\\"(.+)\\\"\)\"/, 'fs.createReadStream("$1")')
+  return code.join().replace('"JAR"', 'jar').replace(/"fs\.createReadStream\(\\"(.+)\\"\)"/, 'fs.createReadStream("$1")')
 }
 
 module.exports.info = {

--- a/src/targets/node/unirest.js
+++ b/src/targets/node/unirest.js
@@ -10,11 +10,10 @@
 
 'use strict'
 
-var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  '
   }, options)
 
@@ -105,7 +104,7 @@ module.exports = function (source, options) {
       .push('});')
       .blank()
 
-  return code.join().replace(/"fs\.createReadStream\(\\\"(.+)\\\"\)\"/, 'fs.createReadStream("$1")')
+  return code.join().replace(/"fs\.createReadStream\("(.+)\\"\)"/, 'fs.createReadStream("$1")')
 }
 
 module.exports.info = {

--- a/src/targets/node/unirest.js
+++ b/src/targets/node/unirest.js
@@ -104,7 +104,7 @@ module.exports = function (source, options) {
       .push('});')
       .blank()
 
-  return code.join().replace(/"fs\.createReadStream\("(.+)\\"\)"/, 'fs.createReadStream("$1")')
+  return code.join().replace(/"fs\.createReadStream\(\\"(.+)\\"\)"/, 'fs.createReadStream("$1")')
 }
 
 module.exports.info = {

--- a/src/targets/objc/helpers.js
+++ b/src/targets/objc/helpers.js
@@ -51,10 +51,10 @@ module.exports = {
       case '[object Number]':
         return '@' + value
       case '[object Array]':
-        var values_representation = value.map(function (v) {
+        var valuesRepresentation = value.map(function (v) {
           return this.literalRepresentation(v)
         }.bind(this))
-        return '@[ ' + values_representation.join(join) + ' ]'
+        return '@[ ' + valuesRepresentation.join(join) + ' ]'
       case '[object Object]':
         var keyValuePairs = []
         for (var k in value) {

--- a/src/targets/objc/nsurlsession.js
+++ b/src/targets/objc/nsurlsession.js
@@ -10,12 +10,11 @@
 
 'use strict'
 
-var util = require('util')
 var helpers = require('./helpers')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '    ',
     pretty: true,
     timeout: '10'

--- a/src/targets/ocaml/cohttp.js
+++ b/src/targets/ocaml/cohttp.js
@@ -10,11 +10,10 @@
 
 'use strict'
 
-var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  '
   }, options)
 

--- a/src/targets/php/curl.js
+++ b/src/targets/php/curl.js
@@ -14,7 +14,7 @@ var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     closingTag: false,
     indent: '  ',
     maxRedirects: 10,

--- a/src/targets/php/helpers.js
+++ b/src/targets/php/helpers.js
@@ -1,10 +1,10 @@
 'use strict'
 
-var convert = function (obj, indent, last_indent) {
+var convert = function (obj, indent, lastIndent) {
   var i, result
 
-  if (!last_indent) {
-    last_indent = ''
+  if (!lastIndent) {
+    lastIndent = ''
   }
 
   switch (Object.prototype.toString.call(obj)) {
@@ -17,7 +17,7 @@ var convert = function (obj, indent, last_indent) {
       break
 
     case '[object String]':
-      result = "'" + obj.replace(/\\/g, '\\\\').replace(/\'/g, "\'") + "'"
+      result = "'" + obj.replace(/\\/g, '\\\\').replace(/'/g, "'") + "'"
       break
 
     case '[object Number]':
@@ -31,7 +31,7 @@ var convert = function (obj, indent, last_indent) {
         result.push(convert(item, indent + indent, indent))
       })
 
-      result = 'array(\n' + indent + result.join(',\n' + indent) + '\n' + last_indent + ')'
+      result = 'array(\n' + indent + result.join(',\n' + indent) + '\n' + lastIndent + ')'
       break
 
     case '[object Object]':
@@ -41,7 +41,7 @@ var convert = function (obj, indent, last_indent) {
           result.push(convert(i, indent) + ' => ' + convert(obj[i], indent + indent, indent))
         }
       }
-      result = 'array(\n' + indent + result.join(',\n' + indent) + '\n' + last_indent + ')'
+      result = 'array(\n' + indent + result.join(',\n' + indent) + '\n' + lastIndent + ')'
       break
 
     default:

--- a/src/targets/php/http1.js
+++ b/src/targets/php/http1.js
@@ -10,12 +10,11 @@
 
 'use strict'
 
-var util = require('util')
 var helpers = require('./helpers')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     closingTag: false,
     indent: '  ',
     noTags: false,

--- a/src/targets/php/http2.js
+++ b/src/targets/php/http2.js
@@ -10,12 +10,11 @@
 
 'use strict'
 
-var util = require('util')
 var helpers = require('./helpers')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     closingTag: false,
     indent: '  ',
     noTags: false,

--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -15,7 +15,7 @@ var helpers = require('../../helpers/shell')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  ',
     short: false,
     binary: false

--- a/src/targets/shell/httpie.js
+++ b/src/targets/shell/httpie.js
@@ -15,7 +15,7 @@ var shell = require('../../helpers/shell')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     body: false,
     cert: false,
     headers: false,
@@ -78,7 +78,7 @@ module.exports = function (source, options) {
     queryStringKeys.forEach(function (name) {
       var value = source.queryObj[name]
 
-      if (util.isArray(value)) {
+      if (Array.isArray(value)) {
         value.forEach(function (val) {
           code.push('%s==%s', name, shell.quote(val))
         })

--- a/src/targets/shell/wget.js
+++ b/src/targets/shell/wget.js
@@ -15,7 +15,7 @@ var helpers = require('../../helpers/shell')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  ',
     short: false,
     verbose: false

--- a/src/targets/swift/nsurlsession.js
+++ b/src/targets/swift/nsurlsession.js
@@ -10,12 +10,11 @@
 
 'use strict'
 
-var util = require('util')
 var helpers = require('./helpers')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = util._extend({
+  var opts = Object.assign({
     indent: '  ',
     pretty: true,
     timeout: '10'

--- a/test/index.js
+++ b/test/index.js
@@ -32,12 +32,12 @@ describe('HTTPSnippet', function () {
   it('should parse HAR file with multiple entries', function (done) {
     var snippet = new HTTPSnippet(fixtures.har)
 
-    snippet.should.have.property('requests').and.be.an.Array
+    snippet.should.have.property('requests').and.be.an.Array()
     snippet.requests.length.should.equal(2)
 
     var results = snippet.convert('shell')
 
-    results.should.be.an.Array
+    results.should.be.an.Array()
     results.length.should.equal(2)
 
     done()
@@ -110,7 +110,7 @@ describe('HTTPSnippet', function () {
   it('should add "uriObj" to source object', function (done) {
     var req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
-    req.uriObj.should.be.an.Object
+    req.uriObj.should.be.an.Object()
     req.uriObj.should.eql({
       auth: null,
       hash: null,
@@ -139,7 +139,7 @@ describe('HTTPSnippet', function () {
   it('should add "queryObj" to source object', function (done) {
     var req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
-    req.queryObj.should.be.an.Object
+    req.queryObj.should.be.an.Object()
     req.queryObj.should.eql({
       baz: 'abc',
       key: 'value',
@@ -155,7 +155,7 @@ describe('HTTPSnippet', function () {
   it('should add "headersObj" to source object', function (done) {
     var req = new HTTPSnippet(fixtures.requests.headers).requests[0]
 
-    req.headersObj.should.be.an.Object
+    req.headersObj.should.be.an.Object()
     req.headersObj.should.eql({
       'accept': 'application/json',
       'x-foo': 'Bar'
@@ -167,7 +167,7 @@ describe('HTTPSnippet', function () {
   it('should modify orignal url to strip query string', function (done) {
     var req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
-    req.url.should.be.a.String
+    req.url.should.be.a.String()
     req.url.should.eql('http://mockbin.com/har')
 
     done()
@@ -176,7 +176,7 @@ describe('HTTPSnippet', function () {
   it('should add "fullUrl" to source object', function (done) {
     var req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
-    req.fullUrl.should.be.a.String
+    req.fullUrl.should.be.a.String()
     req.fullUrl.should.eql('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value')
 
     done()
@@ -185,7 +185,7 @@ describe('HTTPSnippet', function () {
   it('should fix "path" property of "uriObj" to match queryString', function (done) {
     var req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
-    req.uriObj.path.should.be.a.String
+    req.uriObj.path.should.be.a.String()
     req.uriObj.path.should.eql('/har?foo=bar&foo=baz&baz=abc&key=value')
 
     done()

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -15,7 +15,7 @@ describe('Reducer', function () {
 
     var obj = query.reduce(reducer, {})
 
-    obj.should.be.an.Object
+    obj.should.be.an.Object()
     obj.should.eql({key: 'value', foo: 'bar'})
 
     done()
@@ -30,7 +30,7 @@ describe('Reducer', function () {
 
     var obj = query.reduce(reducer, {})
 
-    obj.should.be.an.Object
+    obj.should.be.an.Object()
     obj.should.eql({key: 'value', foo: ['bar1', 'bar2']})
 
     done()

--- a/test/requests.js
+++ b/test/requests.js
@@ -42,7 +42,7 @@ fixtures.cli.forEach(function (cli) {
             try {
               var har = JSON.parse(stdout)
             } catch (err) {
-              err.should.be.null
+              err.should.be.null()
             }
 
             // make an exception for multipart/form-data
@@ -55,7 +55,7 @@ fixtures.cli.forEach(function (cli) {
             }
 
             har.should.have.property('log')
-            har.log.should.have.property('entries').and.be.Array
+            har.log.should.have.property('entries').and.be.Array()
             har.log.entries[0].should.have.property('request')
             har.log.entries[0].request.should.containDeep(fixtures.requests[request])
 

--- a/test/targets.js
+++ b/test/targets.js
@@ -35,9 +35,9 @@ var itShouldHaveTests = function (target, client) {
 
 var itShouldHaveInfo = function (name, obj) {
   it(name + ' should have info method', function () {
-    obj.should.have.property('info').and.be.an.Object
-    obj.info.key.should.equal(name).and.be.a.String
-    obj.info.title.should.be.a.String
+    obj.should.have.property('info').and.be.an.Object()
+    obj.info.key.should.equal(name).and.be.a.String()
+    obj.info.title.should.be.a.String()
   })
 }
 
@@ -59,7 +59,7 @@ var itShouldGenerateOutput = function (request, path, target, client) {
     var instance = new HTTPSnippet(fixtures.requests[request])
     var result = instance.convert(target, client) + '\n'
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.equal(output[fixture].toString())
   })
 }

--- a/test/targets/go/native.js
+++ b/test/targets/go/native.js
@@ -10,31 +10,31 @@ module.exports = function (HTTPSnippet, fixtures) {
       showBoilerplate: false
     })
 
-    result.should.be.a.String
-    result.should.eql('url := \"http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value\"\n\npayload := strings.NewReader(\"foo=bar\")\n\nreq, _ := http.NewRequest(\"POST\", url, payload)\n\nreq.Header.Add(\"cookie\", \"foo=bar; bar=baz\")\nreq.Header.Add(\"accept\", \"application/json\")\nreq.Header.Add(\"content-type\", \"application/x-www-form-urlencoded\")\n\nres, _ := http.DefaultClient.Do(req)\n\ndefer res.Body.Close()\nbody, _ := ioutil.ReadAll(res.Body)\n\nfmt.Println(res)\nfmt.Println(string(body))')
+    result.should.be.a.String()
+    result.should.eql('url := "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"\n\npayload := strings.NewReader("foo=bar")\n\nreq, _ := http.NewRequest("POST", url, payload)\n\nreq.Header.Add("cookie", "foo=bar; bar=baz")\nreq.Header.Add("accept", "application/json")\nreq.Header.Add("content-type", "application/x-www-form-urlencoded")\n\nres, _ := http.DefaultClient.Do(req)\n\ndefer res.Body.Close()\nbody, _ := ioutil.ReadAll(res.Body)\n\nfmt.Println(res)\nfmt.Println(string(body))')
   })
   it('should support checkErrors option', function () {
     var result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
       checkErrors: true
     })
 
-    result.should.be.a.String
-    result.should.eql('package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value\"\n\n\tpayload := strings.NewReader(\"foo=bar\")\n\n\treq, err := http.NewRequest(\"POST\", url, payload)\n\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\treq.Header.Add(\"cookie\", \"foo=bar; bar=baz\")\n\treq.Header.Add(\"accept\", \"application/json\")\n\treq.Header.Add(\"content-type\", \"application/x-www-form-urlencoded\")\n\n\tres, err := http.DefaultClient.Do(req)\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tdefer res.Body.Close()\n\tbody, err := ioutil.ReadAll(res.Body)\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}')
+    result.should.be.a.String()
+    result.should.eql('package main\n\nimport (\n\t"fmt"\n\t"strings"\n\t"net/http"\n\t"io/ioutil"\n)\n\nfunc main() {\n\n\turl := "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"\n\n\tpayload := strings.NewReader("foo=bar")\n\n\treq, err := http.NewRequest("POST", url, payload)\n\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\treq.Header.Add("cookie", "foo=bar; bar=baz")\n\treq.Header.Add("accept", "application/json")\n\treq.Header.Add("content-type", "application/x-www-form-urlencoded")\n\n\tres, err := http.DefaultClient.Do(req)\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tdefer res.Body.Close()\n\tbody, err := ioutil.ReadAll(res.Body)\n\tif err != nil {\n\t\tpanic(err)\n\t}\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}')
   })
   it('should support printBody option', function () {
     var result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
       printBody: false
     })
 
-    result.should.be.a.String
-    result.should.eql('package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n)\n\nfunc main() {\n\n\turl := \"http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value\"\n\n\tpayload := strings.NewReader(\"foo=bar\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"cookie\", \"foo=bar; bar=baz\")\n\treq.Header.Add(\"accept\", \"application/json\")\n\treq.Header.Add(\"content-type\", \"application/x-www-form-urlencoded\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tfmt.Println(res)\n\n}')
+    result.should.be.a.String()
+    result.should.eql('package main\n\nimport (\n\t"fmt"\n\t"strings"\n\t"net/http"\n)\n\nfunc main() {\n\n\turl := "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"\n\n\tpayload := strings.NewReader("foo=bar")\n\n\treq, _ := http.NewRequest("POST", url, payload)\n\n\treq.Header.Add("cookie", "foo=bar; bar=baz")\n\treq.Header.Add("accept", "application/json")\n\treq.Header.Add("content-type", "application/x-www-form-urlencoded")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tfmt.Println(res)\n\n}')
   })
   it('should support timeout option', function () {
     var result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
       timeout: 30
     })
 
-    result.should.be.a.String
-    result.should.eql('package main\n\nimport (\n\t\"fmt\"\n\t\"time\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\tclient := http.Client{\n\t\tTimeout: time.Duration(30 * time.Second),\n\t}\n\n\turl := \"http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value\"\n\n\tpayload := strings.NewReader(\"foo=bar\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"cookie\", \"foo=bar; bar=baz\")\n\treq.Header.Add(\"accept\", \"application/json\")\n\treq.Header.Add(\"content-type\", \"application/x-www-form-urlencoded\")\n\n\tres, _ := client.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}')
+    result.should.be.a.String()
+    result.should.eql('package main\n\nimport (\n\t"fmt"\n\t"time"\n\t"strings"\n\t"net/http"\n\t"io/ioutil"\n)\n\nfunc main() {\n\n\tclient := http.Client{\n\t\tTimeout: time.Duration(30 * time.Second),\n\t}\n\n\turl := "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"\n\n\tpayload := strings.NewReader("foo=bar")\n\n\treq, _ := http.NewRequest("POST", url, payload)\n\n\treq.Header.Add("cookie", "foo=bar; bar=baz")\n\treq.Header.Add("accept", "application/json")\n\treq.Header.Add("content-type", "application/x-www-form-urlencoded")\n\n\tres, _ := client.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}')
   })
 }

--- a/test/targets/javascript/xhr.js
+++ b/test/targets/javascript/xhr.js
@@ -10,7 +10,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       cors: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('var data = null;var xhr = new XMLHttpRequest();xhr.addEventListener("readystatechange", function () {  if (this.readyState === this.DONE) {    console.log(this.responseText);  }});xhr.open("GET", "http://mockbin.com/har");xhr.send(data);')
   })
 }

--- a/test/targets/objc/nsurlsession.js
+++ b/test/targets/objc/nsurlsession.js
@@ -10,7 +10,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: '  '
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSession *session = [NSURLSession sharedSession];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {                                              if (error) {                                                NSLog(@"%@", error);                                              } else {                                                NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;                                                NSLog(@"%@", httpResponse);                                              }                                            }];[dataTask resume];')
   })
   it('should support a timeout option', function () {
@@ -18,7 +18,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       timeout: 5
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:5.0];[request setHTTPMethod:@"GET"];NSURLSession *session = [NSURLSession sharedSession];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {                                                if (error) {                                                    NSLog(@"%@", error);                                                } else {                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;                                                    NSLog(@"%@", httpResponse);                                                }                                            }];[dataTask resume];')
   })
   it('should support pretty option', function () {
@@ -26,7 +26,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       pretty: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSDictionary *headers = @{ @"cookie": @"foo=bar; bar=baz", @"accept": @"application/json", @"content-type": @"application/x-www-form-urlencoded" };NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"foo=bar" dataUsingEncoding:NSUTF8StringEncoding]];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setAllHTTPHeaderFields:headers];[request setHTTPBody:postData];NSURLSession *session = [NSURLSession sharedSession];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {                                                if (error) {                                                    NSLog(@"%@", error);                                                } else {                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;                                                    NSLog(@"%@", httpResponse);                                                }                                            }];[dataTask resume];')
   })
 
@@ -35,7 +35,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       pretty: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSDictionary *headers = @{ @"content-type": @"application/json" };NSDictionary *parameters = @{ @"foo":  };NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"POST"];[request setAllHTTPHeaderFields:headers];[request setHTTPBody:postData];NSURLSession *session = [NSURLSession sharedSession];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {                                                if (error) {                                                    NSLog(@"%@", error);                                                } else {                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;                                                    NSLog(@"%@", httpResponse);                                                }                                            }];[dataTask resume];')
   })
 }

--- a/test/targets/shell/curl.js
+++ b/test/targets/shell/curl.js
@@ -11,7 +11,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql("curl -X POST 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value' -H 'accept: application/json' -H 'content-type: application/x-www-form-urlencoded' -b 'foo=bar; bar=baz' -d foo=bar")
   })
 
@@ -22,7 +22,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       binary: true
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql("curl -X POST 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value' -H 'accept: application/json' -H 'content-type: application/x-www-form-urlencoded' -b 'foo=bar; bar=baz' --data-binary foo=bar")
   })
 
@@ -31,7 +31,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql('curl --request GET --url http://mockbin.com/request --http1.0')
   })
 
@@ -40,7 +40,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: '@'
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\\\n/g, '').should.eql("curl --request POST @--url 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value' @--header 'accept: application/json' @--header 'content-type: application/x-www-form-urlencoded' @--cookie 'foo=bar; bar=baz' @--data foo=bar")
   })
 }

--- a/test/targets/shell/httpie.js
+++ b/test/targets/shell/httpie.js
@@ -11,7 +11,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       verbose: true
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql('http --verbose GET http://mockbin.com/har')
   })
 
@@ -30,7 +30,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       verify: 'x'
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql('http -h -b -v -p=x --verify=x --cert=foo --pretty=x --style=x --timeout=1 GET http://mockbin.com/har')
   })
 
@@ -48,7 +48,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       verify: 'x'
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql('http --headers --body --verbose --print=x --verify=x --cert=foo --pretty=x --style=x --timeout=1 GET http://mockbin.com/har')
   })
 
@@ -57,7 +57,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: '@'
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\\\n/g, '').should.eql("http --form POST 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value' @accept:application/json @content-type:application/x-www-form-urlencoded @cookie:'foo=bar; bar=baz' @foo=bar")
   })
 
@@ -67,7 +67,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       queryParams: true
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\\\n/g, '').should.eql('http GET http://mockbin.com/har foo==bar foo==baz baz==abc key==value')
   })
 
@@ -77,7 +77,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       queryParams: true
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\\\n/g, '').should.eql('http GET http://mockbin.com/har foo==bar foo==baz baz==abc key==value')
   })
 
@@ -88,7 +88,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       queryParams: true
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\\\n/g, '').should.eql('http -f POST http://mockbin.com/har content-type:application/x-www-form-urlencoded foo=bar hello=world')
   })
 }

--- a/test/targets/shell/wget.js
+++ b/test/targets/shell/wget.js
@@ -11,7 +11,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql("wget -q --method POST --header 'cookie: foo=bar; bar=baz' --header 'accept: application/json' --header 'content-type: application/x-www-form-urlencoded' --body-data foo=bar -O - 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value'")
   })
 
@@ -22,7 +22,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       verbose: true
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql('wget -v --method GET -O - http://mockbin.com/har')
   })
 
@@ -33,7 +33,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       verbose: true
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.should.eql('wget --verbose --method GET --output-document - http://mockbin.com/har')
   })
 
@@ -42,7 +42,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: '@'
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\\\n/g, '').should.eql("wget --quiet @--method POST @--header 'cookie: foo=bar; bar=baz' @--header 'accept: application/json' @--header 'content-type: application/x-www-form-urlencoded' @--body-data foo=bar @--output-document @- 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value'")
   })
 }

--- a/test/targets/swift/nsurlsession.js
+++ b/test/targets/swift/nsurlsession.js
@@ -10,7 +10,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       indent: '    '
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('import Foundationlet request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har")! as URL,                                        cachePolicy: .useProtocolCachePolicy,                                    timeoutInterval: 10.0)request.httpMethod = "GET"let session = URLSession.sharedlet dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in    if (error != nil) {        print(error)    } else {        let httpResponse = response as? HTTPURLResponse        print(httpResponse)    }})dataTask.resume()')
   })
   it('should support a timeout option', function () {
@@ -18,7 +18,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       timeout: 5
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('import Foundationlet request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har")! as URL,                                        cachePolicy: .useProtocolCachePolicy,                                    timeoutInterval: 5.0)request.httpMethod = "GET"let session = URLSession.sharedlet dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in  if (error != nil) {    print(error)  } else {    let httpResponse = response as? HTTPURLResponse    print(httpResponse)  }})dataTask.resume()')
   })
   it('should support pretty option', function () {
@@ -26,7 +26,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       pretty: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('import Foundationlet headers = ["cookie": "foo=bar; bar=baz", "accept": "application/json", "content-type": "application/x-www-form-urlencoded"]let postData = NSMutableData(data: "foo=bar".data(using: String.Encoding.utf8)!)let request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value")! as URL,                                        cachePolicy: .useProtocolCachePolicy,                                    timeoutInterval: 10.0)request.httpMethod = "POST"request.allHTTPHeaderFields = headersrequest.httpBody = postData as Datalet session = URLSession.sharedlet dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in  if (error != nil) {    print(error)  } else {    let httpResponse = response as? HTTPURLResponse    print(httpResponse)  }})dataTask.resume()')
   })
   it('should support json object with null value', function () {
@@ -34,7 +34,7 @@ module.exports = function (HTTPSnippet, fixtures) {
       pretty: false
     })
 
-    result.should.be.a.String
+    result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('import Foundationlet headers = ["content-type": "application/json"]let parameters = ["foo": ] as [String : Any]let postData = JSONSerialization.data(withJSONObject: parameters, options: [])let request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har")! as URL,                                        cachePolicy: .useProtocolCachePolicy,                                    timeoutInterval: 10.0)request.httpMethod = "POST"request.allHTTPHeaderFields = headersrequest.httpBody = postData as Datalet session = URLSession.sharedlet dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in  if (error != nil) {    print(error)  } else {    let httpResponse = response as? HTTPURLResponse    print(httpResponse)  }})dataTask.resume()')
   })
 }


### PR DESCRIPTION
* util._extend -> Object.assign
* .to.be.a.String -> .to.be.a.String() and others
* remove unused requires to 'util'
* remove unnecessarily escaped chars in tests
* ignores node_modules  from editorconfig, standard, echint

* add Node 8 to travis to see lint + test ouput
  - @ahmadnassri looks like chalk requires node version >=4 re: #124, so I added node 8 to the travis file. Currently tests are at `692 passing (6s), 1 pending, 99 failing`.

Fixes #125 