### PR TITLE
Add java.net.http.HttpClient based snippet generator

### DIFF
--- a/src/targets/java/index.js
+++ b/src/targets/java/index.js
@@ -10,6 +10,6 @@ module.exports = {
 
   okhttp: require('./okhttp'),
   unirest: require('./unirest'),
-  asynchttp: require('./asynchttp')
-
+  asynchttp: require('./asynchttp'),
+  nethttp: require('./nethttp')
 }

--- a/src/targets/java/nethttp.js
+++ b/src/targets/java/nethttp.js
@@ -1,0 +1,63 @@
+/**
+ * @description
+ * HTTP code snippet generator for Java using java.net.http.
+ *
+ * @author
+ * @wtetsu
+ *
+ * for any questions or issues regarding the generated code snippet, please open an issue mentioning the author.
+ */
+
+'use strict'
+
+var CodeBuilder = require('../../helpers/code-builder')
+
+module.exports = function (source, options) {
+  var opts = Object.assign(
+    {
+      indent: '  '
+    },
+    options
+  )
+
+  var code = new CodeBuilder(opts.indent)
+
+  code.push('HttpRequest request = HttpRequest.newBuilder()')
+  code.push(2, '.uri(URI.create("%s"))', source.fullUrl)
+
+  var headers = Object.keys(source.allHeaders)
+
+  // construct headers
+  if (headers.length) {
+    headers.forEach(function (key) {
+      code.push(2, '.header("%s", "%s")', key, source.allHeaders[key])
+    })
+  }
+
+  if (source.postData.text) {
+    code.push(
+      2,
+      '.method("%s", HttpRequest.BodyPublishers.ofString(%s))',
+      source.method.toUpperCase(),
+      JSON.stringify(source.postData.text)
+    )
+  } else {
+    code.push(2, '.method("%s", HttpRequest.BodyPublishers.noBody())', source.method.toUpperCase())
+  }
+
+  code.push(2, '.build();')
+
+  code.push(
+    'HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());'
+  )
+  code.push('System.out.println(response.body());')
+
+  return code.join()
+}
+
+module.exports.info = {
+  key: 'nethttp',
+  title: 'java.net.http',
+  link: 'https://openjdk.java.net/groups/net/httpclient/intro.html',
+  description: 'Java Standardized HTTP Client API'
+}

--- a/test/fixtures/available-targets.json
+++ b/test/fixtures/available-targets.json
@@ -202,6 +202,12 @@
         "title": "AsyncHttp",
         "link": "https://github.com/AsyncHttpClient/async-http-client",
         "description": "Asynchronous Http and WebSocket Client library for Java"
+      },
+      {
+        "key": "nethttp",
+        "title": "java.net.http",
+        "link": "https://openjdk.java.net/groups/net/httpclient/intro.html",
+        "description": "Java Standardized HTTP Client API"
       }
     ]
   },

--- a/test/fixtures/output/java/nethttp/application-form-encoded.java
+++ b/test/fixtures/output/java/nethttp/application-form-encoded.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "application/x-www-form-urlencoded")
+    .method("POST", HttpRequest.BodyPublishers.ofString("foo=bar&hello=world"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/application-json.java
+++ b/test/fixtures/output/java/nethttp/application-json.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "application/json")
+    .method("POST", HttpRequest.BodyPublishers.ofString("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/cookies.java
+++ b/test/fixtures/output/java/nethttp/cookies.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("cookie", "foo=bar; bar=baz")
+    .method("POST", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/custom-method.java
+++ b/test/fixtures/output/java/nethttp/custom-method.java
@@ -1,0 +1,6 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .method("PROPFIND", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/full.java
+++ b/test/fixtures/output/java/nethttp/full.java
@@ -1,0 +1,9 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"))
+    .header("cookie", "foo=bar; bar=baz")
+    .header("accept", "application/json")
+    .header("content-type", "application/x-www-form-urlencoded")
+    .method("POST", HttpRequest.BodyPublishers.ofString("foo=bar"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/headers.java
+++ b/test/fixtures/output/java/nethttp/headers.java
@@ -1,0 +1,8 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("accept", "application/json")
+    .header("x-foo", "Bar")
+    .method("GET", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/https.java
+++ b/test/fixtures/output/java/nethttp/https.java
@@ -1,0 +1,6 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("https://mockbin.com/har"))
+    .method("GET", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/jsonObj-multiline.java
+++ b/test/fixtures/output/java/nethttp/jsonObj-multiline.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "application/json")
+    .method("POST", HttpRequest.BodyPublishers.ofString("{\n  \"foo\": \"bar\"\n}"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/jsonObj-null-value.java
+++ b/test/fixtures/output/java/nethttp/jsonObj-null-value.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "application/json")
+    .method("POST", HttpRequest.BodyPublishers.ofString("{\"foo\":null}"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/multipart-data.java
+++ b/test/fixtures/output/java/nethttp/multipart-data.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "multipart/form-data; boundary=---011000010111000001101001")
+    .method("POST", HttpRequest.BodyPublishers.ofString("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/multipart-file.java
+++ b/test/fixtures/output/java/nethttp/multipart-file.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "multipart/form-data; boundary=---011000010111000001101001")
+    .method("POST", HttpRequest.BodyPublishers.ofString("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/multipart-form-data.java
+++ b/test/fixtures/output/java/nethttp/multipart-form-data.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "multipart/form-data; boundary=---011000010111000001101001")
+    .method("POST", HttpRequest.BodyPublishers.ofString("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/query.java
+++ b/test/fixtures/output/java/nethttp/query.java
@@ -1,0 +1,6 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"))
+    .method("GET", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/short.java
+++ b/test/fixtures/output/java/nethttp/short.java
@@ -1,0 +1,6 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .method("GET", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/nethttp/text-plain.java
+++ b/test/fixtures/output/java/nethttp/text-plain.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har"))
+    .header("content-type", "text/plain")
+    .method("POST", HttpRequest.BodyPublishers.ofString("Hello World"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/targets/java/nethttp.js
+++ b/test/targets/java/nethttp.js
@@ -1,0 +1,5 @@
+'use strict'
+
+require('should')
+
+module.exports = function (snippet, fixtures) {}


### PR DESCRIPTION
Hello, I added Java code generator that uses java.net.http.HttpClient.

There are already some Java implementations,
but it seems all of them use third party library that are need to be installed.

Advantage:
This code is based on the Java standard library so it's available without installing any third-party library in Java 9+.
and code is concise enough, I think.

Basic code style:
```java
HttpRequest request = HttpRequest.newBuilder()
    .uri(URI.create("http://mockbin.com/har"))
    .header("content-type", "text/plain")
    .method("POST", HttpRequest.BodyPublishers.ofString("Hello World"))
    .build();
HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
System.out.println(response.body());
```
