### PR TITLE
feat: updating javascript targets to use `const` instead of `var`

### DIFF
--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -44,7 +44,7 @@ module.exports = function (source, options) {
       break
 
     case 'multipart/form-data':
-      code.push('var form = new FormData();')
+      code.push('const form = new FormData();')
 
       source.postData.params.forEach(function (param) {
         code.push(

--- a/src/targets/javascript/jquery.js
+++ b/src/targets/javascript/jquery.js
@@ -38,7 +38,7 @@ module.exports = function (source, options) {
       break
 
     case 'multipart/form-data':
-      code.push('var form = new FormData();')
+      code.push('const form = new FormData();')
 
       source.postData.params.forEach(function (param) {
         code.push('form.append(%s, %s);', JSON.stringify(param.name), JSON.stringify(param.value || param.fileName || ''))
@@ -62,7 +62,7 @@ module.exports = function (source, options) {
       }
   }
 
-  code.push('var settings = ' + JSON.stringify(settings, null, opts.indent).replace('"[form]"', 'form'))
+  code.push('const settings = ' + JSON.stringify(settings, null, opts.indent).replace('"[form]"', 'form') + ';')
       .blank()
       .push('$.ajax(settings).done(function (response) {')
       .push(1, 'console.log(response);')

--- a/src/targets/javascript/xhr.js
+++ b/src/targets/javascript/xhr.js
@@ -22,12 +22,12 @@ module.exports = function (source, options) {
 
   switch (source.postData.mimeType) {
     case 'application/json':
-      code.push('var data = JSON.stringify(%s);', JSON.stringify(source.postData.jsonObj, null, opts.indent))
+      code.push('const data = JSON.stringify(%s);', JSON.stringify(source.postData.jsonObj, null, opts.indent))
           .push(null)
       break
 
     case 'multipart/form-data':
-      code.push('var data = new FormData();')
+      code.push('const data = new FormData();')
 
       source.postData.params.forEach(function (param) {
         code.push('data.append(%s, %s);', JSON.stringify(param.name), JSON.stringify(param.value || param.fileName || ''))
@@ -42,11 +42,11 @@ module.exports = function (source, options) {
       break
 
     default:
-      code.push('var data = %s;', JSON.stringify(source.postData.text || null))
+      code.push('const data = %s;', JSON.stringify(source.postData.text || null))
           .blank()
   }
 
-  code.push('var xhr = new XMLHttpRequest();')
+  code.push('const xhr = new XMLHttpRequest();')
 
   if (opts.cors) {
     code.push('xhr.withCredentials = true;')

--- a/src/targets/node/native.js
+++ b/src/targets/node/native.js
@@ -28,20 +28,20 @@ module.exports = function (source, options) {
     headers: source.allHeaders
   }
 
-  code.push('var http = require("%s");', source.uriObj.protocol.replace(':', ''))
+  code.push('const http = require("%s");', source.uriObj.protocol.replace(':', ''))
 
   code.blank()
-      .push('var options = %s;', JSON.stringify(reqOpts, null, opts.indent))
+      .push('const options = %s;', JSON.stringify(reqOpts, null, opts.indent))
       .blank()
-      .push('var req = http.request(options, function (res) {')
-      .push(1, 'var chunks = [];')
+      .push('const req = http.request(options, function (res) {')
+      .push(1, 'const chunks = [];')
       .blank()
       .push(1, 'res.on("data", function (chunk) {')
       .push(2, 'chunks.push(chunk);')
       .push(1, '});')
       .blank()
       .push(1, 'res.on("end", function () {')
-      .push(2, 'var body = Buffer.concat(chunks);')
+      .push(2, 'const body = Buffer.concat(chunks);')
       .push(2, 'console.log(body.toString());')
       .push(1, '});')
       .push('});')
@@ -50,7 +50,7 @@ module.exports = function (source, options) {
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
       if (source.postData.paramsObj) {
-        code.unshift('var qs = require("querystring");')
+        code.unshift('const qs = require("querystring");')
         code.push('req.write(qs.stringify(%s));', stringifyObject(source.postData.paramsObj, {
           indent: '  ',
           inlineCharacterLimit: 80

--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -22,7 +22,7 @@ module.exports = function (source, options) {
   var includeFS = false
   var code = new CodeBuilder(opts.indent)
 
-  code.push('var request = require("request");')
+  code.push("const request = require('request');")
       .blank()
 
   var reqOpts = {
@@ -90,21 +90,21 @@ module.exports = function (source, options) {
   if (source.cookies.length) {
     reqOpts.jar = 'JAR'
 
-    code.push('var jar = request.jar();')
+    code.push('const jar = request.jar();')
 
     var url = source.url
 
     source.cookies.forEach(function (cookie) {
-      code.push('jar.setCookie(request.cookie("%s=%s"), "%s");', encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), url)
+      code.push("jar.setCookie(request.cookie('%s=%s'), '%s');", encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), url)
     })
     code.blank()
   }
 
   if (includeFS) {
-    code.unshift('var fs = require("fs");')
+    code.unshift("const fs = require('fs');")
   }
 
-  code.push('var options = %s;', stringifyObject(reqOpts, { indent: '  ', inlineCharacterLimit: 80 }))
+  code.push('const options = %s;', stringifyObject(reqOpts, { indent: '  ', inlineCharacterLimit: 80 }))
     .blank()
 
   code.push(util.format('request(options, %s', 'function (error, response, body) {'))

--- a/src/targets/node/unirest.js
+++ b/src/targets/node/unirest.js
@@ -20,20 +20,20 @@ module.exports = function (source, options) {
   var includeFS = false
   var code = new CodeBuilder(opts.indent)
 
-  code.push('var unirest = require("unirest");')
+  code.push('const unirest = require("unirest");')
       .blank()
-      .push('var req = unirest("%s", "%s");', source.method, source.url)
+      .push('const req = unirest("%s", "%s");', source.method, source.url)
       .blank()
 
   if (source.cookies.length) {
-    code.push('var CookieJar = unirest.jar();')
+    code.push('const CookieJar = unirest.jar();')
 
     source.cookies.forEach(function (cookie) {
       code.push('CookieJar.add("%s=%s","%s");', encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), source.url)
     })
 
     code.push('req.jar(CookieJar);')
-        .blank()
+      .blank()
   }
 
   if (Object.keys(source.queryObj).length) {
@@ -50,6 +50,7 @@ module.exports = function (source, options) {
     case 'application/x-www-form-urlencoded':
       if (source.postData.paramsObj) {
         code.push('req.form(%s);', JSON.stringify(source.postData.paramsObj, null, opts.indent))
+          .blank()
       }
       break
 
@@ -57,6 +58,7 @@ module.exports = function (source, options) {
       if (source.postData.jsonObj) {
         code.push('req.type("json");')
             .push('req.send(%s);', JSON.stringify(source.postData.jsonObj, null, opts.indent))
+            .blank()
       }
       break
 
@@ -84,20 +86,21 @@ module.exports = function (source, options) {
       })
 
       code.push('req.multipart(%s);', JSON.stringify(multipart, null, opts.indent))
+        .blank()
       break
 
     default:
       if (source.postData.text) {
-        code.push(opts.indent + 'req.send(%s);', JSON.stringify(source.postData.text, null, opts.indent))
+        code.push('req.send(%s);', JSON.stringify(source.postData.text, null, opts.indent))
+          .blank()
       }
   }
 
   if (includeFS) {
-    code.unshift('var fs = require("fs");')
+    code.unshift('const fs = require("fs");')
   }
 
-  code.blank()
-      .push('req.end(function (res) {')
+  code.push('req.end(function (res) {')
       .push(1, 'if (res.error) throw new Error(res.error);')
       .blank()
       .push(1, 'console.log(res.body);')

--- a/test/fixtures/output/javascript/fetch/multipart-data.js
+++ b/test/fixtures/output/javascript/fetch/multipart-data.js
@@ -1,4 +1,4 @@
-var form = new FormData();
+const form = new FormData();
 form.append("foo", "Hello World");
 
 fetch("http://mockbin.com/har", {

--- a/test/fixtures/output/javascript/fetch/multipart-file.js
+++ b/test/fixtures/output/javascript/fetch/multipart-file.js
@@ -1,4 +1,4 @@
-var form = new FormData();
+const form = new FormData();
 form.append("foo", "test/fixtures/files/hello.txt");
 
 fetch("http://mockbin.com/har", {

--- a/test/fixtures/output/javascript/fetch/multipart-form-data.js
+++ b/test/fixtures/output/javascript/fetch/multipart-form-data.js
@@ -1,4 +1,4 @@
-var form = new FormData();
+const form = new FormData();
 form.append("foo", "bar");
 
 fetch("http://mockbin.com/har", {

--- a/test/fixtures/output/javascript/jquery/application-form-encoded.js
+++ b/test/fixtures/output/javascript/jquery/application-form-encoded.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -10,7 +10,7 @@ var settings = {
     "foo": "bar",
     "hello": "world"
   }
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/application-json.js
+++ b/test/fixtures/output/javascript/jquery/application-json.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -8,7 +8,7 @@ var settings = {
   },
   "processData": false,
   "data": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/cookies.js
+++ b/test/fixtures/output/javascript/jquery/cookies.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -6,7 +6,7 @@ var settings = {
   "headers": {
     "cookie": "foo=bar; bar=baz"
   }
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/custom-method.js
+++ b/test/fixtures/output/javascript/jquery/custom-method.js
@@ -1,10 +1,10 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
   "method": "PROPFIND",
   "headers": {}
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/full.js
+++ b/test/fixtures/output/javascript/jquery/full.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value",
@@ -11,7 +11,7 @@ var settings = {
   "data": {
     "foo": "bar"
   }
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/headers.js
+++ b/test/fixtures/output/javascript/jquery/headers.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -7,7 +7,7 @@ var settings = {
     "accept": "application/json",
     "x-foo": "Bar"
   }
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/https.js
+++ b/test/fixtures/output/javascript/jquery/https.js
@@ -1,10 +1,10 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "https://mockbin.com/har",
   "method": "GET",
   "headers": {}
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/jsonObj-multiline.js
+++ b/test/fixtures/output/javascript/jquery/jsonObj-multiline.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -8,7 +8,7 @@ var settings = {
   },
   "processData": false,
   "data": "{\n  \"foo\": \"bar\"\n}"
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/jsonObj-null-value.js
+++ b/test/fixtures/output/javascript/jquery/jsonObj-null-value.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -8,7 +8,7 @@ var settings = {
   },
   "processData": false,
   "data": "{\"foo\":null}"
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/multipart-data.js
+++ b/test/fixtures/output/javascript/jquery/multipart-data.js
@@ -1,7 +1,7 @@
-var form = new FormData();
+const form = new FormData();
 form.append("foo", "Hello World");
 
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -11,7 +11,7 @@ var settings = {
   "contentType": false,
   "mimeType": "multipart/form-data",
   "data": form
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/multipart-file.js
+++ b/test/fixtures/output/javascript/jquery/multipart-file.js
@@ -1,7 +1,7 @@
-var form = new FormData();
+const form = new FormData();
 form.append("foo", "test/fixtures/files/hello.txt");
 
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -11,7 +11,7 @@ var settings = {
   "contentType": false,
   "mimeType": "multipart/form-data",
   "data": form
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/multipart-form-data.js
+++ b/test/fixtures/output/javascript/jquery/multipart-form-data.js
@@ -1,7 +1,7 @@
-var form = new FormData();
+const form = new FormData();
 form.append("foo", "bar");
 
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -11,7 +11,7 @@ var settings = {
   "contentType": false,
   "mimeType": "multipart/form-data",
   "data": form
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/query.js
+++ b/test/fixtures/output/javascript/jquery/query.js
@@ -1,10 +1,10 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value",
   "method": "GET",
   "headers": {}
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/short.js
+++ b/test/fixtures/output/javascript/jquery/short.js
@@ -1,10 +1,10 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
   "method": "GET",
   "headers": {}
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/jquery/text-plain.js
+++ b/test/fixtures/output/javascript/jquery/text-plain.js
@@ -1,4 +1,4 @@
-var settings = {
+const settings = {
   "async": true,
   "crossDomain": true,
   "url": "http://mockbin.com/har",
@@ -7,7 +7,7 @@ var settings = {
     "content-type": "text/plain"
   },
   "data": "Hello World"
-}
+};
 
 $.ajax(settings).done(function (response) {
   console.log(response);

--- a/test/fixtures/output/javascript/xhr/application-form-encoded.js
+++ b/test/fixtures/output/javascript/xhr/application-form-encoded.js
@@ -1,6 +1,6 @@
-var data = "foo=bar&hello=world";
+const data = "foo=bar&hello=world";
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/application-json.js
+++ b/test/fixtures/output/javascript/xhr/application-json.js
@@ -1,4 +1,4 @@
-var data = JSON.stringify({
+const data = JSON.stringify({
   "number": 1,
   "string": "f\"oo",
   "arr": [
@@ -19,7 +19,7 @@ var data = JSON.stringify({
   "boolean": false
 });
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/cookies.js
+++ b/test/fixtures/output/javascript/xhr/cookies.js
@@ -1,6 +1,6 @@
-var data = null;
+const data = null;
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/custom-method.js
+++ b/test/fixtures/output/javascript/xhr/custom-method.js
@@ -1,6 +1,6 @@
-var data = null;
+const data = null;
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/full.js
+++ b/test/fixtures/output/javascript/xhr/full.js
@@ -1,6 +1,6 @@
-var data = "foo=bar";
+const data = "foo=bar";
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/headers.js
+++ b/test/fixtures/output/javascript/xhr/headers.js
@@ -1,6 +1,6 @@
-var data = null;
+const data = null;
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/https.js
+++ b/test/fixtures/output/javascript/xhr/https.js
@@ -1,6 +1,6 @@
-var data = null;
+const data = null;
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/jsonObj-multiline.js
+++ b/test/fixtures/output/javascript/xhr/jsonObj-multiline.js
@@ -1,8 +1,8 @@
-var data = JSON.stringify({
+const data = JSON.stringify({
   "foo": "bar"
 });
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/jsonObj-null-value.js
+++ b/test/fixtures/output/javascript/xhr/jsonObj-null-value.js
@@ -1,8 +1,8 @@
-var data = JSON.stringify({
+const data = JSON.stringify({
   "foo": null
 });
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/multipart-data.js
+++ b/test/fixtures/output/javascript/xhr/multipart-data.js
@@ -1,7 +1,7 @@
-var data = new FormData();
+const data = new FormData();
 data.append("foo", "Hello World");
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/multipart-file.js
+++ b/test/fixtures/output/javascript/xhr/multipart-file.js
@@ -1,7 +1,7 @@
-var data = new FormData();
+const data = new FormData();
 data.append("foo", "test/fixtures/files/hello.txt");
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/multipart-form-data.js
+++ b/test/fixtures/output/javascript/xhr/multipart-form-data.js
@@ -1,7 +1,7 @@
-var data = new FormData();
+const data = new FormData();
 data.append("foo", "bar");
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/query.js
+++ b/test/fixtures/output/javascript/xhr/query.js
@@ -1,6 +1,6 @@
-var data = null;
+const data = null;
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/short.js
+++ b/test/fixtures/output/javascript/xhr/short.js
@@ -1,6 +1,6 @@
-var data = null;
+const data = null;
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/javascript/xhr/text-plain.js
+++ b/test/fixtures/output/javascript/xhr/text-plain.js
@@ -1,6 +1,6 @@
-var data = "Hello World";
+const data = "Hello World";
 
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
 
 xhr.addEventListener("readystatechange", function () {

--- a/test/fixtures/output/node/native/application-form-encoded.js
+++ b/test/fixtures/output/node/native/application-form-encoded.js
@@ -1,7 +1,7 @@
-var qs = require("querystring");
-var http = require("http");
+const qs = require("querystring");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -11,15 +11,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/application-json.js
+++ b/test/fixtures/output/node/native/application-json.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/cookies.js
+++ b/test/fixtures/output/node/native/cookies.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/custom-method.js
+++ b/test/fixtures/output/node/native/custom-method.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "PROPFIND",
   "hostname": "mockbin.com",
   "port": null,
@@ -8,15 +8,15 @@ var options = {
   "headers": {}
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/full.js
+++ b/test/fixtures/output/node/native/full.js
@@ -1,7 +1,7 @@
-var qs = require("querystring");
-var http = require("http");
+const qs = require("querystring");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -13,15 +13,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/headers.js
+++ b/test/fixtures/output/node/native/headers.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "GET",
   "hostname": "mockbin.com",
   "port": null,
@@ -11,15 +11,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/https.js
+++ b/test/fixtures/output/node/native/https.js
@@ -1,6 +1,6 @@
-var http = require("https");
+const http = require("https");
 
-var options = {
+const options = {
   "method": "GET",
   "hostname": "mockbin.com",
   "port": null,
@@ -8,15 +8,15 @@ var options = {
   "headers": {}
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/jsonObj-multiline.js
+++ b/test/fixtures/output/node/native/jsonObj-multiline.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/jsonObj-null-value.js
+++ b/test/fixtures/output/node/native/jsonObj-null-value.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/multipart-data.js
+++ b/test/fixtures/output/node/native/multipart-data.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/multipart-file.js
+++ b/test/fixtures/output/node/native/multipart-file.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/multipart-form-data.js
+++ b/test/fixtures/output/node/native/multipart-form-data.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/query.js
+++ b/test/fixtures/output/node/native/query.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "GET",
   "hostname": "mockbin.com",
   "port": null,
@@ -8,15 +8,15 @@ var options = {
   "headers": {}
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/short.js
+++ b/test/fixtures/output/node/native/short.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "GET",
   "hostname": "mockbin.com",
   "port": null,
@@ -8,15 +8,15 @@ var options = {
   "headers": {}
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/native/text-plain.js
+++ b/test/fixtures/output/node/native/text-plain.js
@@ -1,6 +1,6 @@
-var http = require("http");
+const http = require("http");
 
-var options = {
+const options = {
   "method": "POST",
   "hostname": "mockbin.com",
   "port": null,
@@ -10,15 +10,15 @@ var options = {
   }
 };
 
-var req = http.request(options, function (res) {
-  var chunks = [];
+const req = http.request(options, function (res) {
+  const chunks = [];
 
   res.on("data", function (chunk) {
     chunks.push(chunk);
   });
 
   res.on("end", function () {
-    var body = Buffer.concat(chunks);
+    const body = Buffer.concat(chunks);
     console.log(body.toString());
   });
 });

--- a/test/fixtures/output/node/request/application-form-encoded.js
+++ b/test/fixtures/output/node/request/application-form-encoded.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/x-www-form-urlencoded'},

--- a/test/fixtures/output/node/request/application-json.js
+++ b/test/fixtures/output/node/request/application-json.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/test/fixtures/output/node/request/cookies.js
+++ b/test/fixtures/output/node/request/cookies.js
@@ -1,10 +1,10 @@
-var request = require("request");
+const request = require('request');
 
-var jar = request.jar();
-jar.setCookie(request.cookie("foo=bar"), "http://mockbin.com/har");
-jar.setCookie(request.cookie("bar=baz"), "http://mockbin.com/har");
+const jar = request.jar();
+jar.setCookie(request.cookie('foo=bar'), 'http://mockbin.com/har');
+jar.setCookie(request.cookie('bar=baz'), 'http://mockbin.com/har');
 
-var options = {method: 'POST', url: 'http://mockbin.com/har', jar: 'JAR'};
+const options = {method: 'POST', url: 'http://mockbin.com/har', jar: 'JAR'};
 
 request(options, function (error, response, body) {
   if (error) throw new Error(error);

--- a/test/fixtures/output/node/request/custom-method.js
+++ b/test/fixtures/output/node/request/custom-method.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
+const options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
 
 request(options, function (error, response, body) {
   if (error) throw new Error(error);

--- a/test/fixtures/output/node/request/full.js
+++ b/test/fixtures/output/node/request/full.js
@@ -1,10 +1,10 @@
-var request = require("request");
+const request = require('request');
 
-var jar = request.jar();
-jar.setCookie(request.cookie("foo=bar"), "http://mockbin.com/har");
-jar.setCookie(request.cookie("bar=baz"), "http://mockbin.com/har");
+const jar = request.jar();
+jar.setCookie(request.cookie('foo=bar'), 'http://mockbin.com/har');
+jar.setCookie(request.cookie('bar=baz'), 'http://mockbin.com/har');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   qs: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'},

--- a/test/fixtures/output/node/request/headers.js
+++ b/test/fixtures/output/node/request/headers.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   headers: {accept: 'application/json', 'x-foo': 'Bar'}

--- a/test/fixtures/output/node/request/https.js
+++ b/test/fixtures/output/node/request/https.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {method: 'GET', url: 'https://mockbin.com/har'};
+const options = {method: 'GET', url: 'https://mockbin.com/har'};
 
 request(options, function (error, response, body) {
   if (error) throw new Error(error);

--- a/test/fixtures/output/node/request/jsonObj-multiline.js
+++ b/test/fixtures/output/node/request/jsonObj-multiline.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/test/fixtures/output/node/request/jsonObj-null-value.js
+++ b/test/fixtures/output/node/request/jsonObj-null-value.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/test/fixtures/output/node/request/multipart-data.js
+++ b/test/fixtures/output/node/request/multipart-data.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/test/fixtures/output/node/request/multipart-file.js
+++ b/test/fixtures/output/node/request/multipart-file.js
@@ -1,16 +1,16 @@
-var fs = require("fs");
-var request = require("request");
+const fs = require('fs');
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'},
   formData: {
     foo: {
       value: 'fs.createReadStream("test/fixtures/files/hello.txt")',
-        options: {
-          filename: 'test/fixtures/files/hello.txt',
-          contentType: 'text/plain'
+      options: {
+        filename: 'test/fixtures/files/hello.txt',
+        contentType: 'text/plain'
       }
     }
   }

--- a/test/fixtures/output/node/request/multipart-form-data.js
+++ b/test/fixtures/output/node/request/multipart-form-data.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/test/fixtures/output/node/request/query.js
+++ b/test/fixtures/output/node/request/query.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   qs: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}

--- a/test/fixtures/output/node/request/short.js
+++ b/test/fixtures/output/node/request/short.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {method: 'GET', url: 'http://mockbin.com/har'};
+const options = {method: 'GET', url: 'http://mockbin.com/har'};
 
 request(options, function (error, response, body) {
   if (error) throw new Error(error);

--- a/test/fixtures/output/node/request/text-plain.js
+++ b/test/fixtures/output/node/request/text-plain.js
@@ -1,6 +1,6 @@
-var request = require("request");
+const request = require('request');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'text/plain'},

--- a/test/fixtures/output/node/unirest/application-form-encoded.js
+++ b/test/fixtures/output/node/unirest/application-form-encoded.js
@@ -1,6 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "application/x-www-form-urlencoded"

--- a/test/fixtures/output/node/unirest/application-json.js
+++ b/test/fixtures/output/node/unirest/application-json.js
@@ -1,6 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "application/json"

--- a/test/fixtures/output/node/unirest/cookies.js
+++ b/test/fixtures/output/node/unirest/cookies.js
@@ -1,12 +1,11 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
-var CookieJar = unirest.jar();
+const CookieJar = unirest.jar();
 CookieJar.add("foo=bar","http://mockbin.com/har");
 CookieJar.add("bar=baz","http://mockbin.com/har");
 req.jar(CookieJar);
-
 
 req.end(function (res) {
   if (res.error) throw new Error(res.error);

--- a/test/fixtures/output/node/unirest/custom-method.js
+++ b/test/fixtures/output/node/unirest/custom-method.js
@@ -1,7 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("PROPFIND", "http://mockbin.com/har");
-
+const req = unirest("PROPFIND", "http://mockbin.com/har");
 
 req.end(function (res) {
   if (res.error) throw new Error(res.error);

--- a/test/fixtures/output/node/unirest/full.js
+++ b/test/fixtures/output/node/unirest/full.js
@@ -1,8 +1,8 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
-var CookieJar = unirest.jar();
+const CookieJar = unirest.jar();
 CookieJar.add("foo=bar","http://mockbin.com/har");
 CookieJar.add("bar=baz","http://mockbin.com/har");
 req.jar(CookieJar);

--- a/test/fixtures/output/node/unirest/headers.js
+++ b/test/fixtures/output/node/unirest/headers.js
@@ -1,12 +1,11 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("GET", "http://mockbin.com/har");
+const req = unirest("GET", "http://mockbin.com/har");
 
 req.headers({
   "accept": "application/json",
   "x-foo": "Bar"
 });
-
 
 req.end(function (res) {
   if (res.error) throw new Error(res.error);

--- a/test/fixtures/output/node/unirest/https.js
+++ b/test/fixtures/output/node/unirest/https.js
@@ -1,7 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("GET", "https://mockbin.com/har");
-
+const req = unirest("GET", "https://mockbin.com/har");
 
 req.end(function (res) {
   if (res.error) throw new Error(res.error);

--- a/test/fixtures/output/node/unirest/jsonObj-multiline.js
+++ b/test/fixtures/output/node/unirest/jsonObj-multiline.js
@@ -1,6 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "application/json"

--- a/test/fixtures/output/node/unirest/jsonObj-null-value.js
+++ b/test/fixtures/output/node/unirest/jsonObj-null-value.js
@@ -1,6 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "application/json"

--- a/test/fixtures/output/node/unirest/multipart-data.js
+++ b/test/fixtures/output/node/unirest/multipart-data.js
@@ -1,6 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "multipart/form-data; boundary=---011000010111000001101001"

--- a/test/fixtures/output/node/unirest/multipart-file.js
+++ b/test/fixtures/output/node/unirest/multipart-file.js
@@ -1,7 +1,7 @@
-var fs = require("fs");
-var unirest = require("unirest");
+const fs = require("fs");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "multipart/form-data; boundary=---011000010111000001101001"

--- a/test/fixtures/output/node/unirest/multipart-form-data.js
+++ b/test/fixtures/output/node/unirest/multipart-form-data.js
@@ -1,6 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "multipart/form-data; boundary=---011000010111000001101001"

--- a/test/fixtures/output/node/unirest/query.js
+++ b/test/fixtures/output/node/unirest/query.js
@@ -1,6 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("GET", "http://mockbin.com/har");
+const req = unirest("GET", "http://mockbin.com/har");
 
 req.query({
   "foo": [
@@ -10,7 +10,6 @@ req.query({
   "baz": "abc",
   "key": "value"
 });
-
 
 req.end(function (res) {
   if (res.error) throw new Error(res.error);

--- a/test/fixtures/output/node/unirest/short.js
+++ b/test/fixtures/output/node/unirest/short.js
@@ -1,7 +1,6 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("GET", "http://mockbin.com/har");
-
+const req = unirest("GET", "http://mockbin.com/har");
 
 req.end(function (res) {
   if (res.error) throw new Error(res.error);

--- a/test/fixtures/output/node/unirest/text-plain.js
+++ b/test/fixtures/output/node/unirest/text-plain.js
@@ -1,12 +1,12 @@
-var unirest = require("unirest");
+const unirest = require("unirest");
 
-var req = unirest("POST", "http://mockbin.com/har");
+const req = unirest("POST", "http://mockbin.com/har");
 
 req.headers({
   "content-type": "text/plain"
 });
 
-  req.send("Hello World");
+req.send("Hello World");
 
 req.end(function (res) {
   if (res.error) throw new Error(res.error);

--- a/test/targets/javascript/xhr.js
+++ b/test/targets/javascript/xhr.js
@@ -11,6 +11,6 @@ module.exports = function (HTTPSnippet, fixtures) {
     })
 
     result.should.be.a.String()
-    result.replace(/\n/g, '').should.eql('var data = null;var xhr = new XMLHttpRequest();xhr.addEventListener("readystatechange", function () {  if (this.readyState === this.DONE) {    console.log(this.responseText);  }});xhr.open("GET", "http://mockbin.com/har");xhr.send(data);')
+    result.replace(/\n/g, '').should.eql('const data = null;const xhr = new XMLHttpRequest();xhr.addEventListener("readystatechange", function () {  if (this.readyState === this.DONE) {    console.log(this.responseText);  }});xhr.open("GET", "http://mockbin.com/har");xhr.send(data);')
   })
 }


### PR DESCRIPTION
* Updates all Javascript and Node targets to use `const` instead of `var`.
* Fixes some inconsistencies with the `unirest` target where it was adding unnecessary linebreaks and indents in snippets.
* In the `jquery` target, I've added a semicolon to the `settings` object to stay consistent with the rest of the snippet.