### PR TITLE
feat: adding an option for disabling query string encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ var snippet = new HTTPSnippet({
 });
 ```
 
+#### options
+
+Type: `object`
+
+Available options:
+
+* `escapeQueryStrings` (`boolean`): In the event of you supplying a `source` that alreay contains escaped query strings, this allows you to disable automatic of query strings and prevents them from being double-escaped.
+
 ### convert(target [, options])
 
 #### target

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,14 @@ var validate = require('har-validator/lib/async')
 const { formDataIterator, isBlob } = require('./helpers/form-data.js')
 
 // constructor
-var HTTPSnippet = function (data) {
+var HTTPSnippet = function (data, opts = {}) {
   var entries
   var self = this
   var input = Object.assign({}, data)
+
+  var options = Object.assign({
+    escapeQueryStrings: true
+  }, opts)
 
   // prep the main container
   self.requests = []
@@ -50,12 +54,12 @@ var HTTPSnippet = function (data) {
         throw err
       }
 
-      self.requests.push(self.prepare(entry.request))
+      self.requests.push(self.prepare(entry.request, options))
     })
   })
 }
 
-HTTPSnippet.prototype.prepare = function (request) {
+HTTPSnippet.prototype.prepare = function (request, options) {
   // construct utility properties
   request.queryObj = {}
   request.headersObj = {}
@@ -227,7 +231,15 @@ HTTPSnippet.prototype.prepare = function (request) {
 
   // update the uri object
   request.uriObj.query = request.queryObj
-  request.uriObj.search = qs.stringify(request.queryObj)
+  if (options.escapeQueryStrings) {
+    request.uriObj.search = qs.stringify(request.queryObj)
+  } else {
+    // If we don't want to escape query strings (in the case of the HAR already having them escaped), pass in a dumb
+    // callback to disable querystring from doing so.
+    request.uriObj.search = qs.stringify(request.queryObj, null, null, {
+      encodeURIComponent: (str) => str
+    })
+  }
 
   if (request.uriObj.search) {
     request.uriObj.path = request.uriObj.pathname + '?' + request.uriObj.search

--- a/test/fixtures/output/c/libcurl/query-encoded.c
+++ b/test/fixtures/output/c/libcurl/query-encoded.c
@@ -1,0 +1,6 @@
+CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
+curl_easy_setopt(hnd, CURLOPT_URL, "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00");
+
+CURLcode ret = curl_easy_perform(hnd);

--- a/test/fixtures/output/clojure/clj_http/query-encoded.clj
+++ b/test/fixtures/output/clojure/clj_http/query-encoded.clj
@@ -1,0 +1,4 @@
+(require '[clj-http.client :as client])
+
+(client/get "http://mockbin.com/har" {:query-params {:startTime "2019-06-13T19%3A08%3A25.455Z"
+                                                     :endTime "2015-09-15T14%3A00%3A12-04%3A00"}})

--- a/test/fixtures/output/csharp/httpclient/query-encoded.cs
+++ b/test/fixtures/output/csharp/httpclient/query-encoded.cs
@@ -1,0 +1,12 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Get,
+    RequestUri = new Uri("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/test/fixtures/output/csharp/restsharp/query-encoded.cs
+++ b/test/fixtures/output/csharp/restsharp/query-encoded.cs
@@ -1,0 +1,3 @@
+var client = new RestClient("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00");
+var request = new RestRequest(Method.GET);
+IRestResponse response = client.Execute(request);

--- a/test/fixtures/output/go/native/query-encoded.go
+++ b/test/fixtures/output/go/native/query-encoded.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"io/ioutil"
+)
+
+func main() {
+
+	url := "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00"
+
+	req, _ := http.NewRequest("GET", url, nil)
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}

--- a/test/fixtures/output/http/1.1/query-encoded
+++ b/test/fixtures/output/http/1.1/query-encoded
@@ -1,0 +1,4 @@
+GET /har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00 HTTP/1.1
+Host: mockbin.com
+
+

--- a/test/fixtures/output/java/asynchttp/query-encoded.java
+++ b/test/fixtures/output/java/asynchttp/query-encoded.java
@@ -1,0 +1,8 @@
+AsyncHttpClient client = new DefaultAsyncHttpClient();
+client.prepare("GET", "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00")
+  .execute()
+  .toCompletableFuture()
+  .thenAccept(System.out::println)
+  .join();
+
+client.close();

--- a/test/fixtures/output/java/nethttp/query-encoded.java
+++ b/test/fixtures/output/java/nethttp/query-encoded.java
@@ -1,0 +1,6 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00"))
+    .method("GET", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/test/fixtures/output/java/okhttp/query-encoded.java
+++ b/test/fixtures/output/java/okhttp/query-encoded.java
@@ -1,0 +1,8 @@
+OkHttpClient client = new OkHttpClient();
+
+Request request = new Request.Builder()
+  .url("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00")
+  .get()
+  .build();
+
+Response response = client.newCall(request).execute();

--- a/test/fixtures/output/java/unirest/query-encoded.java
+++ b/test/fixtures/output/java/unirest/query-encoded.java
@@ -1,0 +1,2 @@
+HttpResponse<String> response = Unirest.get("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00")
+  .asString();

--- a/test/fixtures/output/javascript/axios/query-encoded.js
+++ b/test/fixtures/output/javascript/axios/query-encoded.js
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+const options = {
+  method: 'GET',
+  url: 'http://mockbin.com/har',
+  params: {
+    startTime: '2019-06-13T19%3A08%3A25.455Z',
+    endTime: '2015-09-15T14%3A00%3A12-04%3A00'
+  }
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});

--- a/test/fixtures/output/javascript/fetch/query-encoded.js
+++ b/test/fixtures/output/javascript/fetch/query-encoded.js
@@ -1,0 +1,10 @@
+fetch("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00", {
+  "method": "GET",
+  "headers": {}
+})
+.then(response => {
+  console.log(response);
+})
+.catch(err => {
+  console.error(err);
+});

--- a/test/fixtures/output/javascript/jquery/query-encoded.js
+++ b/test/fixtures/output/javascript/jquery/query-encoded.js
@@ -1,0 +1,11 @@
+const settings = {
+  "async": true,
+  "crossDomain": true,
+  "url": "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00",
+  "method": "GET",
+  "headers": {}
+};
+
+$.ajax(settings).done(function (response) {
+  console.log(response);
+});

--- a/test/fixtures/output/javascript/xhr/query-encoded.js
+++ b/test/fixtures/output/javascript/xhr/query-encoded.js
@@ -1,0 +1,14 @@
+const data = null;
+
+const xhr = new XMLHttpRequest();
+xhr.withCredentials = true;
+
+xhr.addEventListener("readystatechange", function () {
+  if (this.readyState === this.DONE) {
+    console.log(this.responseText);
+  }
+});
+
+xhr.open("GET", "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00");
+
+xhr.send(data);

--- a/test/fixtures/output/kotlin/okhttp/query-encoded.kt
+++ b/test/fixtures/output/kotlin/okhttp/query-encoded.kt
@@ -1,0 +1,8 @@
+val client = OkHttpClient()
+
+val request = Request.Builder()
+  .url("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00")
+  .get()
+  .build()
+
+val response = client.newCall(request).execute()

--- a/test/fixtures/output/node/axios/query-encoded.js
+++ b/test/fixtures/output/node/axios/query-encoded.js
@@ -1,0 +1,16 @@
+var axios = require("axios").default;
+
+var options = {
+  method: 'GET',
+  url: 'http://mockbin.com/har',
+  params: {
+    startTime: '2019-06-13T19%3A08%3A25.455Z',
+    endTime: '2015-09-15T14%3A00%3A12-04%3A00'
+  }
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});

--- a/test/fixtures/output/node/fetch/query-encoded.js
+++ b/test/fixtures/output/node/fetch/query-encoded.js
@@ -1,0 +1,16 @@
+const fetch = require('node-fetch');
+
+let url = 'http://mockbin.com/har';
+
+let options = {
+  method: 'GET',
+  qs: {
+    startTime: '2019-06-13T19%3A08%3A25.455Z',
+    endTime: '2015-09-15T14%3A00%3A12-04%3A00'
+  }
+};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));

--- a/test/fixtures/output/node/native/query-encoded.js
+++ b/test/fixtures/output/node/native/query-encoded.js
@@ -1,0 +1,24 @@
+const http = require("http");
+
+const options = {
+  "method": "GET",
+  "hostname": "mockbin.com",
+  "port": null,
+  "path": "/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00",
+  "headers": {}
+};
+
+const req = http.request(options, function (res) {
+  const chunks = [];
+
+  res.on("data", function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on("end", function () {
+    const body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.end();

--- a/test/fixtures/output/node/request/query-encoded.js
+++ b/test/fixtures/output/node/request/query-encoded.js
@@ -1,0 +1,17 @@
+const request = require('request');
+
+const options = {
+  method: 'GET',
+  url: 'http://mockbin.com/har',
+  qs: {
+    startTime: '2019-06-13T19%3A08%3A25.455Z',
+    endTime: '2015-09-15T14%3A00%3A12-04%3A00'
+  }
+};
+
+request(options, function (error, response, body) {
+  if (error) throw new Error(error);
+
+  console.log(body);
+});
+

--- a/test/fixtures/output/node/unirest/query-encoded.js
+++ b/test/fixtures/output/node/unirest/query-encoded.js
@@ -1,0 +1,15 @@
+const unirest = require("unirest");
+
+const req = unirest("GET", "http://mockbin.com/har");
+
+req.query({
+  "startTime": "2019-06-13T19%3A08%3A25.455Z",
+  "endTime": "2015-09-15T14%3A00%3A12-04%3A00"
+});
+
+req.end(function (res) {
+  if (res.error) throw new Error(res.error);
+
+  console.log(res.body);
+});
+

--- a/test/fixtures/output/objc/nsurlsession/query-encoded.m
+++ b/test/fixtures/output/objc/nsurlsession/query-encoded.m
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"GET"];
+
+NSURLSession *session = [NSURLSession sharedSession];
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                                if (error) {
+                                                    NSLog(@"%@", error);
+                                                } else {
+                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+                                                    NSLog(@"%@", httpResponse);
+                                                }
+                                            }];
+[dataTask resume];

--- a/test/fixtures/output/ocaml/cohttp/query-encoded.ml
+++ b/test/fixtures/output/ocaml/cohttp/query-encoded.ml
@@ -1,0 +1,9 @@
+open Cohttp_lwt_unix
+open Cohttp
+open Lwt
+
+let uri = Uri.of_string "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00" in
+
+Client.call `GET uri
+>>= fun (res, body_stream) ->
+  (* Do stuff with the result *)

--- a/test/fixtures/output/php/curl/query-encoded.php
+++ b/test/fixtures/output/php/curl/query-encoded.php
@@ -1,0 +1,24 @@
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, [
+  CURLOPT_URL => "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => "",
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 30,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => "GET",
+]);
+
+$response = curl_exec($curl);
+$err = curl_error($curl);
+
+curl_close($curl);
+
+if ($err) {
+  echo "cURL Error #:" . $err;
+} else {
+  echo $response;
+}

--- a/test/fixtures/output/php/http1/query-encoded.php
+++ b/test/fixtures/output/php/http1/query-encoded.php
@@ -1,0 +1,18 @@
+<?php
+
+$request = new HttpRequest();
+$request->setUrl('http://mockbin.com/har');
+$request->setMethod(HTTP_METH_GET);
+
+$request->setQueryData([
+  'startTime' => '2019-06-13T19%3A08%3A25.455Z',
+  'endTime' => '2015-09-15T14%3A00%3A12-04%3A00'
+]);
+
+try {
+  $response = $request->send();
+
+  echo $response->getBody();
+} catch (HttpException $ex) {
+  echo $ex;
+}

--- a/test/fixtures/output/php/http2/query-encoded.php
+++ b/test/fixtures/output/php/http2/query-encoded.php
@@ -1,0 +1,16 @@
+<?php
+
+$client = new http\Client;
+$request = new http\Client\Request;
+
+$request->setRequestUrl('http://mockbin.com/har');
+$request->setRequestMethod('GET');
+$request->setQuery(new http\QueryString([
+  'startTime' => '2019-06-13T19%3A08%3A25.455Z',
+  'endTime' => '2015-09-15T14%3A00%3A12-04%3A00'
+]));
+
+$client->enqueue($request)->send();
+$response = $client->getResponse();
+
+echo $response->getBody();

--- a/test/fixtures/output/powershell/restmethod/query-encoded.ps1
+++ b/test/fixtures/output/powershell/restmethod/query-encoded.ps1
@@ -1,0 +1,1 @@
+$response = Invoke-RestMethod -Uri 'http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00' -Method GET

--- a/test/fixtures/output/powershell/webrequest/query-encoded.ps1
+++ b/test/fixtures/output/powershell/webrequest/query-encoded.ps1
@@ -1,0 +1,1 @@
+$response = Invoke-WebRequest -Uri 'http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00' -Method GET

--- a/test/fixtures/output/python/python3/query-encoded.py
+++ b/test/fixtures/output/python/python3/query-encoded.py
@@ -1,0 +1,10 @@
+import http.client
+
+conn = http.client.HTTPConnection("mockbin.com")
+
+conn.request("GET", "/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))

--- a/test/fixtures/output/python/requests/query-encoded.py
+++ b/test/fixtures/output/python/requests/query-encoded.py
@@ -1,0 +1,9 @@
+import requests
+
+url = "http://mockbin.com/har"
+
+querystring = {"startTime":"2019-06-13T19%3A08%3A25.455Z","endTime":"2015-09-15T14%3A00%3A12-04%3A00"}
+
+response = requests.request("GET", url, params=querystring)
+
+print(response.text)

--- a/test/fixtures/output/r/httr/query-encoded.r
+++ b/test/fixtures/output/r/httr/query-encoded.r
@@ -1,0 +1,12 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+queryString <- list(
+  startTime = "2019-06-13T19%3A08%3A25.455Z"
+  endTime = "2015-09-15T14%3A00%3A12-04%3A00",
+)
+
+response <- VERB("GET", url, query = queryString, content_type("application/octet-stream"))
+
+content(response, "text")

--- a/test/fixtures/output/ruby/native/query-encoded.rb
+++ b/test/fixtures/output/ruby/native/query-encoded.rb
@@ -1,0 +1,11 @@
+require 'uri'
+require 'net/http'
+
+url = URI("http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00")
+
+http = Net::HTTP.new(url.host, url.port)
+
+request = Net::HTTP::Get.new(url)
+
+response = http.request(request)
+puts response.read_body

--- a/test/fixtures/output/shell/curl/query-encoded.sh
+++ b/test/fixtures/output/shell/curl/query-encoded.sh
@@ -1,0 +1,2 @@
+curl --request GET \
+  --url 'http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00'

--- a/test/fixtures/output/shell/httpie/query-encoded.sh
+++ b/test/fixtures/output/shell/httpie/query-encoded.sh
@@ -1,0 +1,1 @@
+http GET 'http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00'

--- a/test/fixtures/output/shell/wget/query-encoded.sh
+++ b/test/fixtures/output/shell/wget/query-encoded.sh
@@ -1,0 +1,4 @@
+wget --quiet \
+  --method GET \
+  --output-document \
+  - 'http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00'

--- a/test/fixtures/output/swift/nsurlsession/query-encoded.swift
+++ b/test/fixtures/output/swift/nsurlsession/query-encoded.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+let request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00")! as URL,
+                                        cachePolicy: .useProtocolCachePolicy,
+                                    timeoutInterval: 10.0)
+request.httpMethod = "GET"
+
+let session = URLSession.shared
+let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
+  if (error != nil) {
+    print(error)
+  } else {
+    let httpResponse = response as? HTTPURLResponse
+    print(httpResponse)
+  }
+})
+
+dataTask.resume()

--- a/test/fixtures/requests/query-encoded.json
+++ b/test/fixtures/requests/query-encoded.json
@@ -1,0 +1,15 @@
+{
+  "method": "GET",
+  "url": "http://mockbin.com/har",
+  "httpVersion": "HTTP/1.1",
+  "queryString": [
+    {
+      "name": "startTime",
+      "value": "2019-06-13T19%3A08%3A25.455Z"
+    },
+    {
+      "name": "endTime",
+      "value": "2015-09-15T14%3A00%3A12-04%3A00"
+    }
+  ]
+}

--- a/test/targets.js
+++ b/test/targets.js
@@ -76,7 +76,14 @@ var itShouldGenerateOutput = function (request, path, target, client) {
         skipMe['*']['*'].indexOf(request) > -1)) {
       this.skip()
     }
-    var instance = new HTTPSnippet(fixtures.requests[request])
+
+    var options = {}
+    if (request === 'query-encoded') {
+      // Query strings in this HAR are already escaped.
+      options.escapeQueryStrings = false
+    }
+
+    var instance = new HTTPSnippet(fixtures.requests[request], options)
 
     // `form-data` sets the line break as `\r\n`, but we can't easily replicate that in our fixtures so let's convert
     // it to a standard line break instead.


### PR DESCRIPTION
We've discovered a bug where if your HAR definition has query strings that are already encoded (eg: `startTime: 2015-09-15T14%3A00%3A12-04%3A00` instead of `startTime: 2015-09-15T14:00:12-04:00`), the library will re-encode them again when it constructs the `urlObj` and `fullUrl` data that a handful of targets use. This leads to those parameters values getting corrupted.

This PR adds a new argument, and option, to disable this escaping that happens on `urlObj` and `fullUrl`:

```js
new HTTPSnippet(har, { escapeQueryStrings: true })
```

I've added a new `query-encoded` test case that covers this case for every available target.