### PR TITLE
fix: updating the node-fetch target to handle form-urlencoded requests

### DIFF
--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -45,7 +45,7 @@ module.exports = function (source, options) {
         code.push('encodedParams.set(\'' + param.name + '\', \'' + param.value + '\');')
       })
 
-      reqOpts.body = 'encodedParams.toString()'
+      reqOpts.body = 'encodedParams'
       break
 
     case 'application/json':
@@ -110,7 +110,7 @@ module.exports = function (source, options) {
       .push(1, '.catch(err => console.error(\'error:\' + err));')
 
   return code.join()
-    .replace(/'encodedParams.toString\(\)'/, 'encodedParams.toString()')
+    .replace(/'encodedParams'/, 'encodedParams')
     .replace(/"fs\.createReadStream\(\\"(.+)\\"\)"/, 'fs.createReadStream("$1")')
 }
 

--- a/test/fixtures/output/node/fetch/application-form-encoded.js
+++ b/test/fixtures/output/node/fetch/application-form-encoded.js
@@ -1,11 +1,16 @@
+const { URLSearchParams } = require('url');
 const fetch = require('node-fetch');
+const encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
+encodedParams.set('hello', 'world');
 
 let url = 'http://mockbin.com/har';
 
 let options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  body: {foo: 'bar', hello: 'world'}
+  body: encodedParams.toString()
 };
 
 fetch(url, options)

--- a/test/fixtures/output/node/fetch/application-form-encoded.js
+++ b/test/fixtures/output/node/fetch/application-form-encoded.js
@@ -10,7 +10,7 @@ let url = 'http://mockbin.com/har';
 let options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  body: encodedParams.toString()
+  body: encodedParams
 };
 
 fetch(url, options)

--- a/test/fixtures/output/node/fetch/full.js
+++ b/test/fixtures/output/node/fetch/full.js
@@ -1,4 +1,8 @@
+const { URLSearchParams } = require('url');
 const fetch = require('node-fetch');
+const encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
 
 let url = 'http://mockbin.com/har';
 
@@ -10,7 +14,7 @@ let options = {
     'content-type': 'application/x-www-form-urlencoded',
     cookie: 'foo=bar; bar=baz; '
   },
-  body: {foo: 'bar'}
+  body: encodedParams.toString()
 };
 
 fetch(url, options)

--- a/test/fixtures/output/node/fetch/full.js
+++ b/test/fixtures/output/node/fetch/full.js
@@ -14,7 +14,7 @@ let options = {
     'content-type': 'application/x-www-form-urlencoded',
     cookie: 'foo=bar; bar=baz; '
   },
-  body: encodedParams.toString()
+  body: encodedParams
 };
 
 fetch(url, options)

--- a/test/fixtures/output/node/fetch/multipart-form-data.js
+++ b/test/fixtures/output/node/fetch/multipart-form-data.js
@@ -1,7 +1,8 @@
 const FormData = require('form-data');
 const fetch = require('node-fetch');
 const formData = new FormData();
-formData.append('foo','bar');
+
+formData.append('foo', 'bar');
 
 let url = 'http://mockbin.com/har';
 


### PR DESCRIPTION
The `node-fetch` target was originally sending `x-www-form-urlencoded` as a JSON object to `body` when it should be encoded with `URLSearchParams` as per the [docs](https://www.npmjs.com/package/node-fetch#post-with-form-parameters).

I also added a line break in the `multipart/form-data` handling so the `formData.append();` calls have a little bit of room to breathe.