### PR TITLE
feat: updating php targets to use `[]` instead of `array()`

### DIFF
--- a/src/targets/php/curl.js
+++ b/src/targets/php/curl.js
@@ -72,7 +72,7 @@ module.exports = function (source, options) {
     value: source.postData ? source.postData.text : undefined
   }]
 
-  code.push('curl_setopt_array($curl, array(')
+  code.push('curl_setopt_array($curl, [')
 
   var curlopts = new CodeBuilder(opts.indent, '\n' + opts.indent)
 
@@ -97,13 +97,13 @@ module.exports = function (source, options) {
   })
 
   if (headers.length) {
-    curlopts.push('CURLOPT_HTTPHEADER => array(')
+    curlopts.push('CURLOPT_HTTPHEADER => [')
       .push(1, headers.join(',\n' + opts.indent + opts.indent))
-      .push('),')
+      .push('],')
   }
 
   code.push(1, curlopts.join())
-    .push('));')
+    .push(']);')
     .blank()
     .push('$response = curl_exec($curl);')
     .push('$err = curl_error($curl);')

--- a/src/targets/php/helpers.js
+++ b/src/targets/php/helpers.js
@@ -31,7 +31,7 @@ var convert = function (obj, indent, lastIndent) {
         result.push(convert(item, indent + indent, indent))
       })
 
-      result = 'array(\n' + indent + result.join(',\n' + indent) + '\n' + lastIndent + ')'
+      result = '[\n' + indent + result.join(',\n' + indent) + '\n' + lastIndent + ']'
       break
 
     case '[object Object]':
@@ -41,7 +41,7 @@ var convert = function (obj, indent, lastIndent) {
           result.push(convert(i, indent) + ' => ' + convert(obj[i], indent + indent, indent))
         }
       }
-      result = 'array(\n' + indent + result.join(',\n' + indent) + '\n' + lastIndent + ')'
+      result = '[\n' + indent + result.join(',\n' + indent) + '\n' + lastIndent + ']'
       break
 
     default:

--- a/test/fixtures/output/php/curl/application-form-encoded.php
+++ b/test/fixtures/output/php/curl/application-form-encoded.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "foo=bar&hello=world",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: application/x-www-form-urlencoded"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/application-json.php
+++ b/test/fixtures/output/php/curl/application-json.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: application/json"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/cookies.php
+++ b/test/fixtures/output/php/curl/cookies.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,7 +11,7 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_COOKIE => "foo=bar; bar=baz",
-));
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/custom-method.php
+++ b/test/fixtures/output/php/curl/custom-method.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -10,7 +10,7 @@ curl_setopt_array($curl, array(
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "PROPFIND",
-));
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/full.php
+++ b/test/fixtures/output/php/curl/full.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -12,11 +12,11 @@ curl_setopt_array($curl, array(
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "foo=bar",
   CURLOPT_COOKIE => "foo=bar; bar=baz",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "accept: application/json",
     "content-type: application/x-www-form-urlencoded"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/headers.php
+++ b/test/fixtures/output/php/curl/headers.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -10,11 +10,11 @@ curl_setopt_array($curl, array(
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "GET",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "accept: application/json",
     "x-foo: Bar"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/https.php
+++ b/test/fixtures/output/php/curl/https.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "https://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -10,7 +10,7 @@ curl_setopt_array($curl, array(
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "GET",
-));
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/jsonObj-multiline.php
+++ b/test/fixtures/output/php/curl/jsonObj-multiline.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "{\n  \"foo\": \"bar\"\n}",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: application/json"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/jsonObj-null-value.php
+++ b/test/fixtures/output/php/curl/jsonObj-null-value.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "{\"foo\":null}",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: application/json"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/multipart-data.php
+++ b/test/fixtures/output/php/curl/multipart-data.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: multipart/form-data; boundary=---011000010111000001101001"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/multipart-file.php
+++ b/test/fixtures/output/php/curl/multipart-file.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: multipart/form-data; boundary=---011000010111000001101001"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/multipart-form-data.php
+++ b/test/fixtures/output/php/curl/multipart-form-data.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: multipart/form-data; boundary=---011000010111000001101001"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/query.php
+++ b/test/fixtures/output/php/curl/query.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -10,7 +10,7 @@ curl_setopt_array($curl, array(
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "GET",
-));
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/short.php
+++ b/test/fixtures/output/php/curl/short.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -10,7 +10,7 @@ curl_setopt_array($curl, array(
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "GET",
-));
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/curl/text-plain.php
+++ b/test/fixtures/output/php/curl/text-plain.php
@@ -2,7 +2,7 @@
 
 $curl = curl_init();
 
-curl_setopt_array($curl, array(
+curl_setopt_array($curl, [
   CURLOPT_URL => "http://mockbin.com/har",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
@@ -11,10 +11,10 @@ curl_setopt_array($curl, array(
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_POSTFIELDS => "Hello World",
-  CURLOPT_HTTPHEADER => array(
+  CURLOPT_HTTPHEADER => [
     "content-type: text/plain"
-  ),
-));
+  ],
+]);
 
 $response = curl_exec($curl);
 $err = curl_error($curl);

--- a/test/fixtures/output/php/http1/application-form-encoded.php
+++ b/test/fixtures/output/php/http1/application-form-encoded.php
@@ -4,15 +4,15 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/x-www-form-urlencoded'
-));
+]);
 
 $request->setContentType('application/x-www-form-urlencoded');
-$request->setPostFields(array(
+$request->setPostFields([
   'foo' => 'bar',
   'hello' => 'world'
-));
+]);
 
 try {
   $response = $request->send();

--- a/test/fixtures/output/php/http1/application-json.php
+++ b/test/fixtures/output/php/http1/application-json.php
@@ -4,9 +4,9 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/json'
-));
+]);
 
 $request->setBody('{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}');
 

--- a/test/fixtures/output/php/http1/cookies.php
+++ b/test/fixtures/output/php/http1/cookies.php
@@ -4,10 +4,10 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setCookies(array(
+$request->setCookies([
   'bar' => 'baz',
   'foo' => 'bar'
-));
+]);
 
 try {
   $response = $request->send();

--- a/test/fixtures/output/php/http1/full.php
+++ b/test/fixtures/output/php/http1/full.php
@@ -4,29 +4,29 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setQueryData(array(
-  'foo' => array(
+$request->setQueryData([
+  'foo' => [
     'bar',
     'baz'
-  ),
+  ],
   'baz' => 'abc',
   'key' => 'value'
-));
+]);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'accept' => 'application/json',
   'content-type' => 'application/x-www-form-urlencoded'
-));
+]);
 
-$request->setCookies(array(
+$request->setCookies([
   'bar' => 'baz',
   'foo' => 'bar'
-));
+]);
 
 $request->setContentType('application/x-www-form-urlencoded');
-$request->setPostFields(array(
+$request->setPostFields([
   'foo' => 'bar'
-));
+]);
 
 try {
   $response = $request->send();

--- a/test/fixtures/output/php/http1/headers.php
+++ b/test/fixtures/output/php/http1/headers.php
@@ -4,10 +4,10 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_GET);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'accept' => 'application/json',
   'x-foo' => 'Bar'
-));
+]);
 
 try {
   $response = $request->send();

--- a/test/fixtures/output/php/http1/jsonObj-multiline.php
+++ b/test/fixtures/output/php/http1/jsonObj-multiline.php
@@ -4,9 +4,9 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/json'
-));
+]);
 
 $request->setBody('{
   "foo": "bar"

--- a/test/fixtures/output/php/http1/jsonObj-null-value.php
+++ b/test/fixtures/output/php/http1/jsonObj-null-value.php
@@ -4,9 +4,9 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/json'
-));
+]);
 
 $request->setBody('{"foo":null}');
 

--- a/test/fixtures/output/php/http1/multipart-data.php
+++ b/test/fixtures/output/php/http1/multipart-data.php
@@ -4,9 +4,9 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'multipart/form-data; boundary=---011000010111000001101001'
-));
+]);
 
 $request->setBody('-----011000010111000001101001
 Content-Disposition: form-data; name="foo"; filename="hello.txt"

--- a/test/fixtures/output/php/http1/multipart-file.php
+++ b/test/fixtures/output/php/http1/multipart-file.php
@@ -4,9 +4,9 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'multipart/form-data; boundary=---011000010111000001101001'
-));
+]);
 
 $request->setBody('-----011000010111000001101001
 Content-Disposition: form-data; name="foo"; filename="hello.txt"

--- a/test/fixtures/output/php/http1/multipart-form-data.php
+++ b/test/fixtures/output/php/http1/multipart-form-data.php
@@ -4,9 +4,9 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'multipart/form-data; boundary=---011000010111000001101001'
-));
+]);
 
 $request->setBody('-----011000010111000001101001
 Content-Disposition: form-data; name="foo"

--- a/test/fixtures/output/php/http1/query.php
+++ b/test/fixtures/output/php/http1/query.php
@@ -4,14 +4,14 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_GET);
 
-$request->setQueryData(array(
-  'foo' => array(
+$request->setQueryData([
+  'foo' => [
     'bar',
     'baz'
-  ),
+  ],
   'baz' => 'abc',
   'key' => 'value'
-));
+]);
 
 try {
   $response = $request->send();

--- a/test/fixtures/output/php/http1/text-plain.php
+++ b/test/fixtures/output/php/http1/text-plain.php
@@ -4,9 +4,9 @@ $request = new HttpRequest();
 $request->setUrl('http://mockbin.com/har');
 $request->setMethod(HTTP_METH_POST);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'text/plain'
-));
+]);
 
 $request->setBody('Hello World');
 

--- a/test/fixtures/output/php/http2/application-form-encoded.php
+++ b/test/fixtures/output/php/http2/application-form-encoded.php
@@ -4,18 +4,18 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append(new http\QueryString(array(
+$body->append(new http\QueryString([
   'foo' => 'bar',
   'hello' => 'world'
-)));
+]));
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/x-www-form-urlencoded'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/application-json.php
+++ b/test/fixtures/output/php/http2/application-json.php
@@ -10,9 +10,9 @@ $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/json'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/cookies.php
+++ b/test/fixtures/output/php/http2/cookies.php
@@ -6,10 +6,10 @@ $request = new http\Client\Request;
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 
-$client->setCookies(array(
+$client->setCookies([
   'bar' => 'baz',
   'foo' => 'bar'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/full.php
+++ b/test/fixtures/output/php/http2/full.php
@@ -4,33 +4,33 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append(new http\QueryString(array(
+$body->append(new http\QueryString([
   'foo' => 'bar'
-)));
+]));
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);
 
-$request->setQuery(new http\QueryString(array(
-  'foo' => array(
+$request->setQuery(new http\QueryString([
+  'foo' => [
     'bar',
     'baz'
-  ),
+  ],
   'baz' => 'abc',
   'key' => 'value'
-)));
+]));
 
-$request->setHeaders(array(
+$request->setHeaders([
   'accept' => 'application/json',
   'content-type' => 'application/x-www-form-urlencoded'
-));
+]);
 
 
-$client->setCookies(array(
+$client->setCookies([
   'bar' => 'baz',
   'foo' => 'bar'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/headers.php
+++ b/test/fixtures/output/php/http2/headers.php
@@ -5,10 +5,10 @@ $request = new http\Client\Request;
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('GET');
-$request->setHeaders(array(
+$request->setHeaders([
   'accept' => 'application/json',
   'x-foo' => 'Bar'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/jsonObj-multiline.php
+++ b/test/fixtures/output/php/http2/jsonObj-multiline.php
@@ -12,9 +12,9 @@ $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/json'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/jsonObj-null-value.php
+++ b/test/fixtures/output/php/http2/jsonObj-null-value.php
@@ -10,9 +10,9 @@ $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'application/json'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/multipart-data.php
+++ b/test/fixtures/output/php/http2/multipart-data.php
@@ -4,14 +4,14 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->addForm(NULL, array(
-  array(
+$body->addForm(null, [
+  [
     'name' => 'foo',
     'type' => 'text/plain',
     'file' => 'hello.txt',
     'data' => 'Hello World'
-  )
-));
+  ]
+]);
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');

--- a/test/fixtures/output/php/http2/multipart-file.php
+++ b/test/fixtures/output/php/http2/multipart-file.php
@@ -4,14 +4,14 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->addForm(NULL, array(
-  array(
+$body->addForm(null, [
+  [
     'name' => 'foo',
     'type' => 'text/plain',
     'file' => 'test/fixtures/files/hello.txt',
     'data' => null
-  )
-));
+  ]
+]);
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');

--- a/test/fixtures/output/php/http2/multipart-form-data.php
+++ b/test/fixtures/output/php/http2/multipart-form-data.php
@@ -4,9 +4,9 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->addForm(array(
+$body->addForm([
   'foo' => 'bar'
-), NULL);
+], null);
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');

--- a/test/fixtures/output/php/http2/query.php
+++ b/test/fixtures/output/php/http2/query.php
@@ -5,14 +5,14 @@ $request = new http\Client\Request;
 
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('GET');
-$request->setQuery(new http\QueryString(array(
-  'foo' => array(
+$request->setQuery(new http\QueryString([
+  'foo' => [
     'bar',
     'baz'
-  ),
+  ],
   'baz' => 'abc',
   'key' => 'value'
-)));
+]));
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();

--- a/test/fixtures/output/php/http2/text-plain.php
+++ b/test/fixtures/output/php/http2/text-plain.php
@@ -10,9 +10,9 @@ $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);
 
-$request->setHeaders(array(
+$request->setHeaders([
   'content-type' => 'text/plain'
-));
+]);
 
 $client->enqueue($request)->send();
 $response = $client->getResponse();


### PR DESCRIPTION
Does what it says on the tin. Updates all PHP targets to use `[]` for arrays instead of `array()`. Also updates a few instances of `NULL` to the more consistent `null`.