### PR TITLE
feat: change the default response code for Python Requests

### DIFF
--- a/src/targets/python/requests/client.ts
+++ b/src/targets/python/requests/client.ts
@@ -182,7 +182,7 @@ export const requests: Client<RequestsOptions> = {
     blank();
 
     // Print response
-    push('print(response.text)');
+    push('print(response.json())');
 
     return join();
   },

--- a/src/targets/python/requests/fixtures/application-form-encoded.py
+++ b/src/targets/python/requests/fixtures/application-form-encoded.py
@@ -10,4 +10,4 @@ headers = {"content-type": "application/x-www-form-urlencoded"}
 
 response = requests.post(url, data=payload, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/application-json.py
+++ b/src/targets/python/requests/fixtures/application-json.py
@@ -14,4 +14,4 @@ headers = {"content-type": "application/json"}
 
 response = requests.post(url, json=payload, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/cookies.py
+++ b/src/targets/python/requests/fixtures/cookies.py
@@ -6,4 +6,4 @@ headers = {"cookie": "foo=bar; bar=baz"}
 
 response = requests.post(url, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/custom-method.py
+++ b/src/targets/python/requests/fixtures/custom-method.py
@@ -4,4 +4,4 @@ url = "http://mockbin.com/har"
 
 response = requests.request("PROPFIND", url)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/full.py
+++ b/src/targets/python/requests/fixtures/full.py
@@ -13,4 +13,4 @@ headers = {
 
 response = requests.post(url, data=payload, headers=headers, params=querystring)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/headers.py
+++ b/src/targets/python/requests/fixtures/headers.py
@@ -10,4 +10,4 @@ headers = {
 
 response = requests.get(url, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/https.py
+++ b/src/targets/python/requests/fixtures/https.py
@@ -4,4 +4,4 @@ url = "https://mockbin.com/har"
 
 response = requests.get(url)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/jsonObj-multiline.py
+++ b/src/targets/python/requests/fixtures/jsonObj-multiline.py
@@ -7,4 +7,4 @@ headers = {"content-type": "application/json"}
 
 response = requests.post(url, json=payload, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/jsonObj-null-value.py
+++ b/src/targets/python/requests/fixtures/jsonObj-null-value.py
@@ -7,4 +7,4 @@ headers = {"content-type": "application/json"}
 
 response = requests.post(url, json=payload, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/multipart-data.py
+++ b/src/targets/python/requests/fixtures/multipart-data.py
@@ -7,4 +7,4 @@ payload = { "bar": "Bonjour le monde" }
 
 response = requests.post(url, data=payload, files=files)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/multipart-file.py
+++ b/src/targets/python/requests/fixtures/multipart-file.py
@@ -6,4 +6,4 @@ files = { "foo": "open('test/fixtures/files/hello.txt', 'rb')" }
 
 response = requests.post(url, files=files)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/multipart-form-data-no-params.py
+++ b/src/targets/python/requests/fixtures/multipart-form-data-no-params.py
@@ -6,4 +6,4 @@ headers = {"Content-Type": "multipart/form-data"}
 
 response = requests.post(url, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/multipart-form-data.py
+++ b/src/targets/python/requests/fixtures/multipart-form-data.py
@@ -7,4 +7,4 @@ headers = {"Content-Type": "multipart/form-data; boundary=---0110000101110000011
 
 response = requests.post(url, data=payload, headers=headers)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/nested.py
+++ b/src/targets/python/requests/fixtures/nested.py
@@ -6,4 +6,4 @@ querystring = {"foo[bar]":"baz,zap","fiz":"buz","key":"value"}
 
 response = requests.get(url, params=querystring)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/query-params.py
+++ b/src/targets/python/requests/fixtures/query-params.py
@@ -6,4 +6,4 @@ querystring = {"param":"value"}
 
 response = requests.get(url, params=querystring)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/query.py
+++ b/src/targets/python/requests/fixtures/query.py
@@ -6,4 +6,4 @@ querystring = {"foo":["bar","baz"],"baz":"abc","key":"value"}
 
 response = requests.get(url, params=querystring)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/short.py
+++ b/src/targets/python/requests/fixtures/short.py
@@ -4,4 +4,4 @@ url = "http://mockbin.com/har"
 
 response = requests.get(url)
 
-print(response.text)
+print(response.json())

--- a/src/targets/python/requests/fixtures/text-plain.py
+++ b/src/targets/python/requests/fixtures/text-plain.py
@@ -7,4 +7,4 @@ headers = {"content-type": "text/plain"}
 
 response = requests.post(url, data=payload, headers=headers)
 
-print(response.text)
+print(response.json())


### PR DESCRIPTION
When printing the response using the Python Requests client, the default is `print(response.text)`. From what I've seen, most developers use `print(response.json())` or `print response.json()` to print the output of a response. Thus, it makes more sense to have the default print value be in JSON format, rather than raw text format.

@dylanirlbeck is the original author (#153).
I've just resolve conflicts and fix tests that were failing.

Closes #167

changelog(Improvements): Changed the default response code for Python Requests