### PR TITLE
Fix uncompilable code of Java asynchttp

### DIFF
--- a/src/targets/java/asynchttp.js
+++ b/src/targets/java/asynchttp.js
@@ -21,7 +21,7 @@ module.exports = function (source, options) {
 
   code.push('AsyncHttpClient client = new DefaultAsyncHttpClient();')
 
-  code.push(`client.prepare${source.method[0].toUpperCase()}${source.method.substring(1).toLowerCase()}("${source.fullUrl}")`)
+  code.push(`client.prepare("${source.method.toUpperCase()}", "${source.fullUrl}")`)
 
   // Add headers, including the cookies
   var headers = Object.keys(source.allHeaders)

--- a/test/fixtures/output/java/asynchttp/application-form-encoded.java
+++ b/test/fixtures/output/java/asynchttp/application-form-encoded.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "application/x-www-form-urlencoded")
   .setBody("foo=bar&hello=world")
   .execute()

--- a/test/fixtures/output/java/asynchttp/application-json.java
+++ b/test/fixtures/output/java/asynchttp/application-json.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "application/json")
   .setBody("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}")
   .execute()

--- a/test/fixtures/output/java/asynchttp/cookies.java
+++ b/test/fixtures/output/java/asynchttp/cookies.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("cookie", "foo=bar; bar=baz")
   .execute()
   .toCompletableFuture()

--- a/test/fixtures/output/java/asynchttp/custom-method.java
+++ b/test/fixtures/output/java/asynchttp/custom-method.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePropfind("http://mockbin.com/har")
+client.prepare("PROPFIND", "http://mockbin.com/har")
   .execute()
   .toCompletableFuture()
   .thenAccept(System.out::println)

--- a/test/fixtures/output/java/asynchttp/full.java
+++ b/test/fixtures/output/java/asynchttp/full.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value")
+client.prepare("POST", "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value")
   .setHeader("cookie", "foo=bar; bar=baz")
   .setHeader("accept", "application/json")
   .setHeader("content-type", "application/x-www-form-urlencoded")

--- a/test/fixtures/output/java/asynchttp/headers.java
+++ b/test/fixtures/output/java/asynchttp/headers.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.prepareGet("http://mockbin.com/har")
+client.prepare("GET", "http://mockbin.com/har")
   .setHeader("accept", "application/json")
   .setHeader("x-foo", "Bar")
   .execute()

--- a/test/fixtures/output/java/asynchttp/https.java
+++ b/test/fixtures/output/java/asynchttp/https.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.prepareGet("https://mockbin.com/har")
+client.prepare("GET", "https://mockbin.com/har")
   .execute()
   .toCompletableFuture()
   .thenAccept(System.out::println)

--- a/test/fixtures/output/java/asynchttp/jsonObj-multiline.java
+++ b/test/fixtures/output/java/asynchttp/jsonObj-multiline.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "application/json")
   .setBody("{\n  \"foo\": \"bar\"\n}")
   .execute()

--- a/test/fixtures/output/java/asynchttp/jsonObj-null-value.java
+++ b/test/fixtures/output/java/asynchttp/jsonObj-null-value.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "application/json")
   .setBody("{\"foo\":null}")
   .execute()

--- a/test/fixtures/output/java/asynchttp/multipart-data.java
+++ b/test/fixtures/output/java/asynchttp/multipart-data.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001")
   .setBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n")
   .execute()

--- a/test/fixtures/output/java/asynchttp/multipart-file.java
+++ b/test/fixtures/output/java/asynchttp/multipart-file.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001")
   .setBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n")
   .execute()

--- a/test/fixtures/output/java/asynchttp/multipart-form-data.java
+++ b/test/fixtures/output/java/asynchttp/multipart-form-data.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001")
   .setBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n")
   .execute()

--- a/test/fixtures/output/java/asynchttp/query.java
+++ b/test/fixtures/output/java/asynchttp/query.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.prepareGet("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value")
+client.prepare("GET", "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value")
   .execute()
   .toCompletableFuture()
   .thenAccept(System.out::println)

--- a/test/fixtures/output/java/asynchttp/short.java
+++ b/test/fixtures/output/java/asynchttp/short.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.prepareGet("http://mockbin.com/har")
+client.prepare("GET", "http://mockbin.com/har")
   .execute()
   .toCompletableFuture()
   .thenAccept(System.out::println)

--- a/test/fixtures/output/java/asynchttp/text-plain.java
+++ b/test/fixtures/output/java/asynchttp/text-plain.java
@@ -1,5 +1,5 @@
 AsyncHttpClient client = new DefaultAsyncHttpClient();
-client.preparePost("http://mockbin.com/har")
+client.prepare("POST", "http://mockbin.com/har")
   .setHeader("content-type", "text/plain")
   .setBody("Hello World")
   .execute()


### PR DESCRIPTION
I noticed, java/asynchttp/custom-method.java is not compilable because there is no `preparePropfind` method.

```java
AsyncHttpClient client = new DefaultAsyncHttpClient();
client.preparePropfind("http://mockbin.com/har")
```

I unified code style from `client.prepareMethod(url)` to `client.prepare("METHOD", url)` because internal code of DefaultAsyncHttpClient is like this.

```java
    public BoundRequestBuilder prepare(String method, String url) {
        return this.requestBuilder(method, url);
    }

    public BoundRequestBuilder prepareGet(String url) {
        return this.requestBuilder("GET", url);
    }

    public BoundRequestBuilder prepareConnect(String url) {
        return this.requestBuilder("CONNECT", url);
    }

    public BoundRequestBuilder prepareOptions(String url) {
        return this.requestBuilder("OPTIONS", url);
    }

    public BoundRequestBuilder prepareHead(String url) {
        return this.requestBuilder("HEAD", url);
    }

    public BoundRequestBuilder preparePost(String url) {
        return this.requestBuilder("POST", url);
    }

    public BoundRequestBuilder preparePut(String url) {
        return this.requestBuilder("PUT", url);
    }

    // ...
```




