### PR TITLE
fix: prevent crash in Swift/Objc with checking length of input body post params

### DIFF
--- a/src/targets/objc/nsurlsession/client.ts
+++ b/src/targets/objc/nsurlsession/client.ts
@@ -59,15 +59,18 @@ export const nsurlsession: Client<NsurlsessionOptions> = {
             // The user can just add/remove lines adding/removing body parameters.
             blank();
 
+            const [head, ...tail] = postData.params;
             push(
-              `NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"${postData.params[0].name}=${postData.params[0].value}" dataUsingEncoding:NSUTF8StringEncoding]];`,
+              `NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"${head.name}=${head.value}" dataUsingEncoding:NSUTF8StringEncoding]];`,
             );
 
-            for (let i = 1, len = postData.params.length; i < len; i++) {
+            tail.forEach(({ name, value }) => {
               push(
-                `[postData appendData:[@"&${postData.params[i].name}=${postData.params[i].value}" dataUsingEncoding:NSUTF8StringEncoding]];`,
+                `[postData appendData:[@"&${name}=${value}" dataUsingEncoding:NSUTF8StringEncoding]];`,
               );
-            }
+            });
+          } else {
+            req.hasBody = false;
           }
           break;
 

--- a/src/targets/swift/nsurlsession/client.ts
+++ b/src/targets/swift/nsurlsession/client.ts
@@ -59,14 +59,15 @@ export const nsurlsession: Client<NsurlsessionOptions> = {
           // The user can just add/remove lines adding/removing body parameters.
           blank();
           if (postData.params) {
+            const [head, ...tail] = postData.params;
             push(
-              `let postData = NSMutableData(data: "${postData.params[0].name}=${postData.params[0].value}".data(using: String.Encoding.utf8)!)`,
+              `let postData = NSMutableData(data: "${head.name}=${head.value}".data(using: String.Encoding.utf8)!)`,
             );
-            for (let i = 1, len = postData.params.length; i < len; i++) {
-              push(
-                `postData.append("&${postData.params[i].name}=${postData.params[i].value}".data(using: String.Encoding.utf8)!)`,
-              );
-            }
+            tail.forEach(({ name, value }) => {
+              push(`postData.append("&${name}=${value}".data(using: String.Encoding.utf8)!)`);
+            });
+          } else {
+            req.hasBody = false;
           }
           break;
 

--- a/src/targets/targets.test.ts
+++ b/src/targets/targets.test.ts
@@ -38,7 +38,7 @@ const fixtureFilter: string[] = [
  *
  * Switch to `true` in debug mode to put into effect.
  */
-const OVERWRITE_EVERYTHING = false;
+const OVERWRITE_EVERYTHING = Boolean(process.env.OVERWRITE_EVERYTHING) || false;
 
 const testFilter =
   <T>(property: keyof T, list: T[keyof T][]) =>


### PR DESCRIPTION
related to #161

now the generator checks the length of input body params to prevent crash because the first element doesn't exist. So it generates snippets without the body, just like other target languages.

Also, fix #196 with setting `req.hasBody = false` when we have an empty  post data params in input.

changelog(Fixes): Fixed an issue that caused a crash in Swift/Objc with checking length of input body post params