### PR TITLE
fix: stop implicitly coercing warning in Swift snippet generator

### DIFF
--- a/src/targets/swift/nsurlsession/client.ts
+++ b/src/targets/swift/nsurlsession/client.ts
@@ -103,7 +103,7 @@ export const nsurlsession: Client<NsurlsessionOptions> = {
             2,
           );
           push('if (error != nil) {', 2);
-          push('print(error)', 3);
+          push('print(error as Any)', 3);
           push('}', 2);
           push('body += "; filename=\\"\\(filename)\\"\\r\\n"', 2);
           push('body += "Content-Type: \\(contentType)\\r\\n\\r\\n"', 2);
@@ -151,7 +151,7 @@ export const nsurlsession: Client<NsurlsessionOptions> = {
       'let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in',
     );
     push('if (error != nil) {', 1);
-    push('print(error)', 2);
+    push('print(error as Any)', 2);
     push('} else {', 1); // Casting the NSURLResponse to NSHTTPURLResponse so the user can see the status     .
     push('let httpResponse = response as? HTTPURLResponse', 2);
     push('print(httpResponse)', 2);

--- a/src/targets/swift/nsurlsession/fixtures/application-form-encoded.swift
+++ b/src/targets/swift/nsurlsession/fixtures/application-form-encoded.swift
@@ -15,7 +15,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/application-json.swift
+++ b/src/targets/swift/nsurlsession/fixtures/application-json.swift
@@ -22,7 +22,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/cookies.swift
+++ b/src/targets/swift/nsurlsession/fixtures/cookies.swift
@@ -11,7 +11,7 @@ request.allHTTPHeaderFields = headers
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/custom-method.swift
+++ b/src/targets/swift/nsurlsession/fixtures/custom-method.swift
@@ -8,7 +8,7 @@ request.httpMethod = "PROPFIND"
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/full.swift
+++ b/src/targets/swift/nsurlsession/fixtures/full.swift
@@ -18,7 +18,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/headers.swift
+++ b/src/targets/swift/nsurlsession/fixtures/headers.swift
@@ -15,7 +15,7 @@ request.allHTTPHeaderFields = headers
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/https.swift
+++ b/src/targets/swift/nsurlsession/fixtures/https.swift
@@ -8,7 +8,7 @@ request.httpMethod = "GET"
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/indent-option.swift
+++ b/src/targets/swift/nsurlsession/fixtures/indent-option.swift
@@ -8,7 +8,7 @@ request.httpMethod = "GET"
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
     if (error != nil) {
-        print(error)
+        print(error as Any)
     } else {
         let httpResponse = response as? HTTPURLResponse
         print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/json-null-value.swift
+++ b/src/targets/swift/nsurlsession/fixtures/json-null-value.swift
@@ -15,7 +15,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/jsonObj-multiline.swift
+++ b/src/targets/swift/nsurlsession/fixtures/jsonObj-multiline.swift
@@ -15,7 +15,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/jsonObj-null-value.swift
+++ b/src/targets/swift/nsurlsession/fixtures/jsonObj-null-value.swift
@@ -15,7 +15,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/multipart-data.swift
+++ b/src/targets/swift/nsurlsession/fixtures/multipart-data.swift
@@ -26,7 +26,7 @@ for param in parameters {
     let contentType = param["content-type"]!
     let fileContent = String(contentsOfFile: filename, encoding: String.Encoding.utf8)
     if (error != nil) {
-      print(error)
+      print(error as Any)
     }
     body += "; filename=\"\(filename)\"\r\n"
     body += "Content-Type: \(contentType)\r\n\r\n"
@@ -46,7 +46,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/multipart-file.swift
+++ b/src/targets/swift/nsurlsession/fixtures/multipart-file.swift
@@ -21,7 +21,7 @@ for param in parameters {
     let contentType = param["content-type"]!
     let fileContent = String(contentsOfFile: filename, encoding: String.Encoding.utf8)
     if (error != nil) {
-      print(error)
+      print(error as Any)
     }
     body += "; filename=\"\(filename)\"\r\n"
     body += "Content-Type: \(contentType)\r\n\r\n"
@@ -41,7 +41,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/multipart-form-data-no-params.swift
+++ b/src/targets/swift/nsurlsession/fixtures/multipart-form-data-no-params.swift
@@ -11,7 +11,7 @@ request.allHTTPHeaderFields = headers
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/multipart-form-data.swift
+++ b/src/targets/swift/nsurlsession/fixtures/multipart-form-data.swift
@@ -20,7 +20,7 @@ for param in parameters {
     let contentType = param["content-type"]!
     let fileContent = String(contentsOfFile: filename, encoding: String.Encoding.utf8)
     if (error != nil) {
-      print(error)
+      print(error as Any)
     }
     body += "; filename=\"\(filename)\"\r\n"
     body += "Content-Type: \(contentType)\r\n\r\n"
@@ -40,7 +40,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/nested.swift
+++ b/src/targets/swift/nsurlsession/fixtures/nested.swift
@@ -8,7 +8,7 @@ request.httpMethod = "GET"
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/pretty-option.swift
+++ b/src/targets/swift/nsurlsession/fixtures/pretty-option.swift
@@ -14,7 +14,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/query.swift
+++ b/src/targets/swift/nsurlsession/fixtures/query.swift
@@ -8,7 +8,7 @@ request.httpMethod = "GET"
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/short.swift
+++ b/src/targets/swift/nsurlsession/fixtures/short.swift
@@ -8,7 +8,7 @@ request.httpMethod = "GET"
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/text-plain.swift
+++ b/src/targets/swift/nsurlsession/fixtures/text-plain.swift
@@ -14,7 +14,7 @@ request.httpBody = postData as Data
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)

--- a/src/targets/swift/nsurlsession/fixtures/timeout-option.swift
+++ b/src/targets/swift/nsurlsession/fixtures/timeout-option.swift
@@ -8,7 +8,7 @@ request.httpMethod = "GET"
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
   if (error != nil) {
-    print(error)
+    print(error as Any)
   } else {
     let httpResponse = response as? HTTPURLResponse
     print(httpResponse)


### PR DESCRIPTION
related to #193 and #100

![snippet](https://user-images.githubusercontent.com/785830/97635255-1196e000-1a48-11eb-8f2f-22203318f972.png)


More details about the solution: https://stevenpcurtis.medium.com/expression-implicitly-coerced-from-string-to-any-why-swift-why-190dd0a58c58

changelog(Fixes): Fix implicitly coercing warning in Swift snippet generator