### PR TITLE
feat: change the default response code for Python Requests

### DIFF
--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -89,7 +89,7 @@ module.exports = function (source, options) {
       .blank()
 
       // Print response
-      .push('print(response.text)')
+      .push('print(response.json())')
 
   return code.join()
 }


### PR DESCRIPTION
When printing the response using the Python Requests client, the default is `print(response.text)`. From what I've seen, most developers use `print(response.json())` or `print response.json()` to print the output of a response. Thus, it makes more sense to have the default print value be in JSON format, rather than raw text format.