### PR TITLE
fix: don't convert header names to lowercase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,14 @@ HTTPSnippet.prototype.prepare = function (request) {
 
   // construct headers objects
   if (request.headers && request.headers.length) {
-    // loweCase header keys
+    var http2VersionRegex = /^HTTP\/2/
     request.headersObj = request.headers.reduce(function (headers, header) {
-      headers[header.name.toLowerCase()] = header.value
+      var headerName = header.name
+      if (request.httpVersion.match(http2VersionRegex)) {
+        headerName = headerName.toLowerCase()
+      }
+
+      headers[headerName] = header.value
       return headers
     }, {})
   }

--- a/test/index.js
+++ b/test/index.js
@@ -166,6 +166,24 @@ describe('HTTPSnippet', function () {
     done()
   })
 
+  it('should add "headersObj" to source object case insensitive', function (done) {
+    var fixture = Object.assign({}, fixtures.requests.headers)
+    fixture.headers = fixture.headers.concat({
+      name: 'Kong-Admin-Token',
+      value: 'Hunter1'
+    })
+
+    var req = new HTTPSnippet(fixture).requests[0]
+    req.headersObj.should.be.an.Object()
+    req.headersObj.should.eql({
+      'Kong-Admin-Token': 'Hunter1',
+      'accept': 'application/json',
+      'x-foo': 'Bar',
+    })
+
+    done()
+  })
+
   it('should modify orignal url to strip query string', function (done) {
     var req = new HTTPSnippet(fixtures.requests.query).requests[0]
 

--- a/test/index.js
+++ b/test/index.js
@@ -166,8 +166,9 @@ describe('HTTPSnippet', function () {
     done()
   })
 
-  it('should add "headersObj" to source object case insensitive', function (done) {
+  it('should add "headersObj" to source object case insensitive when HTTP/1.0', function (done) {
     var fixture = Object.assign({}, fixtures.requests.headers)
+    fixture.httpVersion = 'HTTP/1.1'
     fixture.headers = fixture.headers.concat({
       name: 'Kong-Admin-Token',
       value: 'Hunter1'
@@ -178,7 +179,26 @@ describe('HTTPSnippet', function () {
     req.headersObj.should.eql({
       'Kong-Admin-Token': 'Hunter1',
       'accept': 'application/json',
-      'x-foo': 'Bar',
+      'x-foo': 'Bar'
+    })
+
+    done()
+  })
+
+  it('should add "headersObj" to source object in lowercase when HTTP/2.x', function (done) {
+    var fixture = Object.assign({}, fixtures.requests.headers)
+    fixture.httpVersion = 'HTTP/2'
+    fixture.headers = fixture.headers.concat({
+      name: 'Kong-Admin-Token',
+      value: 'Hunter1'
+    })
+
+    var req = new HTTPSnippet(fixture).requests[0]
+    req.headersObj.should.be.an.Object()
+    req.headersObj.should.eql({
+      'kong-admin-token': 'Hunter1',
+      'accept': 'application/json',
+      'x-foo': 'Bar'
     })
 
     done()


### PR DESCRIPTION
I've completed @darrenjennings branch to remove the `.toLowerCase` for header names.

Closes #74 