### PR TITLE
fix: clj-http handling of literal null JSON bodies

### DIFF
--- a/src/targets/clojure/clj_http.js
+++ b/src/targets/clojure/clj_http.js
@@ -30,7 +30,9 @@ File.prototype.toString = function () {
 
 var jsType = function (x) {
   return (typeof x !== 'undefined')
-          ? x.constructor.name.toLowerCase()
+          ? ((x !== null)
+              ? x.constructor.name.toLowerCase()
+            : 'null')
           : null
 }
 


### PR DESCRIPTION
`jsToEdn()` expects` jsType(null)` to return `'null'`, but `null` has no fields, so `jsType(null)` fails. Add a special case for `null` to `jsType()` to make things work as expected.