### PR TITLE
Add --globoff option to shell_curl

### DIFF
--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -18,13 +18,22 @@ module.exports = function (source, options) {
   var opts = Object.assign({
     indent: '  ',
     short: false,
-    binary: false
+    binary: false,
+    globOff: false
   }, options)
 
   var code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
 
-  code.push('curl %s %s', opts.short ? '-X' : '--request', source.method)
-      .push(util.format('%s%s', opts.short ? '' : '--url ', helpers.quote(source.fullUrl)))
+  const globOption = opts.short ? '-g' : '--globoff'
+  const requestOption = opts.short ? '-X' : '--request'
+  var formattedUrl = helpers.quote(source.fullUrl)
+
+  code.push('curl %s %s', requestOption, source.method)
+  if (opts.globOff) {
+    formattedUrl = unescape(formattedUrl)
+    code.push(globOption)
+  }
+  code.push(util.format('%s%s', opts.short ? '' : '--url ', formattedUrl))
 
   if (source.httpVersion === 'HTTP/1.0') {
     code.push(opts.short ? '-0' : '--http1.0')

--- a/test/fixtures/output/c/libcurl/nested.c
+++ b/test/fixtures/output/c/libcurl/nested.c
@@ -1,0 +1,6 @@
+CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
+curl_easy_setopt(hnd, CURLOPT_URL, "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value");
+
+CURLcode ret = curl_easy_perform(hnd);

--- a/test/fixtures/output/clojure/clj_http/nested.clj
+++ b/test/fixtures/output/clojure/clj_http/nested.clj
@@ -1,0 +1,5 @@
+(require '[clj-http.client :as client])
+
+(client/get "http://mockbin.com/har" {:query-params {:foo[bar] "baz,zap"
+                                                     :fiz "buz"
+                                                     :key "value"}})

--- a/test/fixtures/output/csharp/httpclient/nested.cs
+++ b/test/fixtures/output/csharp/httpclient/nested.cs
@@ -1,0 +1,12 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Get,
+    RequestUri = new Uri("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/restsharp/nested.cs
+++ b/test/fixtures/output/csharp/restsharp/nested.cs
@@ -1,0 +1,3 @@
+var client = new RestClient("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value");
+var request = new RestRequest(Method.GET);
+IRestResponse response = client.Execute(request);

--- a/test/fixtures/output/go/native/nested.go
+++ b/test/fixtures/output/go/native/nested.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"io/ioutil"
+)
+
+func main() {
+
+	url := "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value"
+
+	req, _ := http.NewRequest("GET", url, nil)
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}

--- a/test/fixtures/output/http/1.1/nested
+++ b/test/fixtures/output/http/1.1/nested
@@ -1,0 +1,4 @@
+GET /har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value HTTP/1.1
+Host: mockbin.com
+
+

--- a/test/fixtures/output/java/asynchttp/nested.java
+++ b/test/fixtures/output/java/asynchttp/nested.java
@@ -1,0 +1,8 @@
+AsyncHttpClient client = new DefaultAsyncHttpClient();
+client.prepare("GET", "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value")
+  .execute()
+  .toCompletableFuture()
+  .thenAccept(System.out::println)
+  .join();
+
+client.close();

--- a/test/fixtures/output/java/nethttp/nested.java
+++ b/test/fixtures/output/java/nethttp/nested.java
@@ -1,0 +1,6 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value"))
+    .method("GET", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/okhttp/nested.java
+++ b/test/fixtures/output/java/okhttp/nested.java
@@ -1,0 +1,8 @@
+OkHttpClient client = new OkHttpClient();
+
+Request request = new Request.Builder()
+  .url("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value")
+  .get()
+  .build();
+
+Response response = client.newCall(request).execute();

--- a/test/fixtures/output/java/unirest/nested.java
+++ b/test/fixtures/output/java/unirest/nested.java
@@ -1,0 +1,2 @@
+HttpResponse<String> response = Unirest.get("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value")
+  .asString();

--- a/test/fixtures/output/javascript/axios/nested.js
+++ b/test/fixtures/output/javascript/axios/nested.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+const options = {
+  method: 'GET',
+  url: 'http://mockbin.com/har',
+  params: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});

--- a/test/fixtures/output/javascript/fetch/nested.js
+++ b/test/fixtures/output/javascript/fetch/nested.js
@@ -1,10 +1,6 @@
-fetch("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value", {
-  "method": "GET",
-  "headers": {}
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'GET'};
+
+fetch('http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value', options)
+  .then(response => response.json())
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/nested.js
+++ b/test/fixtures/output/javascript/fetch/nested.js
@@ -1,0 +1,10 @@
+fetch("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value", {
+  "method": "GET",
+  "headers": {}
+})
+.then(response => {
+  console.log(response);
+})
+.catch(err => {
+  console.error(err);
+});

--- a/test/fixtures/output/javascript/jquery/nested.js
+++ b/test/fixtures/output/javascript/jquery/nested.js
@@ -1,0 +1,11 @@
+const settings = {
+  "async": true,
+  "crossDomain": true,
+  "url": "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value",
+  "method": "GET",
+  "headers": {}
+};
+
+$.ajax(settings).done(function (response) {
+  console.log(response);
+});

--- a/test/fixtures/output/javascript/xhr/nested.js
+++ b/test/fixtures/output/javascript/xhr/nested.js
@@ -1,0 +1,14 @@
+const data = null;
+
+const xhr = new XMLHttpRequest();
+xhr.withCredentials = true;
+
+xhr.addEventListener("readystatechange", function () {
+  if (this.readyState === this.DONE) {
+    console.log(this.responseText);
+  }
+});
+
+xhr.open("GET", "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value");
+
+xhr.send(data);

--- a/test/fixtures/output/kotlin/okhttp/nested.kt
+++ b/test/fixtures/output/kotlin/okhttp/nested.kt
@@ -1,0 +1,8 @@
+val client = OkHttpClient()
+
+val request = Request.Builder()
+  .url("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value")
+  .get()
+  .build()
+
+val response = client.newCall(request).execute()

--- a/test/fixtures/output/node/axios/nested.js
+++ b/test/fixtures/output/node/axios/nested.js
@@ -1,0 +1,13 @@
+var axios = require("axios").default;
+
+var options = {
+  method: 'GET',
+  url: 'http://mockbin.com/har',
+  params: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});

--- a/test/fixtures/output/node/fetch/nested.js
+++ b/test/fixtures/output/node/fetch/nested.js
@@ -1,0 +1,10 @@
+const fetch = require('node-fetch');
+
+let url = 'http://mockbin.com/har';
+
+let options = {method: 'GET', qs: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));

--- a/test/fixtures/output/node/fetch/nested.js
+++ b/test/fixtures/output/node/fetch/nested.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+let url = 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value';
 
-let options = {method: 'GET', qs: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}};
+let options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/native/nested.js
+++ b/test/fixtures/output/node/native/nested.js
@@ -1,0 +1,24 @@
+const http = require("http");
+
+const options = {
+  "method": "GET",
+  "hostname": "mockbin.com",
+  "port": null,
+  "path": "/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value",
+  "headers": {}
+};
+
+const req = http.request(options, function (res) {
+  const chunks = [];
+
+  res.on("data", function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on("end", function () {
+    const body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.end();

--- a/test/fixtures/output/node/request/nested.js
+++ b/test/fixtures/output/node/request/nested.js
@@ -1,0 +1,14 @@
+const request = require('request');
+
+const options = {
+  method: 'GET',
+  url: 'http://mockbin.com/har',
+  qs: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}
+};
+
+request(options, function (error, response, body) {
+  if (error) throw new Error(error);
+
+  console.log(body);
+});
+

--- a/test/fixtures/output/node/unirest/nested.js
+++ b/test/fixtures/output/node/unirest/nested.js
@@ -1,0 +1,16 @@
+const unirest = require("unirest");
+
+const req = unirest("GET", "http://mockbin.com/har");
+
+req.query({
+  "foo[bar]": "baz,zap",
+  "fiz": "buz",
+  "key": "value"
+});
+
+req.end(function (res) {
+  if (res.error) throw new Error(res.error);
+
+  console.log(res.body);
+});
+

--- a/test/fixtures/output/objc/nsurlsession/nested.m
+++ b/test/fixtures/output/objc/nsurlsession/nested.m
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"GET"];
+
+NSURLSession *session = [NSURLSession sharedSession];
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                                if (error) {
+                                                    NSLog(@"%@", error);
+                                                } else {
+                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+                                                    NSLog(@"%@", httpResponse);
+                                                }
+                                            }];
+[dataTask resume];

--- a/test/fixtures/output/ocaml/cohttp/nested.ml
+++ b/test/fixtures/output/ocaml/cohttp/nested.ml
@@ -1,0 +1,9 @@
+open Cohttp_lwt_unix
+open Cohttp
+open Lwt
+
+let uri = Uri.of_string "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value" in
+
+Client.call `GET uri
+>>= fun (res, body_stream) ->
+  (* Do stuff with the result *)

--- a/test/fixtures/output/php/curl/nested.php
+++ b/test/fixtures/output/php/curl/nested.php
@@ -1,0 +1,24 @@
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, [
+  CURLOPT_URL => "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => "",
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 30,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => "GET",
+]);
+
+$response = curl_exec($curl);
+$err = curl_error($curl);
+
+curl_close($curl);
+
+if ($err) {
+  echo "cURL Error #:" . $err;
+} else {
+  echo $response;
+}

--- a/test/fixtures/output/php/http1/nested.php
+++ b/test/fixtures/output/php/http1/nested.php
@@ -1,0 +1,19 @@
+<?php
+
+$request = new HttpRequest();
+$request->setUrl('http://mockbin.com/har');
+$request->setMethod(HTTP_METH_GET);
+
+$request->setQueryData([
+  'foo[bar]' => 'baz,zap',
+  'fiz' => 'buz',
+  'key' => 'value'
+]);
+
+try {
+  $response = $request->send();
+
+  echo $response->getBody();
+} catch (HttpException $ex) {
+  echo $ex;
+}

--- a/test/fixtures/output/php/http2/nested.php
+++ b/test/fixtures/output/php/http2/nested.php
@@ -1,0 +1,17 @@
+<?php
+
+$client = new http\Client;
+$request = new http\Client\Request;
+
+$request->setRequestUrl('http://mockbin.com/har');
+$request->setRequestMethod('GET');
+$request->setQuery(new http\QueryString([
+  'foo[bar]' => 'baz,zap',
+  'fiz' => 'buz',
+  'key' => 'value'
+]));
+
+$client->enqueue($request)->send();
+$response = $client->getResponse();
+
+echo $response->getBody();

--- a/test/fixtures/output/powershell/restmethod/nested.ps1
+++ b/test/fixtures/output/powershell/restmethod/nested.ps1
@@ -1,0 +1,1 @@
+$response = Invoke-RestMethod -Uri 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value' -Method GET 

--- a/test/fixtures/output/powershell/webrequest/nested.ps1
+++ b/test/fixtures/output/powershell/webrequest/nested.ps1
@@ -1,0 +1,1 @@
+$response = Invoke-WebRequest -Uri 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value' -Method GET 

--- a/test/fixtures/output/python/python3/nested.py
+++ b/test/fixtures/output/python/python3/nested.py
@@ -1,0 +1,10 @@
+import http.client
+
+conn = http.client.HTTPConnection("mockbin.com")
+
+conn.request("GET", "/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))

--- a/test/fixtures/output/python/requests/nested.py
+++ b/test/fixtures/output/python/requests/nested.py
@@ -1,0 +1,9 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+querystring = {"foo[bar]":"baz,zap","fiz":"buz","key":"value"}
+
+response = requests.request("GET", url, params=querystring)
+
+print(response.text)

--- a/test/fixtures/output/r/httr/nested.r
+++ b/test/fixtures/output/r/httr/nested.r
@@ -1,0 +1,12 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+queryString <- list(
+  foo[bar] = "baz,zap",
+  fiz = "buz"
+)
+
+response <- VERB("GET", url, query = queryString, content_type("application/octet-stream"))
+
+content(response, "text")

--- a/test/fixtures/output/ruby/native/nested.rb
+++ b/test/fixtures/output/ruby/native/nested.rb
@@ -1,0 +1,11 @@
+require 'uri'
+require 'net/http'
+
+url = URI("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value")
+
+http = Net::HTTP.new(url.host, url.port)
+
+request = Net::HTTP::Get.new(url)
+
+response = http.request(request)
+puts response.read_body

--- a/test/fixtures/output/shell/curl/nested.sh
+++ b/test/fixtures/output/shell/curl/nested.sh
@@ -1,0 +1,2 @@
+curl --request GET \
+  --url 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value'

--- a/test/fixtures/output/shell/httpie/nested.sh
+++ b/test/fixtures/output/shell/httpie/nested.sh
@@ -1,0 +1,1 @@
+http GET 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value'

--- a/test/fixtures/output/shell/wget/nested.sh
+++ b/test/fixtures/output/shell/wget/nested.sh
@@ -1,0 +1,4 @@
+wget --quiet \
+  --method GET \
+  --output-document \
+  - 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value'

--- a/test/fixtures/output/swift/nsurlsession/nested.swift
+++ b/test/fixtures/output/swift/nsurlsession/nested.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+let request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value")! as URL,
+                                        cachePolicy: .useProtocolCachePolicy,
+                                    timeoutInterval: 10.0)
+request.httpMethod = "GET"
+
+let session = URLSession.shared
+let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
+  if (error != nil) {
+    print(error)
+  } else {
+    let httpResponse = response as? HTTPURLResponse
+    print(httpResponse)
+  }
+})
+
+dataTask.resume()

--- a/test/fixtures/requests/nested.json
+++ b/test/fixtures/requests/nested.json
@@ -1,0 +1,19 @@
+{
+  "method": "GET",
+  "url": "http://mockbin.com/har",
+  "httpVersion": "HTTP/1.1",
+  "queryString": [
+    {
+      "name": "foo[bar]",
+      "value": "baz,zap"
+    },
+    {
+      "name": "fiz",
+      "value": "buz"
+    },
+    {
+      "name": "key",
+      "value": "value"
+    }
+  ]
+}

--- a/test/targets/shell/curl.js
+++ b/test/targets/shell/curl.js
@@ -26,6 +26,37 @@ module.exports = function (HTTPSnippet, fixtures) {
     result.should.eql("curl -X POST 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value' -H 'accept: application/json' -H 'content-type: application/x-www-form-urlencoded' -b 'foo=bar; bar=baz' --data-binary foo=bar")
   })
 
+  it('should use short globoff option', function () {
+    var result = new HTTPSnippet(fixtures.requests.nested).convert('shell', 'curl', {
+      short: true,
+      indent: false,
+      globOff: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql("curl -X GET -g 'http://mockbin.com/har?foo[bar]=baz,zap&fiz=buz&key=value'")
+  })
+
+  it('should use long globoff option', function () {
+    var result = new HTTPSnippet(fixtures.requests.nested).convert('shell', 'curl', {
+      indent: false,
+      globOff: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql("curl --request GET --globoff --url 'http://mockbin.com/har?foo[bar]=baz,zap&fiz=buz&key=value'")
+  })
+
+  it('should not de-glob when globoff is false', function () {
+    var result = new HTTPSnippet(fixtures.requests.nested).convert('shell', 'curl', {
+      indent: false,
+      globOff: false
+    })
+
+    result.should.be.a.String()
+    result.should.eql("curl --request GET --url 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value'")
+  })
+
   it('should use --http1.0 for HTTP/1.0', function () {
     var result = new HTTPSnippet(fixtures.curl.http1).convert('shell', 'curl', {
       indent: false


### PR DESCRIPTION
In some common api specifications there exist nested query parameters that take the form of an object.
Example: `page[limit]=10` https://jsonapi.org/

### This PR
1. Adds a fixture for nested query params and associated test cases
2. Adds the `--globoff` or `-g` option for the curl command to allow unescaped brackets in the url