### PR TITLE
Add C# HttpClient target client

### DIFF
--- a/src/targets/csharp/httpclient.js
+++ b/src/targets/csharp/httpclient.js
@@ -2,24 +2,64 @@
 
 var CodeBuilder = require('../../helpers/code-builder')
 
+function getDecompressionMethods (source) {
+  var acceptEncoding = source.allHeaders['accept-encoding']
+  if (!acceptEncoding) {
+    return [] // no decompression
+  }
+
+  var supportedMethods = {
+    gzip: 'DecompressionMethods.GZip',
+    deflate: 'DecompressionMethods.Deflate'
+  }
+  var methods = []
+  acceptEncoding.split(',').forEach(function (encoding) {
+    var match = /\s*([^;\s]+)/.exec(encoding)
+    if (match) {
+      var method = supportedMethods[match[1]]
+      if (method) {
+        methods.push(method)
+      }
+    }
+  })
+
+  return methods
+}
+
 module.exports = function (source, options) {
   var indentation = '    '
   var code = new CodeBuilder(indentation)
 
   var clienthandler = ''
-  if (source.allHeaders.cookie) {
-    clienthandler = 'new HttpClientHandler { UseCookies = false }'
+  var cookies = !!source.allHeaders.cookie
+  var decompressionMethods = getDecompressionMethods(source)
+  if (cookies || decompressionMethods.length) {
+    clienthandler = 'clientHandler'
+    code.push('var clientHandler = new HttpClientHandler')
+    code.push('{')
+    if (cookies) {
+      // enable setting the cookie header
+      code.push(1, 'UseCookies = false,')
+    }
+    if (decompressionMethods.length) {
+      // enable decompression for supported methods
+      code.push(1, 'AutomaticDecompression = %s,', decompressionMethods.join(' | '))
+    }
+    code.push('};')
   }
 
   code.push('var client = new HttpClient(%s);', clienthandler)
+
   code.push('var request = new HttpRequestMessage')
   code.push('{')
 
   var methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE' ]
   var method = source.method.toUpperCase()
   if (method && (methods.indexOf(method) !== -1)) {
+    // buildin method
     method = `HttpMethod.${method[0]}${method.substring(1).toLowerCase()}`
   } else {
+    // custom method
     method = `new HttpMethod("${method}")`
   }
   code.push(1, 'Method = %s,', method)
@@ -27,7 +67,15 @@ module.exports = function (source, options) {
   code.push(1, 'RequestUri = new Uri("%s"),', source.fullUrl)
 
   var headers = Object.keys(source.allHeaders).filter(function (header) {
-    return header !== 'content-type'
+    switch (header) {
+      case 'content-type':
+      case 'content-length':
+      case 'accept-encoding':
+        // skip these headers
+        return false
+      default:
+        return true
+    }
   })
   if (headers.length) {
     code.push(1, 'Headers =')
@@ -84,14 +132,16 @@ module.exports = function (source, options) {
         break
     }
   }
-
   code.push('};')
+
+  // send and read response
   code.push('using (var response = await client.SendAsync(request))')
   code.push('{')
   code.push(1, 'response.EnsureSuccessStatusCode();')
   code.push(1, 'var body = await response.Content.ReadAsStringAsync();')
   code.push(1, 'Console.WriteLine(body);')
   code.push('}')
+
   return code.join()
 }
 

--- a/src/targets/csharp/httpclient.js
+++ b/src/targets/csharp/httpclient.js
@@ -1,0 +1,103 @@
+'use strict'
+
+var CodeBuilder = require('../../helpers/code-builder')
+
+module.exports = function (source, options) {
+  var indentation = '    '
+  var code = new CodeBuilder(indentation)
+
+  var clienthandler = ''
+  if (source.allHeaders.cookie) {
+    clienthandler = 'new HttpClientHandler { UseCookies = false }'
+  }
+
+  code.push('var client = new HttpClient(%s);', clienthandler)
+  code.push('var request = new HttpRequestMessage')
+  code.push('{')
+
+  var methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE' ]
+  var method = source.method.toUpperCase()
+  if (method && (methods.indexOf(method) !== -1)) {
+    method = `HttpMethod.${method[0]}${method.substring(1).toLowerCase()}`
+  } else {
+    method = `new HttpMethod("${method}")`
+  }
+  code.push(1, 'Method = %s,', method)
+
+  code.push(1, 'RequestUri = new Uri("%s"),', source.fullUrl)
+
+  var headers = Object.keys(source.allHeaders).filter(function (header) {
+    return header !== 'content-type'
+  })
+  if (headers.length) {
+    code.push(1, 'Headers =')
+    code.push(1, '{')
+    headers.forEach(function (key) {
+      code.push(2, '{ "%s", "%s" },', key, source.allHeaders[key])
+    })
+    code.push(1, '},')
+  }
+
+  if (source.postData.text) {
+    const contentType = source.postData.mimeType
+    switch (contentType) {
+      case 'application/x-www-form-urlencoded':
+        code.push(1, 'Content = new FormUrlEncodedContent(new Dictionary<string, string>')
+        code.push(1, '{')
+        source.postData.params.forEach(function (param) {
+          code.push(2, '{ "%s", "%s" },', param.name, param.value)
+        })
+        code.push(1, '}),')
+        break
+      case 'multipart/form-data':
+        code.push(1, 'Content = new MultipartFormDataContent')
+        code.push(1, '{')
+        source.postData.params.forEach(function (param) {
+          code.push(2, 'new StringContent(%s)', JSON.stringify(param.value || ''))
+          code.push(2, '{')
+          code.push(3, 'Headers =')
+          code.push(3, '{')
+          if (param.contentType) {
+            code.push(4, 'ContentType = new MediaTypeHeaderValue("%s"),', param.contentType)
+          }
+          code.push(4, 'ContentDisposition = new ContentDispositionHeaderValue("form-data")')
+          code.push(4, '{')
+          code.push(5, 'Name = "%s",', param.name)
+          if (param.fileName) {
+            code.push(5, 'FileName = "%s",', param.fileName)
+          }
+          code.push(4, '}')
+          code.push(3, '}')
+          code.push(2, '},')
+        })
+
+        code.push(1, '},')
+        break
+      default:
+        code.push(1, 'Content = new StringContent(%s)', JSON.stringify(source.postData.text || ''))
+        code.push(1, '{')
+        code.push(2, 'Headers =')
+        code.push(2, '{')
+        code.push(3, 'ContentType = new MediaTypeHeaderValue("%s")', contentType)
+        code.push(2, '}')
+        code.push(1, '}')
+        break
+    }
+  }
+
+  code.push('};')
+  code.push('using (var response = await client.SendAsync(request))')
+  code.push('{')
+  code.push(1, 'response.EnsureSuccessStatusCode();')
+  code.push(1, 'var body = await response.Content.ReadAsStringAsync();')
+  code.push(1, 'Console.WriteLine(body);')
+  code.push('}')
+  return code.join()
+}
+
+module.exports.info = {
+  key: 'httpclient',
+  title: 'HttpClient',
+  link: 'https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient',
+  description: '.NET Standard HTTP Client'
+}

--- a/src/targets/csharp/index.js
+++ b/src/targets/csharp/index.js
@@ -8,5 +8,6 @@ module.exports = {
     default: 'restsharp'
   },
 
-  restsharp: require('./restsharp')
+  restsharp: require('./restsharp'),
+  httpclient: require('./httpclient')
 }

--- a/test/fixtures/available-targets.json
+++ b/test/fixtures/available-targets.json
@@ -230,6 +230,12 @@
         "title": "RestSharp",
         "link": "http://restsharp.org/",
         "description": "Simple REST and HTTP API Client for .NET"
+      },
+      {
+        "key": "httpclient",
+        "title": "HttpClient",
+        "link": "https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient",
+        "description": ".NET Standard HTTP Client"
       }
     ]
   },

--- a/test/fixtures/output/csharp/httpclient/application-form-encoded.cs
+++ b/test/fixtures/output/csharp/httpclient/application-form-encoded.cs
@@ -1,0 +1,17 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new FormUrlEncodedContent(new Dictionary<string, string>
+    {
+        { "foo", "bar" },
+        { "hello", "world" },
+    }),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/application-json.cs
+++ b/test/fixtures/output/csharp/httpclient/application-json.cs
@@ -1,0 +1,19 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new StringContent("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}")
+    {
+        Headers =
+        {
+            ContentType = new MediaTypeHeaderValue("application/json")
+        }
+    }
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/cookies.cs
+++ b/test/fixtures/output/csharp/httpclient/cookies.cs
@@ -1,0 +1,16 @@
+var client = new HttpClient(new HttpClientHandler { UseCookies = false });
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Headers =
+    {
+        { "cookie", "foo=bar; bar=baz" },
+    },
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/cookies.cs
+++ b/test/fixtures/output/csharp/httpclient/cookies.cs
@@ -1,4 +1,8 @@
-var client = new HttpClient(new HttpClientHandler { UseCookies = false });
+var clientHandler = new HttpClientHandler
+{
+    UseCookies = false,
+};
+var client = new HttpClient(clientHandler);
 var request = new HttpRequestMessage
 {
     Method = HttpMethod.Post,

--- a/test/fixtures/output/csharp/httpclient/custom-method.cs
+++ b/test/fixtures/output/csharp/httpclient/custom-method.cs
@@ -1,0 +1,12 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = new HttpMethod("PROPFIND"),
+    RequestUri = new Uri("http://mockbin.com/har"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/full.cs
+++ b/test/fixtures/output/csharp/httpclient/full.cs
@@ -1,4 +1,8 @@
-var client = new HttpClient(new HttpClientHandler { UseCookies = false });
+var clientHandler = new HttpClientHandler
+{
+    UseCookies = false,
+};
+var client = new HttpClient(clientHandler);
 var request = new HttpRequestMessage
 {
     Method = HttpMethod.Post,

--- a/test/fixtures/output/csharp/httpclient/full.cs
+++ b/test/fixtures/output/csharp/httpclient/full.cs
@@ -1,0 +1,21 @@
+var client = new HttpClient(new HttpClientHandler { UseCookies = false });
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"),
+    Headers =
+    {
+        { "cookie", "foo=bar; bar=baz" },
+        { "accept", "application/json" },
+    },
+    Content = new FormUrlEncodedContent(new Dictionary<string, string>
+    {
+        { "foo", "bar" },
+    }),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/headers.cs
+++ b/test/fixtures/output/csharp/httpclient/headers.cs
@@ -1,0 +1,17 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Get,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Headers =
+    {
+        { "accept", "application/json" },
+        { "x-foo", "Bar" },
+    },
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/https.cs
+++ b/test/fixtures/output/csharp/httpclient/https.cs
@@ -1,0 +1,12 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Get,
+    RequestUri = new Uri("https://mockbin.com/har"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/jsonObj-multiline.cs
+++ b/test/fixtures/output/csharp/httpclient/jsonObj-multiline.cs
@@ -1,0 +1,19 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new StringContent("{\n  \"foo\": \"bar\"\n}")
+    {
+        Headers =
+        {
+            ContentType = new MediaTypeHeaderValue("application/json")
+        }
+    }
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/jsonObj-null-value.cs
+++ b/test/fixtures/output/csharp/httpclient/jsonObj-null-value.cs
@@ -1,0 +1,19 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new StringContent("{\"foo\":null}")
+    {
+        Headers =
+        {
+            ContentType = new MediaTypeHeaderValue("application/json")
+        }
+    }
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/multipart-data.cs
+++ b/test/fixtures/output/csharp/httpclient/multipart-data.cs
@@ -1,0 +1,27 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new MultipartFormDataContent
+    {
+        new StringContent("Hello World")
+        {
+            Headers =
+            {
+                ContentType = new MediaTypeHeaderValue("text/plain"),
+                ContentDisposition = new ContentDispositionHeaderValue("form-data")
+                {
+                    Name = "foo",
+                    FileName = "hello.txt",
+                }
+            }
+        },
+    },
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/multipart-file.cs
+++ b/test/fixtures/output/csharp/httpclient/multipart-file.cs
@@ -1,0 +1,27 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new MultipartFormDataContent
+    {
+        new StringContent("")
+        {
+            Headers =
+            {
+                ContentType = new MediaTypeHeaderValue("text/plain"),
+                ContentDisposition = new ContentDispositionHeaderValue("form-data")
+                {
+                    Name = "foo",
+                    FileName = "test/fixtures/files/hello.txt",
+                },
+            }
+        },
+    },
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/multipart-file.cs
+++ b/test/fixtures/output/csharp/httpclient/multipart-file.cs
@@ -14,7 +14,7 @@ var request = new HttpRequestMessage
                 {
                     Name = "foo",
                     FileName = "test/fixtures/files/hello.txt",
-                },
+                }
             }
         },
     },

--- a/test/fixtures/output/csharp/httpclient/multipart-form-data.cs
+++ b/test/fixtures/output/csharp/httpclient/multipart-form-data.cs
@@ -1,0 +1,25 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new MultipartFormDataContent
+    {
+        new StringContent("bar")
+        {
+            Headers =
+            {
+                ContentDisposition = new ContentDispositionHeaderValue("form-data")
+                {
+                    Name = "foo",
+                },
+            }
+        },
+    },
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/multipart-form-data.cs
+++ b/test/fixtures/output/csharp/httpclient/multipart-form-data.cs
@@ -12,7 +12,7 @@ var request = new HttpRequestMessage
                 ContentDisposition = new ContentDispositionHeaderValue("form-data")
                 {
                     Name = "foo",
-                },
+                }
             }
         },
     },

--- a/test/fixtures/output/csharp/httpclient/query.cs
+++ b/test/fixtures/output/csharp/httpclient/query.cs
@@ -1,0 +1,12 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Get,
+    RequestUri = new Uri("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/short.cs
+++ b/test/fixtures/output/csharp/httpclient/short.cs
@@ -1,0 +1,12 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Get,
+    RequestUri = new Uri("http://mockbin.com/har"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/httpclient/text-plain.cs
+++ b/test/fixtures/output/csharp/httpclient/text-plain.cs
@@ -1,0 +1,19 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("http://mockbin.com/har"),
+    Content = new StringContent("Hello World")
+    {
+        Headers =
+        {
+            ContentType = new MediaTypeHeaderValue("text/plain")
+        }
+    }
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/targets/csharp/httpclient.js
+++ b/test/targets/csharp/httpclient.js
@@ -1,0 +1,5 @@
+'use strict'
+
+require('should')
+
+module.exports = function (snippet, fixtures) {}


### PR DESCRIPTION
Adds a second C# target client, one that doesn't require an additional NuGet package to work.
This will generate a C# snippet which can be pasted into the body of an existing (async) method.
#141 

Differences between this and PR #142:
- this also generates working code for *multipart/form-data* requests
- this supports custom HTTP methods
- this enables automatic gzip, deflate (but no br) decompression if a compatible accept header is found
- this generates code similar to the *restsharp* target client: no method declaration boilerplate is generated and the user has to add the required using statements on their own