### PR TITLE
Fix JSON body for fetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq --yes python3 php5-curl php5-cli
+  - sudo apt-get install -qq php7.0 php7.0-curl php7.0-cli
 
 after_script:
   - npm run codeclimate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# specify the node base image with your desired version node:<version>
+FROM node:8
+
+ADD . /src
+WORKDIR /src
+
+RUN apt-get update -qq
+RUN apt-get install -qq php7.0 php7.0-curl php7.0-cli
+RUN apt-get install -qq --yes python3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '3'
+services:
+  httpsnippet:
+    build: .
+    command: [npm, test]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "har",
     "http",
     "httpie",
+    "httr",
     "java",
     "javascript",
     "jquery",

--- a/src/targets/index.js
+++ b/src/targets/index.js
@@ -14,6 +14,7 @@ module.exports = {
   php: require('./php'),
   powershell: require('./powershell'),
   python: require('./python'),
+  r: require('./r'),
   ruby: require('./ruby'),
   shell: require('./shell'),
   swift: require('./swift')

--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -40,7 +40,7 @@ module.exports = function (source, options) {
       break
 
     case 'application/json':
-      options.body = JSON.stringify(source.postData.jsonObj)
+      options.body = JSON.stringify(source.postData.jsonObj, null, opts.indent)
       break
 
     case 'multipart/form-data':

--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -40,7 +40,7 @@ module.exports = function (source, options) {
       break
 
     case 'application/json':
-      options.body = source.postData.jsonObj
+      options.body = JSON.stringify(source.postData.jsonObj)
       break
 
     case 'multipart/form-data':

--- a/src/targets/r/httr.js
+++ b/src/targets/r/httr.js
@@ -1,0 +1,154 @@
+/**
+ * @description
+ * HTTP code snippet generator for R using httr
+ *
+ * @author
+ * @gabrielakoreeda
+ *
+ * for any questions or issues regarding the generated code snippet, please open an issue mentioning the author.
+ */
+
+'use strict'
+
+var util = require('util')
+var CodeBuilder = require('../../helpers/code-builder')
+
+module.exports = function (source, options) {
+  // Start snippet
+  var code = new CodeBuilder()
+
+  // Import httr
+  code.push('library(httr)')
+    .blank()
+
+  // Set URL
+  code.push('url <- "%s"', source.url)
+    .blank()
+
+  // Construct query string
+  var query
+  var qs = source.queryObj
+  var queryCount = Object.keys(qs).length
+  delete source.queryObj['key']
+
+  if (source.queryString.length === 1) {
+    code.push('queryString <- list(%s = "%s")', Object.keys(qs), Object.values(qs).toString())
+      .blank()
+  } else if (source.queryString.length > 1) {
+    var count = 1
+
+    code.push('queryString <- list(')
+
+    for (query in qs) {
+      if (count++ !== queryCount - 1) {
+        code.push('  %s = "%s",', query, qs[query].toString())
+      } else {
+        code.push('  %s = "%s"', query, qs[query].toString())
+      }
+    }
+
+    code.push(')')
+      .blank()
+  }
+
+  // Construct payload
+  var payload = JSON.stringify(source.postData.text)
+
+  if (payload) {
+    code.push('payload <- %s', payload)
+      .blank()
+  }
+
+  // Define encode
+  if (source.postData.text || source.postData.jsonObj || source.postData.params) {
+    switch (source.postData.mimeType) {
+      case 'application/x-www-form-urlencoded':
+        code.push('encode <- "form"')
+          .blank()
+        break
+
+      case 'application/json':
+        code.push('encode <- "json"')
+          .blank()
+        break
+
+      case 'multipart/form-data':
+        code.push('encode <- "multipart"')
+          .blank()
+        break
+
+      default:
+        code.push('encode <- "raw"')
+          .blank()
+        break
+    }
+  }
+
+  // Construct headers
+  var head
+  var headers = source.allHeaders
+  var headerCount = Object.keys(headers).length
+  var header = ''
+  var cookies
+  var accept
+
+  for (head in headers) {
+    if (head === 'accept') {
+      accept = ', accept("' + headers[head] + '")'
+      headerCount = headerCount - 1
+    } else if (head === 'cookie') {
+      cookies = ', set_cookies(`' + headers[head].replace(/;/g, '", `').replace(/` /g, '`').replace(/=/g, '` = "') + '")'
+      headerCount = headerCount - 1
+    } else if (head !== 'content-type') {
+      header = header + head.replace('-', '_') + " = '" + headers[head]
+      if (headerCount > 1) { header = header + "', " }
+    }
+  }
+
+  // Construct request
+  var method = source.method
+  var request = util.format('response <- VERB("%s", url', method)
+
+  if (payload) {
+    request += ', body = payload'
+  }
+
+  if (header !== '') {
+    request += ', add_headers(' + header + "')"
+  }
+
+  if (source.queryString.length) {
+    request += ', query = queryString'
+  }
+
+  request += ', content_type("' + source.postData.mimeType + '")'
+
+  if (typeof accept !== 'undefined') {
+    request += accept
+  }
+
+  if (typeof cookies !== 'undefined') {
+    request += cookies
+  }
+
+  if (source.postData.text || source.postData.jsonObj || source.postData.params) {
+    request += ', encode = encode'
+  }
+
+  request += ')'
+
+  code.push(request)
+    .blank()
+
+  // Print response
+    .push('content(response, "text")')
+
+  return code.join()
+}
+
+module.exports.info = {
+  key: 'httr',
+  title: 'httr',
+  link: 'https://cran.r-project.org/web/packages/httr/vignettes/quickstart.html',
+  description: 'httr: Tools for Working with URLs and HTTP'
+}

--- a/src/targets/r/index.js
+++ b/src/targets/r/index.js
@@ -1,0 +1,12 @@
+'use strict'
+
+module.exports = {
+  info: {
+    key: 'r',
+    title: 'R',
+    extname: '.r',
+    default: 'httr'
+  },
+
+  httr: require('./httr')
+}

--- a/test/fixtures/available-targets.json
+++ b/test/fixtures/available-targets.json
@@ -256,6 +256,20 @@
     ]
   },
   {
+    "key": "r",
+    "title": "R",
+    "extname": ".r",
+    "default": "httr",
+    "clients": [
+      {
+        "key": "httr",
+        "title": "httr",
+        "link": "https://cran.r-project.org/web/packages/httr/vignettes/quickstart.html",
+        "description": "httr: Tools for Working with URLs and HTTP"
+      }
+    ]
+  },
+  {
     "default": "webrequest",
     "extname": ".ps1",
     "key": "powershell",

--- a/test/fixtures/output/r/httr/application-form-encoded.r
+++ b/test/fixtures/output/r/httr/application-form-encoded.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "foo=bar&hello=world"
+
+encode <- "form"
+
+response <- VERB("POST", url, body = payload, content_type("application/x-www-form-urlencoded"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/application-json.r
+++ b/test/fixtures/output/r/httr/application-json.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"
+
+encode <- "json"
+
+response <- VERB("POST", url, body = payload, content_type("application/json"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/cookies.r
+++ b/test/fixtures/output/r/httr/cookies.r
@@ -1,0 +1,7 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+response <- VERB("POST", url, content_type("application/octet-stream"), set_cookies(`foo` = "bar", `bar` = "baz"))
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/custom-method.r
+++ b/test/fixtures/output/r/httr/custom-method.r
@@ -1,0 +1,7 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+response <- VERB("PROPFIND", url, content_type("application/octet-stream"))
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/full.r
+++ b/test/fixtures/output/r/httr/full.r
@@ -1,0 +1,16 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+queryString <- list(
+  foo = "bar,baz",
+  baz = "abc"
+)
+
+payload <- "foo=bar"
+
+encode <- "form"
+
+response <- VERB("POST", url, body = payload, query = queryString, content_type("application/x-www-form-urlencoded"), accept("application/json"), set_cookies(`foo` = "bar", `bar` = "baz"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/headers.r
+++ b/test/fixtures/output/r/httr/headers.r
@@ -1,0 +1,7 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+response <- VERB("GET", url, add_headers(x_foo = 'Bar'), content_type("application/octet-stream"), accept("application/json"))
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/https.r
+++ b/test/fixtures/output/r/httr/https.r
@@ -1,0 +1,7 @@
+library(httr)
+
+url <- "https://mockbin.com/har"
+
+response <- VERB("GET", url, content_type("application/octet-stream"))
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/jsonObj-multiline.r
+++ b/test/fixtures/output/r/httr/jsonObj-multiline.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "{\n  \"foo\": \"bar\"\n}"
+
+encode <- "json"
+
+response <- VERB("POST", url, body = payload, content_type("application/json"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/jsonObj-null-value.r
+++ b/test/fixtures/output/r/httr/jsonObj-null-value.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "{\"foo\":null}"
+
+encode <- "json"
+
+response <- VERB("POST", url, body = payload, content_type("application/json"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/multipart-data.r
+++ b/test/fixtures/output/r/httr/multipart-data.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n"
+
+encode <- "multipart"
+
+response <- VERB("POST", url, body = payload, content_type("multipart/form-data"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/multipart-file.r
+++ b/test/fixtures/output/r/httr/multipart-file.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n"
+
+encode <- "multipart"
+
+response <- VERB("POST", url, body = payload, content_type("multipart/form-data"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/multipart-form-data.r
+++ b/test/fixtures/output/r/httr/multipart-form-data.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n"
+
+encode <- "multipart"
+
+response <- VERB("POST", url, body = payload, content_type("multipart/form-data"), encode = encode)
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/query.r
+++ b/test/fixtures/output/r/httr/query.r
@@ -1,0 +1,12 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+queryString <- list(
+  foo = "bar,baz",
+  baz = "abc"
+)
+
+response <- VERB("GET", url, query = queryString, content_type("application/octet-stream"))
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/short.r
+++ b/test/fixtures/output/r/httr/short.r
@@ -1,0 +1,7 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+response <- VERB("GET", url, content_type("application/octet-stream"))
+
+content(response, "text")

--- a/test/fixtures/output/r/httr/text-plain.r
+++ b/test/fixtures/output/r/httr/text-plain.r
@@ -1,0 +1,11 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+payload <- "Hello World"
+
+encode <- "raw"
+
+response <- VERB("POST", url, body = payload, content_type("text/plain"), encode = encode)
+
+content(response, "text")

--- a/test/targets/r/httr.js
+++ b/test/targets/r/httr.js
@@ -1,0 +1,6 @@
+'use strict'
+
+require('should')
+
+module.exports = function (snippet, fixtures) {
+}


### PR DESCRIPTION
The fetch API will convert the `body` parameter to a string before sending the request. For bodies that are JSON, the JSON object will get converted to a string and become `[object Object]`.

This uses `JSON.stringify()` to convert the object into a JSON string before sending the request.