### PR TITLE
feat: PHP JSON body encoding

### DIFF
--- a/src/targets/php/curl.js
+++ b/src/targets/php/curl.js
@@ -11,6 +11,7 @@
 'use strict'
 
 var util = require('util')
+var helpers = require('./helpers')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
@@ -67,9 +68,13 @@ module.exports = function (source, options) {
     name: 'CURLOPT_CUSTOMREQUEST',
     value: source.method
   }, {
-    escape: true,
+    escape: !source.postData.jsonObj,
     name: 'CURLOPT_POSTFIELDS',
-    value: source.postData ? source.postData.text : undefined
+    value: source.postData ? (
+      source.postData.jsonObj ?
+        'json_encode(' + helpers.convert(source.postData.jsonObj, opts.indent) + ')' :
+      source.postData.text
+    ) : undefined
   }]
 
   code.push('curl_setopt_array($curl, array(')

--- a/src/targets/php/http1.js
+++ b/src/targets/php/http1.js
@@ -66,6 +66,12 @@ module.exports = function (source, options) {
           .blank()
       break
 
+    case 'application/json':
+      code.push('$request->setContentType(%s);', helpers.convert(source.postData.mimeType))
+          .push('$request->setBody(json_encode(%s));', helpers.convert(source.postData.paramsObj, opts.indent))
+          .blank()
+      break
+
     default:
       if (source.postData.text) {
         code.push('$request->setBody(%s);', helpers.convert(source.postData.text))

--- a/src/targets/php/http2.js
+++ b/src/targets/php/http2.js
@@ -75,6 +75,10 @@ module.exports = function (source, options) {
       hasBody = true
       break
 
+    case 'application/json':
+      code.push('$body = new http\\Message\\Body;')
+          .push('$body->append(json_encode(%s));', helpers.convert(source.postData.jsonObj, opts.indent))
+      break;
     default:
       if (source.postData.text) {
         code.push('$body = new http\\Message\\Body;')

--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -1,12 +1,14 @@
 'use strict'
 
 var CodeBuilder = require('../../helpers/code-builder')
+var child_process = require('child_process')
 
 module.exports = function (source, options) {
   var code = new CodeBuilder()
 
   code.push('require \'uri\'')
       .push('require \'net/http\'')
+      .push('require \'json\'')
       .blank()
 
   // To support custom methods we check for the supported methods
@@ -42,7 +44,10 @@ module.exports = function (source, options) {
     })
   }
 
-  if (source.postData.text) {
+  if (source.postData.jsonObj) {
+    code.push('request.body = JSON.generate(%s)',
+      child_process.execSync("ruby -rjson -e 'puts(JSON.parse(ARGF.read).inspect)'", {input: source.postData.text}))
+  } else if (source.postData.text) {
     code.push('request.body = %s', JSON.stringify(source.postData.text))
   }
 


### PR DESCRIPTION
The problem I have with existing snippets are clients, who try to concatenate JSON from example and complain about errors. I found convert function in this module and used it for JSON body encoding

before (http2 code vs curl, but I have no other examples):
```php
$body->append('{"domain":"shrt.co","links":[{"originalURL":"http://yourlongdomain.com/yourlonglink","path":"q8Wr5","title":"Some url title","tags":["string"],"allowDuplicates":false,"expiresAt":123456789000,"expiredURL":"string","password":"pa$$word","utmSource":"google","utmMedium":"cpc","utmCampaign":"spring_sale","cloaking":1,"redirectType":302}]}');

```

after 
```php
curl_setopt_array($curl, array(
  CURLOPT_URL => "https://api.short.cm/links/bulk",
  CURLOPT_RETURNTRANSFER => true,
  CURLOPT_ENCODING => "",
  CURLOPT_MAXREDIRS => 10,
  CURLOPT_TIMEOUT => 30,
  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
  CURLOPT_CUSTOMREQUEST => "POST",
  CURLOPT_POSTFIELDS => json_encode(array(
  'domain' => 'shrt.co',
  'links' => array(
    array(
        'originalURL' => 'http://yourlongdomain.com/yourlonglink',
        'path' => 'q8Wr5',
        'title' => 'Some url title',
        'tags' => array(
                'string'
        ),
        'allowDuplicates' => null,
        'expiresAt' => 123456789000,
        'expiredURL' => 'string',
        'password' => 'pa$$word',
        'utmSource' => 'google',
        'utmMedium' => 'cpc',
        'utmCampaign' => 'spring_sale',
        'cloaking' => 1,
        'redirectType' => 302
    )
  )
)),
  CURLOPT_HTTPHEADER => array(
    "authorization: REPLACE_KEY_VALUE",
    "content-type: application/json"
  ),
));
```