### PR TITLE
chore: node 10.x & ES6 syntax

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,0 @@
-{
-  "asi": true,
-  "browser": true,
-  "node": true
-}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-.jshintrc
 .editorconfig
 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
  - node
  - lts/*
- - 8
+ - 10
 
 before_install:
   - sudo apt-get update -qq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # specify the node base image with your desired version node:<version>
-FROM node:8
+FROM node:10
 
 ADD . /src
 WORKDIR /src

--- a/src/helpers/code-builder.js
+++ b/src/helpers/code-builder.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+const util = require('util')
 
 /**
  * Helper object to format and aggragate lines of code.
@@ -11,7 +11,7 @@ var util = require('util')
  * @param {string} indentation Desired indentation character for aggregated lines of code
  * @param {string} join Desired character to join each line of code
  */
-var CodeBuilder = function (indentation, join) {
+const CodeBuilder = function (indentation, join) {
   this.code = []
   this.indentation = indentation
   this.lineJoin = join || '\n'
@@ -37,8 +37,8 @@ var CodeBuilder = function (indentation, join) {
  *   // returns: 'console.log("\t\thello world")'
  */
 CodeBuilder.prototype.buildLine = function (indentationLevel, line) {
-  var lineIndentation = ''
-  var slice = 2
+  let lineIndentation = ''
+  let slice = 2
   if (Object.prototype.toString.call(indentationLevel) === '[object String]') {
     slice = 1
     line = indentationLevel
@@ -52,7 +52,7 @@ CodeBuilder.prototype.buildLine = function (indentationLevel, line) {
     indentationLevel--
   }
 
-  var format = Array.prototype.slice.call(arguments, slice, arguments.length)
+  const format = Array.prototype.slice.call(arguments, slice, arguments.length)
   format.unshift(lineIndentation + line)
 
   return util.format.apply(this, format)

--- a/src/helpers/reducer.js
+++ b/src/helpers/reducer.js
@@ -13,7 +13,7 @@ module.exports = function (obj, pair) {
   }
 
   // convert to array
-  var arr = [
+  const arr = [
     obj[pair.name],
     pair.value
   ]

--- a/src/helpers/shell.js
+++ b/src/helpers/shell.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+const util = require('util')
 
 module.exports = {
   /**
@@ -9,7 +9,7 @@ module.exports = {
    * http://wiki.bash-hackers.org/syntax/quoting#strong_quoting
    */
   quote: function (value) {
-    var safe = /^[a-z0-9-_/.@%^=:]+$/i
+    const safe = /^[a-z0-9-_/.@%^=:]+$/i
 
     // Unless `value` is a simple shell-safe string, quote it.
     if (!safe.test(value)) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,22 +2,22 @@
 
 'use strict'
 
-var debug = require('debug')('httpsnippet')
-var es = require('event-stream')
-var MultiPartForm = require('form-data')
-var qs = require('querystring')
-var reducer = require('./helpers/reducer')
-var targets = require('./targets')
-var url = require('url')
-var validate = require('har-validator/lib/async')
+const debug = require('debug')('httpsnippet')
+const es = require('event-stream')
+const MultiPartForm = require('form-data')
+const qs = require('querystring')
+const reducer = require('./helpers/reducer')
+const targets = require('./targets')
+const url = require('url')
+const validate = require('har-validator/lib/async')
 
 const { formDataIterator, isBlob } = require('./helpers/form-data.js')
 
 // constructor
-var HTTPSnippet = function (data) {
-  var entries
-  var self = this
-  var input = Object.assign({}, data)
+const HTTPSnippet = function (data) {
+  let entries
+  const self = this
+  const input = Object.assign({}, data)
 
   // prep the main container
   self.requests = []
@@ -72,9 +72,9 @@ HTTPSnippet.prototype.prepare = function (request) {
 
   // construct headers objects
   if (request.headers && request.headers.length) {
-    var http2VersionRegex = /^HTTP\/2/
+    const http2VersionRegex = /^HTTP\/2/
     request.headersObj = request.headers.reduce(function (headers, header) {
-      var headerName = header.name
+      let headerName = header.name
       if (request.httpVersion.match(http2VersionRegex)) {
         headerName = headerName.toLowerCase()
       }
@@ -93,7 +93,7 @@ HTTPSnippet.prototype.prepare = function (request) {
   }
 
   // construct Cookie header
-  var cookies = request.cookies.map(function (cookie) {
+  const cookies = request.cookies.map(function (cookie) {
     return encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value)
   })
 
@@ -111,7 +111,7 @@ HTTPSnippet.prototype.prepare = function (request) {
       request.postData.mimeType = 'multipart/form-data'
 
       if (request.postData.params) {
-        var form = new MultiPartForm()
+        const form = new MultiPartForm()
 
         // The `form-data` module returns one of two things: a native FormData object, or its own polyfill. Since the
         // polyfill does not support the full API of the native FormData object, when this library is running in a
@@ -236,10 +236,10 @@ HTTPSnippet.prototype.convert = function (target, client, opts) {
     opts = client
   }
 
-  var func = this._matchTarget(target, client)
+  const func = this._matchTarget(target, client)
 
   if (func) {
-    var results = this.requests.map(function (request) {
+    const results = this.requests.map(function (request) {
       return func(request, opts)
     })
 
@@ -297,8 +297,8 @@ module.exports.addTargetClient = function (target, client) {
 
 module.exports.availableTargets = function () {
   return Object.keys(targets).map(function (key) {
-    var target = Object.assign({}, targets[key].info)
-    var clients = Object.keys(targets[key])
+    const target = Object.assign({}, targets[key].info)
+    const clients = Object.keys(targets[key])
 
       .filter(function (prop) {
         return !~['info', 'index'].indexOf(prop)


### PR DESCRIPTION
As promised, here a 1st PR related to improving the codebase. 

Besides, I was wondering we could introduce [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages. Using this would help the implementation of automatic release using [semantic-release](https://github.com/semantic-release/semantic-release) tools: it will allow us to generate automatically the CHANGELOG of the release.

If you agree we can enforce the convention using [commitlint](https://github.com/conventional-changelog/commitlint)

@develohpanda @reynolek 