### PR TITLE
fix(target/python) query string fix

### DIFF
--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -26,7 +26,7 @@ module.exports = function (source, options) {
       .blank()
 
   // Construct query string
-  if (source.queryString.length) {
+  if (Object.keys(source.queryObj).length) {
     var qs = 'querystring = ' + JSON.stringify(source.queryObj)
 
     code.push(qs)

--- a/test/targets/python/requests.js
+++ b/test/targets/python/requests.js
@@ -1,10 +1,12 @@
+/* global it */
+
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet) {
   it('should support query parameters provided in HAR\'s url', function () {
-    var result = new HTTPSnippet({ "method": "GET", "url": "http://mockbin.com/har?param=value" }).convert('python', 'requests', {
+    var result = new HTTPSnippet({ 'method': 'GET', 'url': 'http://mockbin.com/har?param=value' }).convert('python', 'requests', {
       showBoilerplate: false
     })
 

--- a/test/targets/python/requests.js
+++ b/test/targets/python/requests.js
@@ -2,5 +2,13 @@
 
 require('should')
 
-module.exports = function (snippet, fixtures) {
+module.exports = function (HTTPSnippet) {
+  it('should support query parameters provided in HAR\'s url', function () {
+    var result = new HTTPSnippet({ "method": "GET", "url": "http://mockbin.com/har?param=value" }).convert('python', 'requests', {
+      showBoilerplate: false
+    })
+
+    result.should.be.a.String()
+    result.should.eql('import requests\n\nurl = "http://mockbin.com/har"\n\nquerystring = {"param":"value"}\n\nresponse = requests.request("GET", url, params=querystring)\n\nprint(response.text)')
+  })
 }

--- a/test/targets/python/requests.js
+++ b/test/targets/python/requests.js
@@ -11,6 +11,14 @@ module.exports = function (HTTPSnippet) {
     })
 
     result.should.be.a.String()
-    result.should.eql('import requests\n\nurl = "http://mockbin.com/har"\n\nquerystring = {"param":"value"}\n\nresponse = requests.request("GET", url, params=querystring)\n\nprint(response.text)')
+    result.should.eql(`import requests
+
+url = "http://mockbin.com/har"
+
+querystring = {"param":"value"}
+
+response = requests.request("GET", url, params=querystring)
+
+print(response.text)`)
   })
 }


### PR DESCRIPTION
This change fixes handling of query string parameters for python/request target.

Query params can be supplied both by `queryString` and `url` (http://www.softwareishard.com/blog/har-12-spec/#request). Both scenarios are supported here https://github.com/Kong/httpsnippet/blob/master/src/index.js#L164.

However `python/requests` was looking only into `queryString` which was a cause of bug.
