### PR TITLE
fix: can't load the form-data polyfill in browsers because fs doesn't exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@
 var debug = require('debug')('httpsnippet')
 var es = require('event-stream')
 var MultiPartForm = require('form-data')
-var FormDataPolyfill = require('form-data/lib/form_data')
 var qs = require('querystring')
 var reducer = require('./helpers/reducer')
 var targets = require('./targets')
@@ -128,7 +127,7 @@ HTTPSnippet.prototype.prepare = function (request) {
         // This hack is pretty awful but it's the only way we can use this library in the browser as if we code this
         // against just the native FormData object, we can't polyfill that back into Node because Blob and File objects,
         // which something like `formdata-polyfill` requires, don't exist there.
-        const isNativeFormData = !(form instanceof FormDataPolyfill)
+        const isNativeFormData = (typeof form[Symbol.iterator] === 'function')
 
         // easter egg
         const boundary = '---011000010111000001101001'


### PR DESCRIPTION
This fixes a bug in the recent `multipart/form-data` work I did in #173 where instead of detecting if the loaded `FormData` object from the `form-data` module is a polyfill, we were loading the polyfill directly from that library. Problem with this is that that [file](https://github.com/form-data/form-data/blob/master/lib/form_data.js) loads the `fs` module, which doesn't exist in the browser.

Instead, we're now just relying on the `form-data` module to give us the appropriate export (for browsers it'll load [`browser.js`](https://github.com/form-data/form-data/blob/master/lib/browser.js)) it has given the environment HTTPSnippet is being run under.