### PR TITLE
Print explicit error when using an invalid target

### DIFF
--- a/bin/httpsnippet
+++ b/bin/httpsnippet
@@ -56,6 +56,11 @@ cmd.args.forEach(function (fileName) {
     })
 
     .then(function (output) {
+      if (!output) {
+        var targetNames = HTTPSnippet.availableTargets().map(function (t) { return t.key }).join(', ')
+        return console.error('%s %s is not a valid target. Valid targets: %s', chalk.red('✖'), chalk.red(cmd.target), chalk.cyan(targetNames))
+      }
+
       // print
       if (!cmd.output) {
         return console.log('%s %s > %s [%s] :\n%s', chalk.green('✓'), chalk.cyan.bold(file), chalk.yellow(cmd.target), chalk.yellow(cmd.client ? cmd.client : 'default'), output)


### PR DESCRIPTION
Screenshot:
<img width="1365" alt="Screenshot 2020-10-01 at 21 52 00" src="https://user-images.githubusercontent.com/4171593/94856742-b1a11f80-0430-11eb-8b3e-73ad6068ab75.png">

Closes #87