### PR TITLE
rfc: drop support for < Node 10

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,0 @@
-{
-  "asi": true,
-  "browser": true,
-  "node": true
-}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-.jshintrc
 .editorconfig
 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
  - node
  - lts/*
- - 8
 
 before_install:
   - sudo apt-get update -qq

--- a/bin/httpsnippet
+++ b/bin/httpsnippet
@@ -2,14 +2,14 @@
 
 'use strict'
 
-var chalk = require('chalk')
-var cmd = require('commander')
-var fs = require('fs')
-var readFile = require('fs-readfile-promise')
-var writeFile = require('fs-writefile-promise')
-var HTTPSnippet = require('..')
-var path = require('path')
-var pkg = require('../package.json')
+const chalk = require('chalk')
+const cmd = require('commander')
+const fs = require('fs')
+const readFile = require('fs-readfile-promise')
+const writeFile = require('fs-writefile-promise')
+const HTTPSnippet = require('..')
+const path = require('path')
+const pkg = require('../package.json')
 
 cmd
   .version(pkg.version)
@@ -23,8 +23,9 @@ if (!cmd.args.length || !cmd.target) {
   cmd.help()
 }
 
+let dir
 if (cmd.output) {
-  var dir = path.resolve(cmd.output)
+  dir = path.resolve(cmd.output)
 
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
@@ -32,7 +33,7 @@ if (cmd.output) {
 }
 
 cmd.args.forEach(function (fileName) {
-  var file = path.basename(fileName)
+  const file = path.basename(fileName)
 
   readFile(fileName)
     .then(JSON.parse)
@@ -57,7 +58,7 @@ cmd.args.forEach(function (fileName) {
 
     .then(function (output) {
       if (!output) {
-        var targetNames = HTTPSnippet.availableTargets().map(function (t) { return t.key }).join(', ')
+        const targetNames = HTTPSnippet.availableTargets().map(function (t) { return t.key }).join(', ')
         return console.error('%s %s is not a valid target. Valid targets: %s', chalk.red('✖'), chalk.red(cmd.target), chalk.cyan(targetNames))
       }
 
@@ -67,9 +68,9 @@ cmd.args.forEach(function (fileName) {
       }
 
       // write to file
-      var name = path.basename(file, path.extname(file))
+      const name = path.basename(file, path.extname(file))
 
-      var filename = path.format({
+      const filename = path.format({
         dir: dir,
         base: name + HTTPSnippet.extname(cmd.target)
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,140 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
+      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        }
+      }
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -11,27 +145,16 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
     },
     "ajv": {
       "version": "6.10.0",
@@ -44,12 +167,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true
-    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -58,15 +175,9 @@
       "optional": true
     },
     "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-regex": {
@@ -79,6 +190,16 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -88,14 +209,40 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "array.prototype.find": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+    "array-includes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
+      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "get-intrinsic": "^1.0.1",
+        "is-string": "^1.0.5"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "function-bind": "^1.1.1"
       }
     },
     "asn1": {
@@ -111,6 +258,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "asynckit": {
@@ -130,17 +283,6 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -156,6 +298,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -166,37 +314,35 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camelcase": {
@@ -223,26 +369,21 @@
         "supports-color": "^2.0.0"
       }
     },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+    "chokidar": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
       }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
     },
     "cliui": {
       "version": "5.0.0",
@@ -259,12 +400,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -288,18 +423,6 @@
           }
         }
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
     },
     "codeclimate-test-reporter": {
       "version": "0.5.1",
@@ -365,18 +488,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -389,14 +500,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "dashdash": {
@@ -449,51 +572,21 @@
         "object-keys": "^1.0.12"
       }
     },
-    "deglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
-      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
-      "dev": true,
-      "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^3.0.9",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -612,6 +705,23 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+          "dev": true
+        }
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -622,111 +732,82 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.18.0-next.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.3",
+        "string.prototype.trimstart": "^1.0.3"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+          "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+          "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
-      },
-      "dependencies": {
-        "es6-symbol": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true,
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
-          }
-        }
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -747,15 +828,365 @@
         "source-map": "~0.2.0"
       }
     },
-    "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+    "eslint": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz",
+      "integrity": "sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.2.tgz",
+      "integrity": "sha512-fx3f1rJDsl9bY7qzyX8SAtP8GBSk6MfXFaTfaGgk12aAYW4gJSyRm7dM790L6cbXv63fvjY4XeSzXnb4WM+SKw==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-10.0.0.tgz",
+      "integrity": "sha512-hLeA2f5e06W1xyr/93/QJulN/rLbUVUmqTlexv9PRKHFwEC9ffJcH2LvJhMoEqYQBEYafedgGZXH2W8NUpt5lA==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flatmap": "^1.2.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "object.entries": "^1.1.2",
+        "object.fromentries": "^2.0.2",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.18.1",
+        "string.prototype.matchall": "^4.0.2"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       },
       "dependencies": {
@@ -767,192 +1198,46 @@
         }
       }
     },
-    "eslint": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.16.0",
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.5.2",
-        "debug": "^2.1.1",
-        "doctrine": "^2.0.0",
-        "escope": "^3.6.0",
-        "espree": "^3.4.0",
-        "esquery": "^1.0.0",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "glob": "^7.0.3",
-        "globals": "^9.14.0",
-        "ignore": "^3.2.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.7.5",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
         }
       }
     },
-    "eslint-config-standard": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
-      "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
-      "dev": true
-    },
-    "eslint-config-standard-jsx": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
-      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
-      "dev": true
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
-      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0",
-        "object-assign": "^4.0.1",
-        "resolve": "^1.1.6"
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^2.0.0"
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
-      "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.1.1",
-        "contains-path": "^0.1.0",
-        "debug": "^2.2.0",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.2.0",
-        "eslint-module-utils": "^2.0.0",
-        "has": "^1.0.1",
-        "lodash.cond": "^4.3.0",
-        "minimatch": "^3.0.3",
-        "pkg-up": "^1.0.0"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
-      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
-      "dev": true,
-      "requires": {
-        "ignore": "^3.0.11",
-        "minimatch": "^3.0.2",
-        "object-assign": "^4.0.1",
-        "resolve": "^1.1.7",
-        "semver": "5.3.0"
-      }
-    },
-    "eslint-plugin-promise": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
-      "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
-      "dev": true
-    },
-    "eslint-plugin-react": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
-      "dev": true,
-      "requires": {
-        "array.prototype.find": "^2.0.1",
-        "doctrine": "^1.2.2",
-        "has": "^1.0.1",
-        "jsx-ast-utils": "^1.3.4",
-        "object.assign": "^4.0.4"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-standard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -962,35 +1247,35 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }
@@ -1007,16 +1292,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -1029,29 +1304,6 @@
         "split": "0.3",
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
-      }
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dev": true,
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
-          "dev": true
-        }
       }
     },
     "extend": {
@@ -1082,24 +1334,22 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "flat-cache": "^2.0.1"
       }
     },
-    "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "to-regex-range": "^5.0.1"
       }
     },
     "find-root": {
@@ -1118,25 +1368,27 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1202,29 +1454,24 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.0"
-      }
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1232,15 +1479,34 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
+      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        }
+      }
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
       "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
     },
     "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true
     },
     "getpass": {
@@ -1265,11 +1531,23 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.15",
@@ -1364,6 +1642,12 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1376,10 +1660,20 @@
       }
     },
     "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1409,32 +1703,16 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
       }
-    },
-    "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1442,17 +1720,29 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-      "dev": true
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -1460,52 +1750,65 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-my-json-valid": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
-      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "is-extglob": "^2.1.1"
       }
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        }
       }
     },
     "is-regexp": {
@@ -1513,10 +1816,10 @@
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-symbol": {
@@ -1605,9 +1908,9 @@
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -1651,14 +1954,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json-stable-stringify": {
+    "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1666,17 +1966,14 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1691,10 +1988,34 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
-      "dev": true
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.2",
+        "object.assign": "^4.1.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
+      }
     },
     "lcov-parse": {
       "version": "0.0.10",
@@ -1724,14 +2045,14 @@
       }
     },
     "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
         "strip-bom": "^3.0.0"
       }
     },
@@ -1751,56 +2072,73 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
-      "dev": true
-    },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "^2.0.1"
           }
         },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lru-cache": {
@@ -1869,58 +2207,73 @@
       "integrity": "sha1-LISJPtZ24NmPsY+5piEv0bK5qBk="
     },
     "mocha": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
-      "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
+      "integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
       "dev": true,
       "requires": {
-        "ansi-colors": "3.2.3",
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "debug": "3.2.6",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
+        "diff": "4.0.2",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "2.2.0",
+        "js-yaml": "3.14.0",
+        "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.4",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.5",
-        "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
+        "ms": "2.1.2",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
+        "which": "2.0.2",
         "wide-align": "1.1.3",
+        "workerpool": "6.0.2",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
         "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1932,73 +2285,82 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "p-locate": "^5.0.0"
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "yocto-queue": "^0.1.0"
           }
         },
         "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "^3.0.2"
           }
         },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -2008,10 +2370,10 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
       "dev": true
     },
     "natural-compare": {
@@ -2026,30 +2388,6 @@
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
       "dev": true
     },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
-    },
-    "node-environment-flags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
-      "dev": true,
-      "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -2059,10 +2397,40 @@
         "abbrev": "1"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
     "oauth-sign": {
@@ -2077,91 +2445,46 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
-    "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
-    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
-    "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+    "object.entries": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
       }
     },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+    "object.fromentries": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
+      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        }
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.values": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
+      "integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -2172,12 +2495,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
     },
     "optionator": {
       "version": "0.8.2",
@@ -2192,12 +2509,6 @@
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
       }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -2223,14 +2534,22 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -2245,11 +2564,26 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.0.0"
+      }
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -2265,10 +2599,16 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
     "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
@@ -2292,13 +2632,93 @@
       }
     },
     "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
       }
     },
     "pkg-config": {
@@ -2321,59 +2741,28 @@
         "find-up": "^2.1.0"
       }
     },
-    "pkg-up": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
-      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true,
-      "requires": {
-        "find-up": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        }
-      }
-    },
-    "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-      "dev": true
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -2398,6 +2787,15 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -2410,40 +2808,57 @@
         "strip-json-comments": "~2.0.1"
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "mute-stream": "0.0.5"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+    "readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "picomatch": "^2.2.1"
       }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
     },
     "request": {
       "version": "2.88.0",
@@ -2498,16 +2913,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      }
-    },
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -2515,20 +2920,10 @@
       "dev": true
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
-    },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
-      }
     },
     "rimraf": {
       "version": "2.6.3",
@@ -2555,27 +2950,6 @@
         }
       }
     },
-    "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0"
-      }
-    },
-    "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
-    },
-    "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -2589,10 +2963,39 @@
       "dev": true
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2600,32 +3003,20 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+        "shebang-regex": "^3.0.0"
       }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "should": {
       "version": "13.2.3",
@@ -2681,6 +3072,25 @@
       "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+          "dev": true
+        }
+      }
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -2688,10 +3098,32 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "source-map": {
       "version": "0.2.0",
@@ -2702,6 +3134,38 @@
       "requires": {
         "amdefine": ">=0.0.4"
       }
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true
     },
     "split": {
       "version": "0.3.3",
@@ -2735,32 +3199,39 @@
       }
     },
     "standard": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
-      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-16.0.3.tgz",
+      "integrity": "sha512-70F7NH0hSkNXosXRltjSv6KpTAOkUkSfyu3ynyM5dtRUiLtR+yX9EGZ7RKwuGUqCJiX/cnkceVM6HTZ4JpaqDg==",
       "dev": true,
       "requires": {
-        "eslint": "~3.19.0",
-        "eslint-config-standard": "10.2.1",
-        "eslint-config-standard-jsx": "4.0.2",
-        "eslint-plugin-import": "~2.2.0",
-        "eslint-plugin-node": "~4.2.2",
-        "eslint-plugin-promise": "~3.5.0",
-        "eslint-plugin-react": "~6.10.0",
-        "eslint-plugin-standard": "~3.0.1",
-        "standard-engine": "~7.0.0"
+        "eslint": "~7.13.0",
+        "eslint-config-standard": "16.0.2",
+        "eslint-config-standard-jsx": "10.0.0",
+        "eslint-plugin-import": "~2.22.1",
+        "eslint-plugin-node": "~11.1.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.21.5",
+        "standard-engine": "^14.0.1"
       }
     },
     "standard-engine": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
-      "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-14.0.1.tgz",
+      "integrity": "sha512-7FEzDwmHDOGva7r9ifOzD3BGdTbA7ujJ50afLVdW/tK14zQEptJjbFuUfn50irqdHDcTbNh0DTIoMPynMCXb0Q==",
       "dev": true,
       "requires": {
-        "deglob": "^2.1.0",
-        "get-stdin": "^5.0.1",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.5",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "stream-combiner": {
@@ -2772,277 +3243,53 @@
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
+            "ansi-regex": "^3.0.0"
           }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
+        }
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
+      "integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has-symbols": "^1.0.1",
+        "internal-slot": "^1.0.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3"
+      },
+      "dependencies": {
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
           "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
           "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
         }
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        }
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        }
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        }
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-object": {
@@ -3081,33 +3328,39 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
-        "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -3117,22 +3370,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -3147,6 +3401,15 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -3166,6 +3429,18 @@
         }
       }
     },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3181,12 +3456,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -3196,10 +3465,10 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "uglify-js": {
@@ -3222,12 +3491,6 @@
         }
       }
     },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -3236,26 +3499,27 @@
         "punycode": "^2.1.0"
       }
     },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "verror": {
       "version": "1.10.0",
@@ -3292,10 +3556,22 @@
         "string-width": "^1.0.2 || 2"
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "workerpool": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
       "dev": true
     },
     "wrap-ansi": {
@@ -3323,12 +3599,6 @@
           "requires": {
             "color-convert": "^1.9.0"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
@@ -3359,13 +3629,19 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",
@@ -3374,9 +3650,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {
@@ -3417,12 +3693,6 @@
           "requires": {
             "locate-path": "^3.0.0"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
         },
         "locate-path": {
           "version": "3.0.0",
@@ -3491,15 +3761,36 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,21 +2616,6 @@
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
       "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
     },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      },
-      "dependencies": {
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        }
-      }
-    },
     "pkg-conf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "xmlhttprequest"
   ],
   "engines": {
-    "node": ">=4"
+    "node": ">=10"
   },
   "files": [
     "bin",
@@ -57,6 +57,7 @@
     "codeclimate": "codeclimate < coverage/lcov.info"
   },
   "standard": {
+    "env": "mocha",
     "ignore": [
       "**/test/fixtures/**"
     ]
@@ -73,10 +74,10 @@
     "echint": "^4.0.2",
     "glob": "^6.0.1",
     "istanbul": "^0.4.0",
-    "mocha": "^6.2.0",
+    "mocha": "^8.2.1",
     "require-directory": "^2.1.1",
     "should": "^13.2.3",
-    "standard": "^10.0.2"
+    "standard": "^16.0.3"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "fs-readfile-promise": "^2.0.1",
     "fs-writefile-promise": "^1.0.3",
     "har-validator": "^5.0.0",
-    "pinkie-promise": "^2.0.0",
     "stringify-object": "^3.3.0"
   }
 }

--- a/src/helpers/code-builder.js
+++ b/src/helpers/code-builder.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+const util = require('util')
 
 /**
  * Helper object to format and aggragate lines of code.
@@ -11,7 +11,7 @@ var util = require('util')
  * @param {string} indentation Desired indentation character for aggregated lines of code
  * @param {string} join Desired character to join each line of code
  */
-var CodeBuilder = function (indentation, join) {
+const CodeBuilder = function (indentation, join) {
   this.code = []
   this.indentation = indentation
   this.lineJoin = join || '\n'
@@ -37,8 +37,8 @@ var CodeBuilder = function (indentation, join) {
  *   // returns: 'console.log("\t\thello world")'
  */
 CodeBuilder.prototype.buildLine = function (indentationLevel, line) {
-  var lineIndentation = ''
-  var slice = 2
+  let lineIndentation = ''
+  let slice = 2
   if (Object.prototype.toString.call(indentationLevel) === '[object String]') {
     slice = 1
     line = indentationLevel
@@ -52,7 +52,7 @@ CodeBuilder.prototype.buildLine = function (indentationLevel, line) {
     indentationLevel--
   }
 
-  var format = Array.prototype.slice.call(arguments, slice, arguments.length)
+  const format = Array.prototype.slice.call(arguments, slice, arguments.length)
   format.unshift(lineIndentation + line)
 
   return util.format.apply(this, format)

--- a/src/helpers/form-data.js
+++ b/src/helpers/form-data.js
@@ -74,8 +74,8 @@ function getHeader (boundary, name, field) {
 module.exports.getBoundary = () => {
   // This generates a 50 character boundary similar to those used by Firefox.
   // They are optimized for boyer-moore parsing.
-  var boundary = '--------------------------'
-  for (var i = 0; i < 24; i++) {
+  let boundary = '--------------------------'
+  for (let i = 0; i < 24; i++) {
     boundary += Math.floor(Math.random() * 10).toString(16)
   }
 

--- a/src/helpers/headers.js
+++ b/src/helpers/headers.js
@@ -18,6 +18,7 @@ module.exports = {
    * @return {string}
    */
   getHeaderName: (headers, name) => {
+    // eslint-disable-next-line array-callback-return
     return Object.keys(headers).find(k => {
       if (k.toLowerCase() === name.toLowerCase()) {
         return k

--- a/src/helpers/reducer.js
+++ b/src/helpers/reducer.js
@@ -13,7 +13,7 @@ module.exports = function (obj, pair) {
   }
 
   // convert to array
-  var arr = [
+  const arr = [
     obj[pair.name],
     pair.value
   ]

--- a/src/helpers/shell.js
+++ b/src/helpers/shell.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+const util = require('util')
 
 module.exports = {
   /**
@@ -9,7 +9,7 @@ module.exports = {
    * http://wiki.bash-hackers.org/syntax/quoting#strong_quoting
    */
   quote: function (value) {
-    var safe = /^[a-z0-9-_/.@%^=:]+$/i
+    const safe = /^[a-z0-9-_/.@%^=:]+$/i
 
     // Unless `value` is a simple shell-safe string, quote it.
     if (!safe.test(value)) {

--- a/src/targets/c/libcurl.js
+++ b/src/targets/c/libcurl.js
@@ -1,22 +1,22 @@
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var code = new CodeBuilder()
+  const code = new CodeBuilder()
 
   code.push('CURL *hnd = curl_easy_init();')
-      .blank()
-      .push('curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "%s");', source.method.toUpperCase())
-      .push('curl_easy_setopt(hnd, CURLOPT_URL, "%s");', source.fullUrl)
+    .blank()
+    .push('curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "%s");', source.method.toUpperCase())
+    .push('curl_easy_setopt(hnd, CURLOPT_URL, "%s");', source.fullUrl)
 
   // Add headers, including the cookies
-  var headers = Object.keys(source.headersObj)
+  const headers = Object.keys(source.headersObj)
 
   // construct headers
   if (headers.length) {
     code.blank()
-        .push('struct curl_slist *headers = NULL;')
+      .push('struct curl_slist *headers = NULL;')
 
     headers.forEach(function (key) {
       code.push('headers = curl_slist_append(headers, "%s: %s");', key, source.headersObj[key])
@@ -28,16 +28,16 @@ module.exports = function (source, options) {
   // construct cookies
   if (source.allHeaders.cookie) {
     code.blank()
-        .push('curl_easy_setopt(hnd, CURLOPT_COOKIE, "%s");', source.allHeaders.cookie)
+      .push('curl_easy_setopt(hnd, CURLOPT_COOKIE, "%s");', source.allHeaders.cookie)
   }
 
   if (source.postData.text) {
     code.blank()
-        .push('curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, %s);', JSON.stringify(source.postData.text))
+      .push('curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, %s);', JSON.stringify(source.postData.text))
   }
 
   code.blank()
-      .push('CURLcode ret = curl_easy_perform(hnd);')
+    .push('CURLcode ret = curl_easy_perform(hnd);')
 
   return code.join()
 }

--- a/src/targets/csharp/httpclient.js
+++ b/src/targets/csharp/httpclient.js
@@ -1,23 +1,23 @@
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
-var helpers = require('../../helpers/headers')
+const CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('../../helpers/headers')
 
 function getDecompressionMethods (source) {
-  var acceptEncoding = helpers.getHeader(source.allHeaders, 'accept-encoding')
+  const acceptEncoding = helpers.getHeader(source.allHeaders, 'accept-encoding')
   if (!acceptEncoding) {
     return [] // no decompression
   }
 
-  var supportedMethods = {
+  const supportedMethods = {
     gzip: 'DecompressionMethods.GZip',
     deflate: 'DecompressionMethods.Deflate'
   }
-  var methods = []
+  const methods = []
   acceptEncoding.split(',').forEach(function (encoding) {
-    var match = /\s*([^;\s]+)/.exec(encoding)
+    const match = /\s*([^;\s]+)/.exec(encoding)
     if (match) {
-      var method = supportedMethods[match[1]]
+      const method = supportedMethods[match[1]]
       if (method) {
         methods.push(method)
       }
@@ -28,12 +28,15 @@ function getDecompressionMethods (source) {
 }
 
 module.exports = function (source, options) {
-  var indentation = '    '
-  var code = new CodeBuilder(indentation)
+  const opts = Object.assign({
+    indent: '    '
+  }, options)
 
-  var clienthandler = ''
-  var cookies = !!source.allHeaders.cookie
-  var decompressionMethods = getDecompressionMethods(source)
+  const code = new CodeBuilder(opts.indent)
+
+  let clienthandler = ''
+  const cookies = !!source.allHeaders.cookie
+  const decompressionMethods = getDecompressionMethods(source)
   if (cookies || decompressionMethods.length) {
     clienthandler = 'clientHandler'
     code.push('var clientHandler = new HttpClientHandler')
@@ -54,8 +57,8 @@ module.exports = function (source, options) {
   code.push('var request = new HttpRequestMessage')
   code.push('{')
 
-  var methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE' ]
-  var method = source.method.toUpperCase()
+  const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE']
+  let method = source.method.toUpperCase()
   if (method && (methods.indexOf(method) !== -1)) {
     // buildin method
     method = `HttpMethod.${method[0]}${method.substring(1).toLowerCase()}`
@@ -67,7 +70,7 @@ module.exports = function (source, options) {
 
   code.push(1, 'RequestUri = new Uri("%s"),', source.fullUrl)
 
-  var headers = Object.keys(source.allHeaders).filter(function (header) {
+  const headers = Object.keys(source.allHeaders).filter(function (header) {
     switch (header.toLowerCase()) {
       case 'content-type':
       case 'content-length':

--- a/src/targets/csharp/restsharp.js
+++ b/src/targets/csharp/restsharp.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
-var helpers = require('../../helpers/headers')
+const CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('../../helpers/headers')
 
 module.exports = function (source, options) {
-  var code = new CodeBuilder()
-  var methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS' ]
+  const code = new CodeBuilder()
+  const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
 
   if (methods.indexOf(source.method.toUpperCase()) === -1) {
     return 'Method not supported'
@@ -15,7 +15,7 @@ module.exports = function (source, options) {
   }
 
   // Add headers, including the cookies
-  var headers = Object.keys(source.headersObj)
+  const headers = Object.keys(source.headersObj)
 
   // construct headers
   if (headers.length) {

--- a/src/targets/go/native.js
+++ b/src/targets/go/native.js
@@ -10,25 +10,25 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
   // Let's Go!
-  var code = new CodeBuilder('\t')
+  const code = new CodeBuilder('\t')
 
   // Define Options
-  var opts = Object.assign({
+  const opts = Object.assign({
     showBoilerplate: true,
     checkErrors: false,
     printBody: true,
     timeout: -1
   }, options)
 
-  var errorPlaceholder = opts.checkErrors ? 'err' : '_'
+  const errorPlaceholder = opts.checkErrors ? 'err' : '_'
 
-  var indent = opts.showBoilerplate ? 1 : 0
+  const indent = opts.showBoilerplate ? 1 : 0
 
-  var errorCheck = function () {
+  const errorCheck = function () {
     if (opts.checkErrors) {
       code.push(indent, 'if err != nil {')
         .push(indent + 1, 'panic(err)')
@@ -64,7 +64,7 @@ module.exports = function (source, options) {
   }
 
   // Create client
-  var client
+  let client
   if (opts.timeout > 0) {
     client = 'client'
     code.push(indent, 'client := http.Client{')

--- a/src/targets/http/http1.1.js
+++ b/src/targets/http/http1.1.js
@@ -11,9 +11,9 @@
 
 'use strict'
 
-var CRLF = '\r\n'
-var CodeBuilder = require('../../helpers/code-builder')
-var util = require('util')
+const CRLF = '\r\n'
+const CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
 
 /**
  * Request follows the request message format in accordance to RFC 7230, Section 3.
@@ -21,7 +21,7 @@ var util = require('util')
  * See more at https://tools.ietf.org/html/rfc7230#section-3.
  */
 module.exports = function (source, options) {
-  var opts = Object.assign(
+  const opts = Object.assign(
     {
       absoluteURI: false,
       autoContentLength: true,
@@ -32,12 +32,12 @@ module.exports = function (source, options) {
 
   // RFC 7230 Section 3. Message Format
   // All lines have no indentation, and should be terminated with CRLF.
-  var code = new CodeBuilder('', CRLF)
+  const code = new CodeBuilder('', CRLF)
 
   // RFC 7230 Section 5.3. Request Target
   // Determines if the Request-Line should use 'absolute-form' or 'origin-form'.
   // Basically it means whether the "http://domain.com" will prepend the full url.
-  var requestUrl = opts.absoluteURI ? source.fullUrl : source.uriObj.path
+  const requestUrl = opts.absoluteURI ? source.fullUrl : source.uriObj.path
 
   // RFC 7230 Section 3.1.1. Request-Line
   code.push('%s %s %s', source.method, requestUrl, source.httpVersion)
@@ -45,7 +45,7 @@ module.exports = function (source, options) {
   // RFC 7231 Section 5. Header Fields
   Object.keys(source.allHeaders).forEach(function (key) {
     // Capitalize header keys, even though it's not required by the spec.
-    var keyCapitalized = key.toLowerCase().replace(/(^|-)(\w)/g, function (x) {
+    const keyCapitalized = key.toLowerCase().replace(/(^|-)(\w)/g, function (x) {
       return x.toUpperCase()
     })
 
@@ -78,8 +78,8 @@ module.exports = function (source, options) {
   code.blank()
 
   // Separate header section and message body section.
-  var headerSection = code.join()
-  var messageBody = ''
+  const headerSection = code.join()
+  let messageBody = ''
 
   // RFC 7230 Section 3.3. Message Body
   if (source.postData.text) {

--- a/src/targets/http/index.js
+++ b/src/targets/http/index.js
@@ -8,5 +8,5 @@ module.exports = {
     default: '1.1'
   },
 
-  '1.1': require('./http1.1')
+  1.1: require('./http1.1')
 }

--- a/src/targets/java/asynchttp.js
+++ b/src/targets/java/asynchttp.js
@@ -10,21 +10,21 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   code.push('AsyncHttpClient client = new DefaultAsyncHttpClient();')
 
   code.push(`client.prepare("${source.method.toUpperCase()}", "${source.fullUrl}")`)
 
   // Add headers, including the cookies
-  var headers = Object.keys(source.allHeaders)
+  const headers = Object.keys(source.allHeaders)
 
   // construct headers
   if (headers.length) {

--- a/src/targets/java/nethttp.js
+++ b/src/targets/java/nethttp.js
@@ -10,22 +10,22 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign(
+  const opts = Object.assign(
     {
       indent: '  '
     },
     options
   )
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   code.push('HttpRequest request = HttpRequest.newBuilder()')
   code.push(2, '.uri(URI.create("%s"))', source.fullUrl)
 
-  var headers = Object.keys(source.allHeaders)
+  const headers = Object.keys(source.allHeaders)
 
   // construct headers
   if (headers.length) {

--- a/src/targets/java/okhttp.js
+++ b/src/targets/java/okhttp.js
@@ -10,18 +10,18 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
-  var methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD']
+  const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD']
 
-  var methodsWithBody = ['POST', 'PUT', 'DELETE', 'PATCH']
+  const methodsWithBody = ['POST', 'PUT', 'DELETE', 'PATCH']
 
   code.push('OkHttpClient client = new OkHttpClient();')
     .blank()
@@ -54,7 +54,7 @@ module.exports = function (source, options) {
   }
 
   // Add headers, including the cookies
-  var headers = Object.keys(source.allHeaders)
+  const headers = Object.keys(source.allHeaders)
 
   // construct headers
   if (headers.length) {

--- a/src/targets/java/unirest.js
+++ b/src/targets/java/unirest.js
@@ -10,16 +10,16 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
-  var methods = [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS' ]
+  const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
 
   if (methods.indexOf(source.method.toUpperCase()) === -1) {
     code.push('HttpResponse<String> response = Unirest.customMethod("%s","%s")', source.method.toUpperCase(), source.fullUrl)
@@ -28,7 +28,7 @@ module.exports = function (source, options) {
   }
 
   // Add headers, including the cookies
-  var headers = Object.keys(source.allHeaders)
+  const headers = Object.keys(source.allHeaders)
 
   // construct headers
   if (headers.length) {

--- a/src/targets/javascript/axios.js
+++ b/src/targets/javascript/axios.js
@@ -9,21 +9,21 @@
  */
 'use strict'
 
-var util = require('util')
-var stringifyObject = require('stringify-object')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const stringifyObject = require('stringify-object')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   code.push('import axios from "axios";')
-      .blank()
+    .blank()
 
-  var reqOpts = {
+  const reqOpts = {
     method: source.method,
     url: source.url
   }
@@ -73,10 +73,10 @@ module.exports = function (source, options) {
     .blank()
 
   code.push(util.format('axios.request(options).then(%s', 'function (response) {'))
-      .push(1, 'console.log(response.data);')
-      .push('}).catch(%s', 'function (error) {')
-      .push(1, 'console.error(error);')
-      .push('});')
+    .push(1, 'console.log(response.data);')
+    .push('}).catch(%s', 'function (error) {')
+    .push(1, 'console.error(error);')
+    .push('});')
 
   return code.join()
 }

--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -10,10 +10,10 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign(
+  const opts = Object.assign(
     {
       indent: '  ',
       credentials: null
@@ -21,7 +21,7 @@ module.exports = function (source, options) {
     options
   )
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   options = {
     method: source.method,

--- a/src/targets/javascript/jquery.js
+++ b/src/targets/javascript/jquery.js
@@ -10,17 +10,17 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
-var helpers = require('../../helpers/headers')
+const CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('../../helpers/headers')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
-  var settings = {
+  const settings = {
     async: true,
     crossDomain: true,
     url: source.fullUrl,
@@ -67,10 +67,10 @@ module.exports = function (source, options) {
   }
 
   code.push('const settings = ' + JSON.stringify(settings, null, opts.indent).replace('"[form]"', 'form') + ';')
-      .blank()
-      .push('$.ajax(settings).done(function (response) {')
-      .push(1, 'console.log(response);')
-      .push('});')
+    .blank()
+    .push('$.ajax(settings).done(function (response) {')
+    .push(1, 'console.log(response);')
+    .push('});')
 
   return code.join()
 }

--- a/src/targets/javascript/xhr.js
+++ b/src/targets/javascript/xhr.js
@@ -10,21 +10,21 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
-var helpers = require('../../helpers/headers')
+const CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('../../helpers/headers')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  ',
     cors: true
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   switch (source.postData.mimeType) {
     case 'application/json':
       code.push('const data = JSON.stringify(%s);', JSON.stringify(source.postData.jsonObj, null, opts.indent))
-          .push(null)
+        .push(null)
       break
 
     case 'multipart/form-data':
@@ -46,7 +46,7 @@ module.exports = function (source, options) {
 
     default:
       code.push('const data = %s;', JSON.stringify(source.postData.text || null))
-          .blank()
+        .blank()
   }
 
   code.push('const xhr = new XMLHttpRequest();')
@@ -56,20 +56,20 @@ module.exports = function (source, options) {
   }
 
   code.blank()
-      .push('xhr.addEventListener("readystatechange", function () {')
-      .push(1, 'if (this.readyState === this.DONE) {')
-      .push(2, 'console.log(this.responseText);')
-      .push(1, '}')
-      .push('});')
-      .blank()
-      .push('xhr.open(%s, %s);', JSON.stringify(source.method), JSON.stringify(source.fullUrl))
+    .push('xhr.addEventListener("readystatechange", function () {')
+    .push(1, 'if (this.readyState === this.DONE) {')
+    .push(2, 'console.log(this.responseText);')
+    .push(1, '}')
+    .push('});')
+    .blank()
+    .push('xhr.open(%s, %s);', JSON.stringify(source.method), JSON.stringify(source.fullUrl))
 
   Object.keys(source.allHeaders).forEach(function (key) {
     code.push('xhr.setRequestHeader(%s, %s);', JSON.stringify(key), JSON.stringify(source.allHeaders[key]))
   })
 
   code.blank()
-      .push('xhr.send(data);')
+    .push('xhr.send(data);')
 
   return code.join()
 }

--- a/src/targets/kotlin/okhttp.js
+++ b/src/targets/kotlin/okhttp.js
@@ -10,18 +10,18 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
-  var methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD']
+  const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD']
 
-  var methodsWithBody = ['POST', 'PUT', 'DELETE', 'PATCH']
+  const methodsWithBody = ['POST', 'PUT', 'DELETE', 'PATCH']
 
   code.push('val client = OkHttpClient()')
     .blank()
@@ -54,7 +54,7 @@ module.exports = function (source, options) {
   }
 
   // Add headers, including the cookies
-  var headers = Object.keys(source.allHeaders)
+  const headers = Object.keys(source.allHeaders)
 
   // construct headers
   if (headers.length) {

--- a/src/targets/node/axios.js
+++ b/src/targets/node/axios.js
@@ -9,21 +9,21 @@
  */
 'use strict'
 
-var util = require('util')
-var stringifyObject = require('stringify-object')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const stringifyObject = require('stringify-object')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   code.push('var axios = require("axios").default;')
-      .blank()
+    .blank()
 
-  var reqOpts = {
+  const reqOpts = {
     method: source.method,
     url: source.url
   }
@@ -57,10 +57,10 @@ module.exports = function (source, options) {
     .blank()
 
   code.push(util.format('axios.request(options).then(%s', 'function (response) {'))
-      .push(1, 'console.log(response.data);')
-      .push('}).catch(%s', 'function (error) {')
-      .push(1, 'console.error(error);')
-      .push('});')
+    .push(1, 'console.log(response.data);')
+    .push('}).catch(%s', 'function (error) {')
+    .push(1, 'console.error(error);')
+    .push('});')
 
   return code.join()
 }

--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -10,20 +10,20 @@
 
 'use strict'
 
-var stringifyObject = require('stringify-object')
-var CodeBuilder = require('../../helpers/code-builder')
+const stringifyObject = require('stringify-object')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var includeFS = false
-  var code = new CodeBuilder(opts.indent)
+  let includeFS = false
+  const code = new CodeBuilder(opts.indent)
 
   code.push('const fetch = require(\'node-fetch\');')
-  var url = source.url
-  var reqOpts = {
+  const url = source.url
+  const reqOpts = {
     method: source.method
   }
 
@@ -80,7 +80,7 @@ module.exports = function (source, options) {
 
   // construct cookies argument
   if (source.cookies.length) {
-    var cookies = ''
+    let cookies = ''
     source.cookies.forEach(function (cookie) {
       cookies = cookies + encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value) + '; '
     })
@@ -105,9 +105,9 @@ module.exports = function (source, options) {
       .blank()
   }
   code.push('fetch(url, options)')
-      .push(1, '.then(res => res.json())')
-      .push(1, '.then(json => console.log(json))')
-      .push(1, '.catch(err => console.error(\'error:\' + err));')
+    .push(1, '.then(res => res.json())')
+    .push(1, '.then(json => console.log(json))')
+    .push(1, '.catch(err => console.error(\'error:\' + err));')
 
   return code.join()
     .replace(/'encodedParams'/, 'encodedParams')

--- a/src/targets/node/native.js
+++ b/src/targets/node/native.js
@@ -10,17 +10,17 @@
 
 'use strict'
 
-var stringifyObject = require('stringify-object')
-var CodeBuilder = require('../../helpers/code-builder')
+const stringifyObject = require('stringify-object')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
-  var reqOpts = {
+  const reqOpts = {
     method: source.method,
     hostname: source.uriObj.hostname,
     port: source.uriObj.port,
@@ -31,21 +31,21 @@ module.exports = function (source, options) {
   code.push('const http = require("%s");', source.uriObj.protocol.replace(':', ''))
 
   code.blank()
-      .push('const options = %s;', JSON.stringify(reqOpts, null, opts.indent))
-      .blank()
-      .push('const req = http.request(options, function (res) {')
-      .push(1, 'const chunks = [];')
-      .blank()
-      .push(1, 'res.on("data", function (chunk) {')
-      .push(2, 'chunks.push(chunk);')
-      .push(1, '});')
-      .blank()
-      .push(1, 'res.on("end", function () {')
-      .push(2, 'const body = Buffer.concat(chunks);')
-      .push(2, 'console.log(body.toString());')
-      .push(1, '});')
-      .push('});')
-      .blank()
+    .push('const options = %s;', JSON.stringify(reqOpts, null, opts.indent))
+    .blank()
+    .push('const req = http.request(options, function (res) {')
+    .push(1, 'const chunks = [];')
+    .blank()
+    .push(1, 'res.on("data", function (chunk) {')
+    .push(2, 'chunks.push(chunk);')
+    .push(1, '});')
+    .blank()
+    .push(1, 'res.on("end", function () {')
+    .push(2, 'const body = Buffer.concat(chunks);')
+    .push(2, 'console.log(body.toString());')
+    .push(1, '});')
+    .push('});')
+    .blank()
 
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':

--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -10,22 +10,22 @@
 
 'use strict'
 
-var util = require('util')
-var stringifyObject = require('stringify-object')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const stringifyObject = require('stringify-object')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var includeFS = false
-  var code = new CodeBuilder(opts.indent)
+  let includeFS = false
+  const code = new CodeBuilder(opts.indent)
 
   code.push("const request = require('request');")
-      .blank()
+    .blank()
 
-  var reqOpts = {
+  const reqOpts = {
     method: source.method,
     url: source.url
   }
@@ -54,7 +54,7 @@ module.exports = function (source, options) {
       reqOpts.formData = {}
 
       source.postData.params.forEach(function (param) {
-        var attachment = {}
+        const attachment = {}
 
         if (!param.fileName && !param.fileName && !param.contentType) {
           reqOpts.formData[param.name] = param.value
@@ -92,7 +92,7 @@ module.exports = function (source, options) {
 
     code.push('const jar = request.jar();')
 
-    var url = source.url
+    const url = source.url
 
     source.cookies.forEach(function (cookie) {
       code.push("jar.setCookie(request.cookie('%s=%s'), '%s');", encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), url)
@@ -109,11 +109,11 @@ module.exports = function (source, options) {
 
   code.push(util.format('request(options, %s', 'function (error, response, body) {'))
 
-      .push(1, 'if (error) throw new Error(error);')
-      .blank()
-      .push(1, 'console.log(body);')
-      .push('});')
-      .blank()
+    .push(1, 'if (error) throw new Error(error);')
+    .blank()
+    .push(1, 'console.log(body);')
+    .push('});')
+    .blank()
 
   return code.join().replace('"JAR"', 'jar').replace(/'fs\.createReadStream\("(.+)"\)'/g, "fs.createReadStream('$1')")
 }

--- a/src/targets/node/unirest.js
+++ b/src/targets/node/unirest.js
@@ -10,20 +10,20 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var includeFS = false
-  var code = new CodeBuilder(opts.indent)
+  let includeFS = false
+  const code = new CodeBuilder(opts.indent)
 
   code.push('const unirest = require("unirest");')
-      .blank()
-      .push('const req = unirest("%s", "%s");', source.method, source.url)
-      .blank()
+    .blank()
+    .push('const req = unirest("%s", "%s");', source.method, source.url)
+    .blank()
 
   if (source.cookies.length) {
     code.push('const CookieJar = unirest.jar();')
@@ -38,12 +38,12 @@ module.exports = function (source, options) {
 
   if (Object.keys(source.queryObj).length) {
     code.push('req.query(%s);', JSON.stringify(source.queryObj, null, opts.indent))
-        .blank()
+      .blank()
   }
 
   if (Object.keys(source.headersObj).length) {
     code.push('req.headers(%s);', JSON.stringify(source.headersObj, null, opts.indent))
-        .blank()
+      .blank()
   }
 
   switch (source.postData.mimeType) {
@@ -57,16 +57,16 @@ module.exports = function (source, options) {
     case 'application/json':
       if (source.postData.jsonObj) {
         code.push('req.type("json");')
-            .push('req.send(%s);', JSON.stringify(source.postData.jsonObj, null, opts.indent))
-            .blank()
+          .push('req.send(%s);', JSON.stringify(source.postData.jsonObj, null, opts.indent))
+          .blank()
       }
       break
 
-    case 'multipart/form-data':
-      var multipart = []
+    case 'multipart/form-data': {
+      const multipart = []
 
       source.postData.params.forEach(function (param) {
-        var part = {}
+        const part = {}
 
         if (param.fileName && !param.value) {
           includeFS = true
@@ -88,6 +88,7 @@ module.exports = function (source, options) {
       code.push('req.multipart(%s);', JSON.stringify(multipart, null, opts.indent))
         .blank()
       break
+    }
 
     default:
       if (source.postData.text) {
@@ -101,11 +102,11 @@ module.exports = function (source, options) {
   }
 
   code.push('req.end(function (res) {')
-      .push(1, 'if (res.error) throw new Error(res.error);')
-      .blank()
-      .push(1, 'console.log(res.body);')
-      .push('});')
-      .blank()
+    .push(1, 'if (res.error) throw new Error(res.error);')
+    .blank()
+    .push(1, 'console.log(res.body);')
+    .push('});')
+    .blank()
 
   return code.join().replace(/"fs\.createReadStream\(\\"(.+)\\"\)"/, 'fs.createReadStream("$1")')
 }

--- a/src/targets/objc/helpers.js
+++ b/src/targets/objc/helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+const util = require('util')
 
 module.exports = {
   /**
@@ -33,8 +33,8 @@ module.exports = {
    *   NSDictionary *params = @{ @"a": @"b", @"c": @"d" };
    */
   nsDeclaration: function (nsClass, name, parameters, indent) {
-    var opening = nsClass + ' *' + name + ' = '
-    var literal = this.literalRepresentation(parameters, indent ? opening.length : undefined)
+    const opening = nsClass + ' *' + name + ' = '
+    const literal = this.literalRepresentation(parameters, indent ? opening.length : undefined)
     return opening + literal + ';'
   },
 
@@ -45,24 +45,30 @@ module.exports = {
    * @return {string}
    */
   literalRepresentation: function (value, indentation) {
-    var join = indentation === undefined ? ', ' : ',\n   ' + this.blankString(indentation)
+    const join = indentation === undefined ? ', ' : ',\n   ' + this.blankString(indentation)
 
     switch (Object.prototype.toString.call(value)) {
       case '[object Number]':
         return '@' + value
-      case '[object Array]':
-        var valuesRepresentation = value.map(function (v) {
+
+      case '[object Array]': {
+        const valuesRepresentation = value.map(function (v) {
           return this.literalRepresentation(v)
         }.bind(this))
         return '@[ ' + valuesRepresentation.join(join) + ' ]'
-      case '[object Object]':
-        var keyValuePairs = []
-        for (var k in value) {
+      }
+
+      case '[object Object]': {
+        const keyValuePairs = []
+        for (const k in value) {
           keyValuePairs.push(util.format('@"%s": %s', k, this.literalRepresentation(value[k])))
         }
         return '@{ ' + keyValuePairs.join(join) + ' }'
+      }
+
       case '[object Boolean]':
         return value ? '@YES' : '@NO'
+
       default:
         if (value === null || value === undefined) {
           return ''

--- a/src/targets/objc/nsurlsession.js
+++ b/src/targets/objc/nsurlsession.js
@@ -10,19 +10,19 @@
 
 'use strict'
 
-var helpers = require('./helpers')
-var CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('./helpers')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '    ',
     pretty: true,
     timeout: '10'
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
-  // Markers for headers to be created as litteral objects and later be set on the NSURLRequest if exist
-  var req = {
+  const code = new CodeBuilder(opts.indent)
+  // Markers for headers to be created as literal objects and later be set on the NSURLRequest if exist
+  const req = {
     hasHeaders: false,
     hasBody: false
   }
@@ -33,7 +33,7 @@ module.exports = function (source, options) {
   if (Object.keys(source.allHeaders).length) {
     req.hasHeaders = true
     code.blank()
-        .push(helpers.nsDeclaration('NSDictionary', 'headers', source.allHeaders, opts.pretty))
+      .push(helpers.nsDeclaration('NSDictionary', 'headers', source.allHeaders, opts.pretty))
   }
 
   if (source.postData.text || source.postData.jsonObj || source.postData.params) {
@@ -45,9 +45,10 @@ module.exports = function (source, options) {
         // we make it easier for the user to edit it according to his or her needs after pasting.
         // The user can just add/remove lines adding/removing body parameters.
         code.blank()
-            .push('NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
-          source.postData.params[0].name, source.postData.params[0].value)
-        for (var i = 1, len = source.postData.params.length; i < len; i++) {
+          .push('NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
+            source.postData.params[0].name, source.postData.params[0].value)
+
+        for (let i = 1, len = source.postData.params.length; i < len; i++) {
           code.push('[postData appendData:[@"&%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
             source.postData.params[i].name, source.postData.params[i].value)
         }
@@ -56,8 +57,8 @@ module.exports = function (source, options) {
       case 'application/json':
         if (source.postData.jsonObj) {
           code.push(helpers.nsDeclaration('NSDictionary', 'parameters', source.postData.jsonObj, opts.pretty))
-              .blank()
-              .push('NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];')
+            .blank()
+            .push('NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];')
         }
         break
 
@@ -66,40 +67,40 @@ module.exports = function (source, options) {
         // we make it easier for the user to edit it according to his or her needs after pasting.
         // The user can just edit the parameters NSDictionary or put this part of a snippet in a multipart builder method.
         code.push(helpers.nsDeclaration('NSArray', 'parameters', source.postData.params, opts.pretty))
-            .push('NSString *boundary = @"%s";', source.postData.boundary)
-            .blank()
-            .push('NSError *error;')
-            .push('NSMutableString *body = [NSMutableString string];')
-            .push('for (NSDictionary *param in parameters) {')
-            .push(1, '[body appendFormat:@"--%@\\r\\n", boundary];')
-            .push(1, 'if (param[@"fileName"]) {')
-            .push(2, '[body appendFormat:@"Content-Disposition:form-data; name=\\"%@\\"; filename=\\"%@\\"\\r\\n", param[@"name"], param[@"fileName"]];')
-            .push(2, '[body appendFormat:@"Content-Type: %@\\r\\n\\r\\n", param[@"contentType"]];')
-            .push(2, '[body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];')
-            .push(2, 'if (error) {')
-            .push(3, 'NSLog(@"%@", error);')
-            .push(2, '}')
-            .push(1, '} else {')
-            .push(2, '[body appendFormat:@"Content-Disposition:form-data; name=\\"%@\\"\\r\\n\\r\\n", param[@"name"]];')
-            .push(2, '[body appendFormat:@"%@", param[@"value"]];')
-            .push(1, '}')
-            .push('}')
-            .push('[body appendFormat:@"\\r\\n--%@--\\r\\n", boundary];')
-            .push('NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];')
+          .push('NSString *boundary = @"%s";', source.postData.boundary)
+          .blank()
+          .push('NSError *error;')
+          .push('NSMutableString *body = [NSMutableString string];')
+          .push('for (NSDictionary *param in parameters) {')
+          .push(1, '[body appendFormat:@"--%@\\r\\n", boundary];')
+          .push(1, 'if (param[@"fileName"]) {')
+          .push(2, '[body appendFormat:@"Content-Disposition:form-data; name=\\"%@\\"; filename=\\"%@\\"\\r\\n", param[@"name"], param[@"fileName"]];')
+          .push(2, '[body appendFormat:@"Content-Type: %@\\r\\n\\r\\n", param[@"contentType"]];')
+          .push(2, '[body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];')
+          .push(2, 'if (error) {')
+          .push(3, 'NSLog(@"%@", error);')
+          .push(2, '}')
+          .push(1, '} else {')
+          .push(2, '[body appendFormat:@"Content-Disposition:form-data; name=\\"%@\\"\\r\\n\\r\\n", param[@"name"]];')
+          .push(2, '[body appendFormat:@"%@", param[@"value"]];')
+          .push(1, '}')
+          .push('}')
+          .push('[body appendFormat:@"\\r\\n--%@--\\r\\n", boundary];')
+          .push('NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];')
         break
 
       default:
         code.blank()
-            .push('NSData *postData = [[NSData alloc] initWithData:[@"' + source.postData.text + '" dataUsingEncoding:NSUTF8StringEncoding]];')
+          .push('NSData *postData = [[NSData alloc] initWithData:[@"' + source.postData.text + '" dataUsingEncoding:NSUTF8StringEncoding]];')
     }
   }
 
   code.blank()
-      .push('NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"' + source.fullUrl + '"]')
-      // NSURLRequestUseProtocolCachePolicy is the default policy, let's just always set it to avoid confusion.
-      .push('                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy')
-      .push('                                                   timeoutInterval:' + parseInt(opts.timeout, 10).toFixed(1) + '];')
-      .push('[request setHTTPMethod:@"' + source.method + '"];')
+    .push('NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"' + source.fullUrl + '"]')
+    // NSURLRequestUseProtocolCachePolicy is the default policy, let's just always set it to avoid confusion.
+    .push('                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy')
+    .push('                                                   timeoutInterval:' + parseInt(opts.timeout, 10).toFixed(1) + '];')
+    .push('[request setHTTPMethod:@"' + source.method + '"];')
 
   if (req.hasHeaders) {
     code.push('[request setAllHTTPHeaderFields:headers];')
@@ -110,19 +111,19 @@ module.exports = function (source, options) {
   }
 
   code.blank()
-      // Retrieving the shared session will be less verbose than creating a new one.
-      .push('NSURLSession *session = [NSURLSession sharedSession];')
-      .push('NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request')
-      .push('                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {')
-      .push(1, '                                            if (error) {')
-      .push(2, '                                            NSLog(@"%@", error);')
-      .push(1, '                                            } else {')
-      // Casting the NSURLResponse to NSHTTPURLResponse so the user can see the status     .
-      .push(2, '                                            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;')
-      .push(2, '                                            NSLog(@"%@", httpResponse);')
-      .push(1, '                                            }')
-      .push('                                            }];')
-      .push('[dataTask resume];')
+    // Retrieving the shared session will be less verbose than creating a new one.
+    .push('NSURLSession *session = [NSURLSession sharedSession];')
+    .push('NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request')
+    .push('                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {')
+    .push(1, '                                            if (error) {')
+    .push(2, '                                            NSLog(@"%@", error);')
+    .push(1, '                                            } else {')
+    // Casting the NSURLResponse to NSHTTPURLResponse so the user can see the status     .
+    .push(2, '                                            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;')
+    .push(2, '                                            NSLog(@"%@", httpResponse);')
+    .push(1, '                                            }')
+    .push('                                            }];')
+    .push('[dataTask resume];')
 
   return code.join()
 }

--- a/src/targets/ocaml/cohttp.js
+++ b/src/targets/ocaml/cohttp.js
@@ -10,24 +10,24 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  '
   }, options)
 
-  var methods = ['get', 'post', 'head', 'delete', 'patch', 'put', 'options']
-  var code = new CodeBuilder(opts.indent)
+  const methods = ['get', 'post', 'head', 'delete', 'patch', 'put', 'options']
+  const code = new CodeBuilder(opts.indent)
 
   code.push('open Cohttp_lwt_unix')
-      .push('open Cohttp')
-      .push('open Lwt')
-      .blank()
-      .push('let uri = Uri.of_string "%s" in', source.fullUrl)
+    .push('open Cohttp')
+    .push('open Lwt')
+    .blank()
+    .push('let uri = Uri.of_string "%s" in', source.fullUrl)
 
   // Add headers, including the cookies
-  var headers = Object.keys(source.allHeaders)
+  const headers = Object.keys(source.allHeaders)
 
   if (headers.length === 1) {
     code.push('let headers = Header.add (Header.init ()) "%s" "%s" in', headers[0], source.allHeaders[headers[0]])
@@ -58,7 +58,7 @@ module.exports = function (source, options) {
 
   // Catch result
   code.push('>>= fun (res, body_stream) ->')
-      .push(1, '(* Do stuff with the result *)')
+    .push(1, '(* Do stuff with the result *)')
 
   return code.join()
 }

--- a/src/targets/php/curl.js
+++ b/src/targets/php/curl.js
@@ -10,11 +10,11 @@
 
 'use strict'
 
-var util = require('util')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     closingTag: false,
     indent: '  ',
     maxRedirects: 10,
@@ -24,7 +24,7 @@ module.exports = function (source, options) {
     timeout: 30
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   if (!opts.noTags) {
     code.push(opts.shortTags ? '<?' : '<?php')
@@ -34,7 +34,7 @@ module.exports = function (source, options) {
   code.push('$curl = curl_init();')
     .blank()
 
-  var curlOptions = [{
+  const curlOptions = [{
     escape: true,
     name: 'CURLOPT_PORT',
     value: source.uriObj.port
@@ -74,7 +74,7 @@ module.exports = function (source, options) {
 
   code.push('curl_setopt_array($curl, [')
 
-  var curlopts = new CodeBuilder(opts.indent, '\n' + opts.indent)
+  const curlopts = new CodeBuilder(opts.indent, '\n' + opts.indent)
 
   curlOptions.forEach(function (option) {
     if (!~[null, undefined].indexOf(option.value)) {
@@ -83,7 +83,7 @@ module.exports = function (source, options) {
   })
 
   // construct cookies
-  var cookies = source.cookies.map(function (cookie) {
+  const cookies = source.cookies.map(function (cookie) {
     return encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value)
   })
 
@@ -92,7 +92,7 @@ module.exports = function (source, options) {
   }
 
   // construct cookies
-  var headers = Object.keys(source.headersObj).sort().map(function (key) {
+  const headers = Object.keys(source.headersObj).sort().map(function (key) {
     return util.format('"%s: %s"', key, source.headersObj[key])
   })
 

--- a/src/targets/php/helpers.js
+++ b/src/targets/php/helpers.js
@@ -1,7 +1,7 @@
 'use strict'
 
-var convert = function (obj, indent, lastIndent) {
-  var i, result
+const convert = function (obj, indent, lastIndent) {
+  let i, result
 
   if (!lastIndent) {
     lastIndent = ''
@@ -37,6 +37,7 @@ var convert = function (obj, indent, lastIndent) {
     case '[object Object]':
       result = []
       for (i in obj) {
+        // eslint-disable-next-line no-prototype-builtins
         if (obj.hasOwnProperty(i)) {
           result.push(convert(i, indent) + ' => ' + convert(obj[i], indent + indent, indent))
         }

--- a/src/targets/php/http1.js
+++ b/src/targets/php/http1.js
@@ -10,22 +10,22 @@
 
 'use strict'
 
-var helpers = require('./helpers')
-var CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('./helpers')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     closingTag: false,
     indent: '  ',
     noTags: false,
     shortTags: false
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   if (!opts.noTags) {
     code.push(opts.shortTags ? '<?' : '<?php')
-        .blank()
+      .blank()
   }
 
   if (!~helpers.methods.indexOf(source.method.toUpperCase())) {
@@ -33,7 +33,7 @@ module.exports = function (source, options) {
   }
 
   code.push('$request = new HttpRequest();')
-      .push('$request->setUrl(%s);', helpers.convert(source.url))
+    .push('$request->setUrl(%s);', helpers.convert(source.url))
 
   if (~helpers.methods.indexOf(source.method.toUpperCase())) {
     code.push('$request->setMethod(HTTP_METH_%s);', source.method.toUpperCase())
@@ -45,44 +45,44 @@ module.exports = function (source, options) {
 
   if (Object.keys(source.queryObj).length) {
     code.push('$request->setQueryData(%s);', helpers.convert(source.queryObj, opts.indent))
-        .blank()
+      .blank()
   }
 
   if (Object.keys(source.headersObj).length) {
     code.push('$request->setHeaders(%s);', helpers.convert(source.headersObj, opts.indent))
-        .blank()
+      .blank()
   }
 
   if (Object.keys(source.cookiesObj).length) {
     code.push('$request->setCookies(%s);', helpers.convert(source.cookiesObj, opts.indent))
-        .blank()
+      .blank()
   }
 
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
       code.push('$request->setContentType(%s);', helpers.convert(source.postData.mimeType))
-          .push('$request->setPostFields(%s);', helpers.convert(source.postData.paramsObj, opts.indent))
-          .blank()
+        .push('$request->setPostFields(%s);', helpers.convert(source.postData.paramsObj, opts.indent))
+        .blank()
       break
 
     default:
       if (source.postData.text) {
         code.push('$request->setBody(%s);', helpers.convert(source.postData.text))
-            .blank()
+          .blank()
       }
   }
 
   code.push('try {')
-      .push(1, '$response = $request->send();')
-      .blank()
-      .push(1, 'echo $response->getBody();')
-      .push('} catch (HttpException $ex) {')
-      .push(1, 'echo $ex;')
-      .push('}')
+    .push(1, '$response = $request->send();')
+    .blank()
+    .push(1, 'echo $response->getBody();')
+    .push('} catch (HttpException $ex) {')
+    .push(1, 'echo $ex;')
+    .push('}')
 
   if (!opts.noTags && opts.closingTag) {
     code.blank()
-        .push('?>')
+      .push('?>')
   }
 
   return code.join()

--- a/src/targets/powershell/common.js
+++ b/src/targets/powershell/common.js
@@ -1,21 +1,21 @@
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
-var helpers = require('../../helpers/headers')
+const CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('../../helpers/headers')
 
 module.exports = function (command) {
   return function (source, options) {
-    var code = new CodeBuilder()
-    var methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
+    const code = new CodeBuilder()
+    const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
 
     if (methods.indexOf(source.method.toUpperCase()) === -1) {
       return 'Method not supported'
     }
 
-    var commandOptions = []
+    const commandOptions = []
 
     // Add headers, including the cookies
-    var headers = Object.keys(source.headersObj)
+    const headers = Object.keys(source.headersObj)
 
     // construct headers
     if (headers.length) {

--- a/src/targets/python/helpers.js
+++ b/src/targets/python/helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+const util = require('util')
 
 /**
  * Create an string of given length filled with blank spaces
@@ -17,11 +17,11 @@ function buildString (length, str) {
  * and indentation.
  */
 function concatValues (concatType, values, pretty, indentation, indentLevel) {
-  var currentIndent = buildString(indentLevel, indentation)
-  var closingBraceIndent = buildString(indentLevel - 1, indentation)
-  var join = pretty ? ',\n' + currentIndent : ', '
-  var openingBrace = concatType === 'object' ? '{' : '['
-  var closingBrace = concatType === 'object' ? '}' : ']'
+  const currentIndent = buildString(indentLevel, indentation)
+  const closingBraceIndent = buildString(indentLevel - 1, indentation)
+  const join = pretty ? ',\n' + currentIndent : ', '
+  const openingBrace = concatType === 'object' ? '{' : '['
+  const closingBrace = concatType === 'object' ? '}' : ']'
 
   if (pretty) {
     return openingBrace + '\n' + currentIndent + values.join(join) + '\n' + closingBraceIndent + closingBrace
@@ -45,9 +45,9 @@ module.exports = {
       case '[object Number]':
         return value
 
-      case '[object Array]':
-        var pretty = false
-        var valuesRepresentation = value.map(function (v) {
+      case '[object Array]': {
+        let pretty = false
+        const valuesRepresentation = value.map(function (v) {
           // Switch to prettify if the value is a dictionary with multiple keys
           if (Object.prototype.toString.call(v) === '[object Object]') {
             pretty = Object.keys(v).length > 1
@@ -55,13 +55,15 @@ module.exports = {
           return this.literalRepresentation(v, opts, indentLevel)
         }.bind(this))
         return concatValues('array', valuesRepresentation, pretty, opts.indent, indentLevel)
+      }
 
-      case '[object Object]':
-        var keyValuePairs = []
-        for (var k in value) {
+      case '[object Object]': {
+        const keyValuePairs = []
+        for (const k in value) {
           keyValuePairs.push(util.format('"%s": %s', k, this.literalRepresentation(value[k], opts, indentLevel)))
         }
         return concatValues('object', keyValuePairs, opts.pretty && keyValuePairs.length > 1, opts.indent, indentLevel)
+      }
 
       case '[object Null]':
         return 'None'

--- a/src/targets/python/python3.js
+++ b/src/targets/python/python3.js
@@ -10,46 +10,45 @@
 
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var code = new CodeBuilder()
+  const code = new CodeBuilder()
   // Start Request
   code.push('import http.client')
-      .blank()
+    .blank()
 
   // Check which protocol to be used for the client connection
-  var protocol = source.uriObj.protocol
+  const protocol = source.uriObj.protocol
   if (protocol === 'https:') {
     code.push('conn = http.client.HTTPSConnection("%s")', source.uriObj.host)
-        .blank()
+      .blank()
   } else {
     code.push('conn = http.client.HTTPConnection("%s")', source.uriObj.host)
-        .blank()
+      .blank()
   }
 
   // Create payload string if it exists
-  var payload = JSON.stringify(source.postData.text)
+  const payload = JSON.stringify(source.postData.text)
   if (payload) {
     code.push('payload = %s', payload)
-        .blank()
+      .blank()
   }
 
   // Create Headers
-  var header
-  var headers = source.allHeaders
-  var headerCount = Object.keys(headers).length
+  const headers = source.allHeaders
+  const headerCount = Object.keys(headers).length
   if (headerCount === 1) {
-    for (header in headers) {
+    for (const header in headers) {
       code.push('headers = { \'%s\': "%s" }', header, headers[header])
-          .blank()
+        .blank()
     }
   } else if (headerCount > 1) {
-    var count = 1
+    let count = 1
 
     code.push('headers = {')
 
-    for (header in headers) {
+    for (const header in headers) {
       if (count++ !== headerCount) {
         code.push('    \'%s\': "%s",', header, headers[header])
       } else {
@@ -58,12 +57,12 @@ module.exports = function (source, options) {
     }
 
     code.push('    }')
-        .blank()
+      .blank()
   }
 
   // Make Request
-  var method = source.method
-  var path = source.uriObj.path
+  const method = source.method
+  const path = source.uriObj.path
   if (payload && headerCount) {
     code.push('conn.request("%s", "%s", payload, headers)', method, path)
   } else if (payload && !headerCount) {
@@ -76,10 +75,10 @@ module.exports = function (source, options) {
 
   // Get Response
   code.blank()
-      .push('res = conn.getresponse()')
-      .push('data = res.read()')
-      .blank()
-      .push('print(data.decode("utf-8"))')
+    .push('res = conn.getresponse()')
+    .push('data = res.read()')
+    .blank()
+    .push('print(data.decode("utf-8"))')
 
   return code.join()
 }

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -10,33 +10,34 @@
 
 'use strict'
 
-var util = require('util')
-var CodeBuilder = require('../../helpers/code-builder')
-var helpers = require('./helpers')
+const util = require('util')
+const CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('./helpers')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '    ',
     pretty: true
   }, options)
 
   // Start snippet
-  var code = new CodeBuilder('    ')
+  const code = new CodeBuilder(opts.indent)
 
   // Import requests
   code.push('import requests')
-      .blank()
+    .blank()
 
   // Set URL
   code.push('url = "%s"', source.url)
-      .blank()
+    .blank()
 
   // Construct query string
+  let qs
   if (Object.keys(source.queryObj).length) {
-    var qs = 'querystring = ' + JSON.stringify(source.queryObj)
+    qs = 'querystring = ' + JSON.stringify(source.queryObj)
 
     code.push(qs)
-        .blank()
+      .blank()
   }
 
   // Construct payload
@@ -51,30 +52,30 @@ module.exports = function (source, options) {
       }
       break
 
-    default:
-      var payload = JSON.stringify(source.postData.text)
+    default: {
+      const payload = JSON.stringify(source.postData.text)
       if (payload) {
         code.push('payload = %s', payload)
         hasPayload = true
       }
+    }
   }
 
   // Construct headers
-  var header
-  var headers = source.allHeaders
-  var headerCount = Object.keys(headers).length
+  const headers = source.allHeaders
+  const headerCount = Object.keys(headers).length
 
   if (headerCount === 1) {
-    for (header in headers) {
+    for (const header in headers) {
       code.push('headers = {"%s": "%s"}', header, headers[header])
-          .blank()
+        .blank()
     }
   } else if (headerCount > 1) {
-    var count = 1
+    let count = 1
 
     code.push('headers = {')
 
-    for (header in headers) {
+    for (const header in headers) {
       if (count++ !== headerCount) {
         code.push(1, '"%s": "%s",', header, headers[header])
       } else {
@@ -83,12 +84,12 @@ module.exports = function (source, options) {
     }
 
     code.push('}')
-        .blank()
+      .blank()
   }
 
   // Construct request
-  var method = source.method
-  var request = util.format('response = requests.request("%s", url', method)
+  const method = source.method
+  let request = util.format('response = requests.request("%s", url', method)
 
   if (hasPayload) {
     if (jsonPayload) {
@@ -109,10 +110,10 @@ module.exports = function (source, options) {
   request += ')'
 
   code.push(request)
-      .blank()
+    .blank()
 
-      // Print response
-      .push('print(response.text)')
+    // Print response
+    .push('print(response.text)')
 
   return code.join()
 }

--- a/src/targets/r/httr.js
+++ b/src/targets/r/httr.js
@@ -10,12 +10,12 @@
 
 'use strict'
 
-var util = require('util')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
   // Start snippet
-  var code = new CodeBuilder()
+  const code = new CodeBuilder()
 
   // Import httr
   code.push('library(httr)')
@@ -26,20 +26,19 @@ module.exports = function (source, options) {
     .blank()
 
   // Construct query string
-  var query
-  var qs = source.queryObj
-  var queryCount = Object.keys(qs).length
-  delete source.queryObj['key']
+  const qs = source.queryObj
+  const queryCount = Object.keys(qs).length
+  delete source.queryObj.key
 
   if (source.queryString.length === 1) {
     code.push('queryString <- list(%s = "%s")', Object.keys(qs), Object.values(qs).toString())
       .blank()
   } else if (source.queryString.length > 1) {
-    var count = 1
+    let count = 1
 
     code.push('queryString <- list(')
 
-    for (query in qs) {
+    for (const query in qs) {
       if (count++ !== queryCount - 1) {
         code.push('  %s = "%s",', query, qs[query].toString())
       } else {
@@ -52,7 +51,7 @@ module.exports = function (source, options) {
   }
 
   // Construct payload
-  var payload = JSON.stringify(source.postData.text)
+  const payload = JSON.stringify(source.postData.text)
 
   if (payload) {
     code.push('payload <- %s', payload)
@@ -85,14 +84,13 @@ module.exports = function (source, options) {
   }
 
   // Construct headers
-  var head
-  var headers = source.allHeaders
-  var headerCount = Object.keys(headers).length
-  var header = ''
-  var cookies
-  var accept
+  const headers = source.allHeaders
+  let headerCount = Object.keys(headers).length
+  let header = ''
+  let cookies
+  let accept
 
-  for (head in headers) {
+  for (const head in headers) {
     if (head.toLowerCase() === 'accept') {
       accept = ', accept("' + headers[head] + '")'
       headerCount = headerCount - 1
@@ -106,8 +104,8 @@ module.exports = function (source, options) {
   }
 
   // Construct request
-  var method = source.method
-  var request = util.format('response <- VERB("%s", url', method)
+  const method = source.method
+  let request = util.format('response <- VERB("%s", url', method)
 
   if (payload) {
     request += ', body = payload'

--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -1,12 +1,12 @@
 'use strict'
 
-var CodeBuilder = require('../../helpers/code-builder')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var code = new CodeBuilder()
+  const code = new CodeBuilder()
 
   code.push('require \'uri\'')
-      .push('require \'net/http\'')
+    .push('require \'net/http\'')
 
   if (source.uriObj.protocol === 'https:') {
     code.push('require \'openssl\'')
@@ -16,31 +16,31 @@ module.exports = function (source, options) {
 
   // To support custom methods we check for the supported methods
   // and if doesn't exist then we build a custom class for it
-  var method = source.method.toUpperCase()
-  var methods = ['GET', 'POST', 'HEAD', 'DELETE', 'PATCH', 'PUT', 'OPTIONS', 'COPY', 'LOCK', 'UNLOCK', 'MOVE', 'TRACE']
-  var capMethod = method.charAt(0) + method.substring(1).toLowerCase()
+  const method = source.method.toUpperCase()
+  const methods = ['GET', 'POST', 'HEAD', 'DELETE', 'PATCH', 'PUT', 'OPTIONS', 'COPY', 'LOCK', 'UNLOCK', 'MOVE', 'TRACE']
+  const capMethod = method.charAt(0) + method.substring(1).toLowerCase()
   if (methods.indexOf(method) < 0) {
     code.push('class Net::HTTP::%s < Net::HTTPRequest', capMethod)
-        .push('  METHOD = \'%s\'', method.toUpperCase())
-        .push('  REQUEST_HAS_BODY = \'%s\'', source.postData.text ? 'true' : 'false')
-        .push('  RESPONSE_HAS_BODY = true')
-        .push('end')
-        .blank()
+      .push('  METHOD = \'%s\'', method.toUpperCase())
+      .push('  REQUEST_HAS_BODY = \'%s\'', source.postData.text ? 'true' : 'false')
+      .push('  RESPONSE_HAS_BODY = true')
+      .push('end')
+      .blank()
   }
 
   code.push('url = URI("%s")', source.fullUrl)
-      .blank()
-      .push('http = Net::HTTP.new(url.host, url.port)')
+    .blank()
+    .push('http = Net::HTTP.new(url.host, url.port)')
 
   if (source.uriObj.protocol === 'https:') {
     code.push('http.use_ssl = true')
-        .push('http.verify_mode = OpenSSL::SSL::VERIFY_NONE')
+      .push('http.verify_mode = OpenSSL::SSL::VERIFY_NONE')
   }
 
   code.blank()
-      .push('request = Net::HTTP::%s.new(url)', capMethod)
+    .push('request = Net::HTTP::%s.new(url)', capMethod)
 
-  var headers = Object.keys(source.allHeaders)
+  const headers = Object.keys(source.allHeaders)
   if (headers.length) {
     headers.forEach(function (key) {
       code.push('request["%s"] = \'%s\'', key, source.allHeaders[key])
@@ -52,8 +52,8 @@ module.exports = function (source, options) {
   }
 
   code.blank()
-      .push('response = http.request(request)')
-      .push('puts response.read_body')
+    .push('response = http.request(request)')
+    .push('puts response.read_body')
 
   return code.join()
 }

--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -10,21 +10,21 @@
 
 'use strict'
 
-var util = require('util')
-var helpers = require('../../helpers/shell')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const helpers = require('../../helpers/shell')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  ',
     short: false,
     binary: false
   }, options)
 
-  var code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
+  const code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
 
   code.push('curl %s %s', opts.short ? '-X' : '--request', source.method)
-      .push(util.format('%s%s', opts.short ? '' : '--url ', helpers.quote(source.fullUrl)))
+    .push(util.format('%s%s', opts.short ? '' : '--url ', helpers.quote(source.fullUrl)))
 
   if (source.httpVersion === 'HTTP/1.0') {
     code.push(opts.short ? '-0' : '--http1.0')
@@ -32,7 +32,7 @@ module.exports = function (source, options) {
 
   // construct headers
   Object.keys(source.headersObj).sort().forEach(function (key) {
-    var header = util.format('%s: %s', key, source.headersObj[key])
+    const header = util.format('%s: %s', key, source.headersObj[key])
     code.push('%s %s', opts.short ? '-H' : '--header', helpers.quote(header))
   })
 
@@ -43,8 +43,8 @@ module.exports = function (source, options) {
   // construct post params
   switch (source.postData.mimeType) {
     case 'multipart/form-data':
-      source.postData.params.map(function (param) {
-        var post = ''
+      source.postData.params.forEach(function (param) {
+        let post = ''
         if (param.fileName) {
           post = util.format('%s=@%s', param.name, param.fileName)
         } else {
@@ -57,7 +57,7 @@ module.exports = function (source, options) {
 
     case 'application/x-www-form-urlencoded':
       if (source.postData.params) {
-        source.postData.params.map(function (param) {
+        source.postData.params.forEach(function (param) {
           code.push(
             '%s %s', opts.binary ? '--data-binary' : (opts.short ? '-d' : '--data'),
             helpers.quote(util.format('%s=%s', param.name, param.value))

--- a/src/targets/shell/httpie.js
+++ b/src/targets/shell/httpie.js
@@ -10,12 +10,12 @@
 
 'use strict'
 
-var util = require('util')
-var shell = require('../../helpers/shell')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const shell = require('../../helpers/shell')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     body: false,
     cert: false,
     headers: false,
@@ -30,10 +30,10 @@ module.exports = function (source, options) {
     verify: false
   }, options)
 
-  var code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
+  const code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
 
-  var raw = false
-  var flags = []
+  let raw = false
+  const flags = []
 
   if (opts.headers) {
     flags.push(opts.short ? '-h' : '--headers')
@@ -73,10 +73,10 @@ module.exports = function (source, options) {
 
   // construct query params
   if (opts.queryParams) {
-    var queryStringKeys = Object.keys(source.queryObj)
+    const queryStringKeys = Object.keys(source.queryObj)
 
     queryStringKeys.forEach(function (name) {
-      var value = source.queryObj[name]
+      const value = source.queryObj[name]
 
       if (Array.isArray(value)) {
         value.forEach(function (val) {

--- a/src/targets/shell/wget.js
+++ b/src/targets/shell/wget.js
@@ -10,18 +10,18 @@
 
 'use strict'
 
-var util = require('util')
-var helpers = require('../../helpers/shell')
-var CodeBuilder = require('../../helpers/code-builder')
+const util = require('util')
+const helpers = require('../../helpers/shell')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  ',
     short: false,
     verbose: false
   }, options)
 
-  var code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
+  const code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
 
   if (opts.verbose) {
     code.push('wget %s', opts.short ? '-v' : '--verbose')
@@ -32,7 +32,7 @@ module.exports = function (source, options) {
   code.push('--method %s', helpers.quote(source.method))
 
   Object.keys(source.allHeaders).forEach(function (key) {
-    var header = util.format('%s: %s', key, source.allHeaders[key])
+    const header = util.format('%s: %s', key, source.allHeaders[key])
     code.push('--header %s', helpers.quote(header))
   })
 
@@ -41,7 +41,7 @@ module.exports = function (source, options) {
   }
 
   code.push(opts.short ? '-O' : '--output-document')
-      .push('- %s', helpers.quote(source.fullUrl))
+    .push('- %s', helpers.quote(source.fullUrl))
 
   return code.join()
 }

--- a/src/targets/swift/helpers.js
+++ b/src/targets/swift/helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var util = require('util')
+const util = require('util')
 
 /**
  * Create an string of given length filled with blank spaces
@@ -18,9 +18,9 @@ function buildString (length, str) {
  * and indentation.
  */
 function concatArray (arr, pretty, indentation, indentLevel) {
-  var currentIndent = buildString(indentLevel, indentation)
-  var closingBraceIndent = buildString(indentLevel - 1, indentation)
-  var join = pretty ? ',\n' + currentIndent : ', '
+  const currentIndent = buildString(indentLevel, indentation)
+  const closingBraceIndent = buildString(indentLevel - 1, indentation)
+  const join = pretty ? ',\n' + currentIndent : ', '
 
   if (pretty) {
     return '[\n' + currentIndent + arr.join(join) + '\n' + closingBraceIndent + ']'
@@ -55,10 +55,11 @@ module.exports = {
     switch (Object.prototype.toString.call(value)) {
       case '[object Number]':
         return value
-      case '[object Array]':
+
+      case '[object Array]': {
         // Don't prettify arrays nto not take too much space
-        var pretty = false
-        var valuesRepresentation = value.map(function (v) {
+        let pretty = false
+        const valuesRepresentation = value.map(function (v) {
           // Switch to prettify if the value is a dictionary with multiple keys
           if (Object.prototype.toString.call(v) === '[object Object]') {
             pretty = Object.keys(v).length > 1
@@ -66,14 +67,19 @@ module.exports = {
           return this.literalRepresentation(v, opts, indentLevel)
         }.bind(this))
         return concatArray(valuesRepresentation, pretty, opts.indent, indentLevel)
-      case '[object Object]':
-        var keyValuePairs = []
-        for (var k in value) {
+      }
+
+      case '[object Object]': {
+        const keyValuePairs = []
+        for (const k in value) {
           keyValuePairs.push(util.format('"%s": %s', k, this.literalRepresentation(value[k], opts, indentLevel)))
         }
         return concatArray(keyValuePairs, opts.pretty && keyValuePairs.length > 1, opts.indent, indentLevel)
+      }
+
       case '[object Boolean]':
         return value.toString()
+
       default:
         if (value === null || value === undefined) {
           return ''

--- a/src/targets/swift/nsurlsession.js
+++ b/src/targets/swift/nsurlsession.js
@@ -10,20 +10,20 @@
 
 'use strict'
 
-var helpers = require('./helpers')
-var CodeBuilder = require('../../helpers/code-builder')
+const helpers = require('./helpers')
+const CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
-  var opts = Object.assign({
+  const opts = Object.assign({
     indent: '  ',
     pretty: true,
     timeout: '10'
   }, options)
 
-  var code = new CodeBuilder(opts.indent)
+  const code = new CodeBuilder(opts.indent)
 
   // Markers for headers to be created as litteral objects and later be set on the NSURLRequest if exist
-  var req = {
+  const req = {
     hasHeaders: false,
     hasBody: false
   }
@@ -34,7 +34,7 @@ module.exports = function (source, options) {
   if (Object.keys(source.allHeaders).length) {
     req.hasHeaders = true
     code.blank()
-        .push(helpers.literalDeclaration('headers', source.allHeaders, opts))
+      .push(helpers.literalDeclaration('headers', source.allHeaders, opts))
   }
 
   if (source.postData.text || source.postData.jsonObj || source.postData.params) {
@@ -46,8 +46,8 @@ module.exports = function (source, options) {
         // we make it easier for the user to edit it according to his or her needs after pasting.
         // The user can just add/remove lines adding/removing body parameters.
         code.blank()
-            .push('let postData = NSMutableData(data: "%s=%s".data(using: String.Encoding.utf8)!)', source.postData.params[0].name, source.postData.params[0].value)
-        for (var i = 1, len = source.postData.params.length; i < len; i++) {
+          .push('let postData = NSMutableData(data: "%s=%s".data(using: String.Encoding.utf8)!)', source.postData.params[0].name, source.postData.params[0].value)
+        for (let i = 1, len = source.postData.params.length; i < len; i++) {
           code.push('postData.append("&%s=%s".data(using: String.Encoding.utf8)!)', source.postData.params[i].name, source.postData.params[i].value)
         }
         break
@@ -55,8 +55,8 @@ module.exports = function (source, options) {
       case 'application/json':
         if (source.postData.jsonObj) {
           code.push(helpers.literalDeclaration('parameters', source.postData.jsonObj, opts), 'as [String : Any]')
-              .blank()
-              .push('let postData = JSONSerialization.data(withJSONObject: parameters, options: [])')
+            .blank()
+            .push('let postData = JSONSerialization.data(withJSONObject: parameters, options: [])')
         }
         break
 
@@ -67,42 +67,42 @@ module.exports = function (source, options) {
          * The user can just edit the parameters NSDictionary or put this part of a snippet in a multipart builder method.
         */
         code.push(helpers.literalDeclaration('parameters', source.postData.params, opts))
-            .blank()
-            .push('let boundary = "%s"', source.postData.boundary)
-            .blank()
-            .push('var body = ""')
-            .push('var error: NSError? = nil')
-            .push('for param in parameters {')
-            .push(1, 'let paramName = param["name"]!')
-            .push(1, 'body += "--\\(boundary)\\r\\n"')
-            .push(1, 'body += "Content-Disposition:form-data; name=\\"\\(paramName)\\""')
-            .push(1, 'if let filename = param["fileName"] {')
-            .push(2, 'let contentType = param["content-type"]!')
-            .push(2, 'let fileContent = String(contentsOfFile: filename, encoding: String.Encoding.utf8)')
-            .push(2, 'if (error != nil) {')
-            .push(3, 'print(error)')
-            .push(2, '}')
-            .push(2, 'body += "; filename=\\"\\(filename)\\"\\r\\n"')
-            .push(2, 'body += "Content-Type: \\(contentType)\\r\\n\\r\\n"')
-            .push(2, 'body += fileContent')
-            .push(1, '} else if let paramValue = param["value"] {')
-            .push(2, 'body += "\\r\\n\\r\\n\\(paramValue)"')
-            .push(1, '}')
-            .push('}')
+          .blank()
+          .push('let boundary = "%s"', source.postData.boundary)
+          .blank()
+          .push('var body = ""')
+          .push('var error: NSError? = nil')
+          .push('for param in parameters {')
+          .push(1, 'let paramName = param["name"]!')
+          .push(1, 'body += "--\\(boundary)\\r\\n"')
+          .push(1, 'body += "Content-Disposition:form-data; name=\\"\\(paramName)\\""')
+          .push(1, 'if let filename = param["fileName"] {')
+          .push(2, 'let contentType = param["content-type"]!')
+          .push(2, 'let fileContent = String(contentsOfFile: filename, encoding: String.Encoding.utf8)')
+          .push(2, 'if (error != nil) {')
+          .push(3, 'print(error)')
+          .push(2, '}')
+          .push(2, 'body += "; filename=\\"\\(filename)\\"\\r\\n"')
+          .push(2, 'body += "Content-Type: \\(contentType)\\r\\n\\r\\n"')
+          .push(2, 'body += fileContent')
+          .push(1, '} else if let paramValue = param["value"] {')
+          .push(2, 'body += "\\r\\n\\r\\n\\(paramValue)"')
+          .push(1, '}')
+          .push('}')
         break
 
       default:
         code.blank()
-            .push('let postData = NSData(data: "%s".data(using: String.Encoding.utf8)!)', source.postData.text)
+          .push('let postData = NSData(data: "%s".data(using: String.Encoding.utf8)!)', source.postData.text)
     }
   }
 
   code.blank()
-      // NSURLRequestUseProtocolCachePolicy is the default policy, let's just always set it to avoid confusion.
-      .push('let request = NSMutableURLRequest(url: NSURL(string: "%s")! as URL,', source.fullUrl)
-      .push('                                        cachePolicy: .useProtocolCachePolicy,')
-      .push('                                    timeoutInterval: %s)', parseInt(opts.timeout, 10).toFixed(1))
-      .push('request.httpMethod = "%s"', source.method)
+    // NSURLRequestUseProtocolCachePolicy is the default policy, let's just always set it to avoid confusion.
+    .push('let request = NSMutableURLRequest(url: NSURL(string: "%s")! as URL,', source.fullUrl)
+    .push('                                        cachePolicy: .useProtocolCachePolicy,')
+    .push('                                    timeoutInterval: %s)', parseInt(opts.timeout, 10).toFixed(1))
+    .push('request.httpMethod = "%s"', source.method)
 
   if (req.hasHeaders) {
     code.push('request.allHTTPHeaderFields = headers')
@@ -113,19 +113,19 @@ module.exports = function (source, options) {
   }
 
   code.blank()
-      // Retrieving the shared session will be less verbose than creating a new one.
-      .push('let session = URLSession.shared')
-      .push('let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in')
-      .push(1, 'if (error != nil) {')
-      .push(2, 'print(error)')
-      .push(1, '} else {')
-      // Casting the NSURLResponse to NSHTTPURLResponse so the user can see the status     .
-      .push(2, 'let httpResponse = response as? HTTPURLResponse')
-      .push(2, 'print(httpResponse)')
-      .push(1, '}')
-      .push('})')
-      .blank()
-      .push('dataTask.resume()')
+    // Retrieving the shared session will be less verbose than creating a new one.
+    .push('let session = URLSession.shared')
+    .push('let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in')
+    .push(1, 'if (error != nil) {')
+    .push(2, 'print(error)')
+    .push(1, '} else {')
+    // Casting the NSURLResponse to NSHTTPURLResponse so the user can see the status     .
+    .push(2, 'let httpResponse = response as? HTTPURLResponse')
+    .push(2, 'print(httpResponse)')
+    .push(1, '}')
+    .push('})')
+    .blank()
+    .push('dataTask.resume()')
 
   return code.join()
 }

--- a/test/headers.js
+++ b/test/headers.js
@@ -1,13 +1,11 @@
-/* global describe, it */
-
 'use strict'
 
-var helpers = require('../src/helpers/headers')
-var should = require('should')
+const helpers = require('../src/helpers/headers')
+const should = require('should')
 
 const headers = {
   'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001',
-  'accept': 'application/json'
+  accept: 'application/json'
 }
 
 describe('Headers', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1,15 +1,13 @@
-/* global describe, it */
-
 'use strict'
 
-var fixtures = require('./fixtures')
-var HTTPSnippet = require('../src')
+const fixtures = require('./fixtures')
+const HTTPSnippet = require('../src')
 
-var should = require('should')
+const should = require('should')
 
 describe('HTTPSnippet', function () {
   it('should return false if no matching target', function (done) {
-    var snippet = new HTTPSnippet(fixtures.requests.short)
+    const snippet = new HTTPSnippet(fixtures.requests.short)
 
     snippet.convert(null).should.eql(false)
 
@@ -17,11 +15,11 @@ describe('HTTPSnippet', function () {
   })
 
   it('should fail validation', function (done) {
-    var snippet;
+    let snippet;
 
     /* eslint-disable no-extra-parens */
     (function () {
-      snippet = new HTTPSnippet({yolo: 'foo'})
+      snippet = new HTTPSnippet({ yolo: 'foo' })
     }).should.throw(Error)
 
     should.not.exist(snippet)
@@ -30,12 +28,12 @@ describe('HTTPSnippet', function () {
   })
 
   it('should parse HAR file with multiple entries', function (done) {
-    var snippet = new HTTPSnippet(fixtures.har)
+    const snippet = new HTTPSnippet(fixtures.har)
 
     snippet.should.have.property('requests').and.be.an.Array()
     snippet.requests.length.should.equal(2)
 
-    var results = snippet.convert('shell')
+    const results = snippet.convert('shell')
 
     results.should.be.an.Array()
     results.length.should.equal(2)
@@ -44,7 +42,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should convert multipart/mixed to multipart/form-data', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['multipart/mixed']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['multipart/mixed']).requests[0]
 
     req.postData.mimeType.should.eql('multipart/form-data')
 
@@ -52,7 +50,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should convert multipart/related to multipart/form-data', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['multipart/related']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['multipart/related']).requests[0]
 
     req.postData.mimeType.should.eql('multipart/form-data')
 
@@ -60,7 +58,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should convert multipart/alternative to multipart/form-data', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['multipart/alternative']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['multipart/alternative']).requests[0]
 
     req.postData.mimeType.should.eql('multipart/form-data')
 
@@ -68,7 +66,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should convert text/json to application/json', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['text/json']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['text/json']).requests[0]
 
     req.postData.mimeType.should.eql('application/json')
 
@@ -76,7 +74,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should convert text/x-json to application/json', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['text/x-json']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['text/x-json']).requests[0]
 
     req.postData.mimeType.should.eql('application/json')
 
@@ -84,7 +82,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should convert application/x-json to application/json', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['application/x-json']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['application/x-json']).requests[0]
 
     req.postData.mimeType.should.eql('application/json')
 
@@ -92,7 +90,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should gracefully fallback if not able to parse JSON', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['invalid-json']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['invalid-json']).requests[0]
 
     req.postData.mimeType.should.eql('text/plain')
 
@@ -100,7 +98,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should set postData.text = empty string when postData.params === undefined in application/x-www-form-urlencoded', function (done) {
-    var req = new HTTPSnippet(fixtures.mimetypes['application/x-www-form-urlencoded']).requests[0]
+    const req = new HTTPSnippet(fixtures.mimetypes['application/x-www-form-urlencoded']).requests[0]
 
     req.postData.text.should.eql('')
 
@@ -108,7 +106,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should add "uriObj" to source object', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.query).requests[0]
+    const req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
     req.uriObj.should.be.an.Object()
 
@@ -139,7 +137,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should add "queryObj" to source object', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.query).requests[0]
+    const req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
     req.queryObj.should.be.an.Object()
     req.queryObj.should.eql({
@@ -155,11 +153,11 @@ describe('HTTPSnippet', function () {
   })
 
   it('should add "headersObj" to source object', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.headers).requests[0]
+    const req = new HTTPSnippet(fixtures.requests.headers).requests[0]
 
     req.headersObj.should.be.an.Object()
     req.headersObj.should.eql({
-      'accept': 'application/json',
+      accept: 'application/json',
       'x-foo': 'Bar'
     })
 
@@ -167,18 +165,18 @@ describe('HTTPSnippet', function () {
   })
 
   it('should add "headersObj" to source object case insensitive when HTTP/1.0', function (done) {
-    var fixture = Object.assign({}, fixtures.requests.headers)
+    const fixture = Object.assign({}, fixtures.requests.headers)
     fixture.httpVersion = 'HTTP/1.1'
     fixture.headers = fixture.headers.concat({
       name: 'Kong-Admin-Token',
       value: 'Hunter1'
     })
 
-    var req = new HTTPSnippet(fixture).requests[0]
+    const req = new HTTPSnippet(fixture).requests[0]
     req.headersObj.should.be.an.Object()
     req.headersObj.should.eql({
       'Kong-Admin-Token': 'Hunter1',
-      'accept': 'application/json',
+      accept: 'application/json',
       'x-foo': 'Bar'
     })
 
@@ -186,18 +184,18 @@ describe('HTTPSnippet', function () {
   })
 
   it('should add "headersObj" to source object in lowercase when HTTP/2.x', function (done) {
-    var fixture = Object.assign({}, fixtures.requests.headers)
+    const fixture = Object.assign({}, fixtures.requests.headers)
     fixture.httpVersion = 'HTTP/2'
     fixture.headers = fixture.headers.concat({
       name: 'Kong-Admin-Token',
       value: 'Hunter1'
     })
 
-    var req = new HTTPSnippet(fixture).requests[0]
+    const req = new HTTPSnippet(fixture).requests[0]
     req.headersObj.should.be.an.Object()
     req.headersObj.should.eql({
       'kong-admin-token': 'Hunter1',
-      'accept': 'application/json',
+      accept: 'application/json',
       'x-foo': 'Bar'
     })
 
@@ -205,7 +203,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should modify orignal url to strip query string', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.query).requests[0]
+    const req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
     req.url.should.be.a.String()
     req.url.should.eql('http://mockbin.com/har')
@@ -214,7 +212,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should add "fullUrl" to source object', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.query).requests[0]
+    const req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
     req.fullUrl.should.be.a.String()
     req.fullUrl.should.eql('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value')
@@ -223,7 +221,7 @@ describe('HTTPSnippet', function () {
   })
 
   it('should fix "path" property of "uriObj" to match queryString', function (done) {
-    var req = new HTTPSnippet(fixtures.requests.query).requests[0]
+    const req = new HTTPSnippet(fixtures.requests.query).requests[0]
 
     req.uriObj.path.should.be.a.String()
     req.uriObj.path.should.eql('/har?foo=bar&foo=baz&baz=abc&key=value')

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -1,38 +1,36 @@
-/* global describe, it */
-
 'use strict'
 
-var reducer = require('../src/helpers/reducer')
+const reducer = require('../src/helpers/reducer')
 
 require('should')
 
 describe('Reducer', function () {
   it('should convert array object pair to key-value object', function (done) {
-    var query = [
-      {name: 'key', value: 'value'},
-      {name: 'foo', value: 'bar'}
+    const query = [
+      { name: 'key', value: 'value' },
+      { name: 'foo', value: 'bar' }
     ]
 
-    var obj = query.reduce(reducer, {})
+    const obj = query.reduce(reducer, {})
 
     obj.should.be.an.Object()
-    obj.should.eql({key: 'value', foo: 'bar'})
+    obj.should.eql({ key: 'value', foo: 'bar' })
 
     done()
   })
 
   it('should convert multi-dimensional arrays to key=[array] object', function (done) {
-    var query = [
-      {name: 'key', value: 'value'},
-      {name: 'foo', value: 'bar1'},
-      {name: 'foo', value: 'bar2'},
-      {name: 'foo', value: 'bar3'}
+    const query = [
+      { name: 'key', value: 'value' },
+      { name: 'foo', value: 'bar1' },
+      { name: 'foo', value: 'bar2' },
+      { name: 'foo', value: 'bar3' }
     ]
 
-    var obj = query.reduce(reducer, {})
+    const obj = query.reduce(reducer, {})
 
     obj.should.be.an.Object()
-    obj.should.eql({key: 'value', foo: ['bar1', 'bar2', 'bar3']})
+    obj.should.eql({ key: 'value', foo: ['bar1', 'bar2', 'bar3'] })
 
     done()
   })

--- a/test/requests.js
+++ b/test/requests.js
@@ -2,16 +2,17 @@
 
 'use strict'
 
-var fixtures = require('./fixtures')
-var HTTPSnippet = require('../src')
-var targets = require('../src/targets')
-var shell = require('child_process')
-var util = require('util')
+const fixtures = require('./fixtures')
+const HTTPSnippet = require('../src')
+const targets = require('../src/targets')
+const shell = require('child_process')
+const util = require('util')
 
 require('should')
 
-var base = './test/fixtures/output/'
-var requests = [ 'application-form-encoded',
+const base = './test/fixtures/output/'
+const requests = [
+  'application-form-encoded',
   'application-json',
   'cookies',
   'custom-method',
@@ -28,19 +29,20 @@ fixtures.cli.forEach(function (cli) {
     cli.clients.forEach(function (client) {
       requests.forEach(function (request) {
         it(client + ' request should match mock for ' + request, function (done) {
-          var stdout = ''
-          var fixture = cli.target + '/' + client + '/' + request + HTTPSnippet.extname(cli.target)
-          var command = util.format(cli.run, base + fixture)
+          let stdout = ''
+          const fixture = cli.target + '/' + client + '/' + request + HTTPSnippet.extname(cli.target)
+          const command = util.format(cli.run, base + fixture)
 
-          var ls = shell.exec(command)
+          const ls = shell.exec(command)
 
           ls.stdout.on('data', function (data) {
             stdout += data
           })
 
           ls.on('exit', function (code) {
+            let har
             try {
-              var har = JSON.parse(stdout)
+              har = JSON.parse(stdout)
             } catch (err) {
               err.should.be.null()
             }

--- a/test/targets.js
+++ b/test/targets.js
@@ -1,28 +1,26 @@
-/* global describe, it, beforeEach */
-
 'use strict'
 
-var fixtures = require('./fixtures')
-var fs = require('fs')
-var glob = require('glob')
-var HTTPSnippet = require('../src')
-var path = require('path')
-var should = require('should')
-var targets = require('../src/targets')
+const fixtures = require('./fixtures')
+const fs = require('fs')
+const glob = require('glob')
+const HTTPSnippet = require('../src')
+const path = require('path')
+const should = require('should')
+const targets = require('../src/targets')
 
-var base = './test/fixtures/output/'
+const base = './test/fixtures/output/'
 
 // read all output files
-var output = glob.sync('**/*', {cwd: base, nodir: true}).reduce(function (obj, name) {
+const output = glob.sync('**/*', { cwd: base, nodir: true }).reduce(function (obj, name) {
   obj[name] = fs.readFileSync(base + name)
   return obj
 }, {})
 
-var clearInfo = function (key) {
+const clearInfo = function (key) {
   return !~['info', 'index'].indexOf(key)
 }
 
-var itShouldHaveTests = function (target, client) {
+const itShouldHaveTests = function (target, client) {
   it(target + ' should have tests', function (done) {
     fs.readdir(path.join(__dirname, 'targets', target), function (err, files) {
       should.not.exist(err)
@@ -33,7 +31,7 @@ var itShouldHaveTests = function (target, client) {
   })
 }
 
-var itShouldHaveInfo = function (name, obj) {
+const itShouldHaveInfo = function (name, obj) {
   it(name + ' should have info method', function () {
     obj.should.have.property('info').and.be.an.Object()
     obj.info.key.should.equal(name).and.be.a.String()
@@ -43,16 +41,16 @@ var itShouldHaveInfo = function (name, obj) {
 
 // TODO: investigate issues with these fixtures
 const skipMe = {
-  'clojure': {
-    'clj_http': ['jsonObj-null-value', 'jsonObj-multiline']
+  clojure: {
+    clj_http: ['jsonObj-null-value', 'jsonObj-multiline']
   },
   '*': {
     '*': []
   }
 }
 
-var itShouldHaveRequestTestOutputFixture = function (request, target, client) {
-  var fixture = target + '/' + client + '/' + request + HTTPSnippet.extname(target)
+const itShouldHaveRequestTestOutputFixture = function (request, target, client) {
+  const fixture = target + '/' + client + '/' + request + HTTPSnippet.extname(target)
 
   it('should have output test for ' + request, function () {
     if (skipMe[target] &&
@@ -65,8 +63,8 @@ var itShouldHaveRequestTestOutputFixture = function (request, target, client) {
   })
 }
 
-var itShouldGenerateOutput = function (request, path, target, client) {
-  var fixture = path + request + HTTPSnippet.extname(target)
+const itShouldGenerateOutput = function (request, path, target, client) {
+  const fixture = path + request + HTTPSnippet.extname(target)
 
   it('should generate ' + request + ' snippet', function () {
     if (Object.keys(output).indexOf(fixture) === -1 ||
@@ -76,11 +74,12 @@ var itShouldGenerateOutput = function (request, path, target, client) {
         skipMe['*']['*'].indexOf(request) > -1)) {
       this.skip()
     }
-    var instance = new HTTPSnippet(fixtures.requests[request])
+
+    const instance = new HTTPSnippet(fixtures.requests[request])
 
     // `form-data` sets the line break as `\r\n`, but we can't easily replicate that in our fixtures so let's convert
     // it to a standard line break instead.
-    var result = instance.convert(target, client).replace(/\r\n/g, '\n').trim()
+    const result = instance.convert(target, client).replace(/\r\n/g, '\n').trim()
 
     result.should.be.a.String()
     result.should.equal(output[fixture].toString().trim())
@@ -105,7 +104,7 @@ describe('Custom targets', function () {
 
     it('should throw if the target does not have a properly constructed info object', function () {
       (function () {
-        HTTPSnippet.addTarget({info: {key: ''}})
+        HTTPSnippet.addTarget({ info: { key: '' } })
       }).should.throw(Error)
     })
 
@@ -156,7 +155,7 @@ describe('Custom targets', function () {
 
     it('should throw if client already exists', function () {
       (function () {
-        HTTPSnippet.addTargetClient('node', {...customClient, info: {...customClient.info, key: 'axios'}})
+        HTTPSnippet.addTargetClient('node', { ...customClient, info: { ...customClient.info, key: 'axios' } })
       }).should.throw(Error)
     })
 
@@ -174,7 +173,7 @@ describe('Custom targets', function () {
 
     it('should throw if the target does not have a properly constructed info object', function () {
       (function () {
-        HTTPSnippet.addTargetClient('node', {info: {key: ''}})
+        HTTPSnippet.addTargetClient('node', { info: { key: '' } })
       }).should.throw(Error)
     })
 
@@ -205,7 +204,7 @@ describe('Targets', function () {
 
           itShouldHaveTests(target, client)
 
-          var test = require(path.join(__dirname, 'targets', target, client))
+          const test = require(path.join(__dirname, 'targets', target, client))
 
           test(HTTPSnippet, fixtures)
 

--- a/test/targets/go/native.js
+++ b/test/targets/go/native.js
@@ -1,20 +1,19 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
   it('should support false boilerplate option', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
       showBoilerplate: false
     })
 
     result.should.be.a.String()
     result.should.eql('url := "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"\n\npayload := strings.NewReader("foo=bar")\n\nreq, _ := http.NewRequest("POST", url, payload)\n\nreq.Header.Add("cookie", "foo=bar; bar=baz")\nreq.Header.Add("accept", "application/json")\nreq.Header.Add("content-type", "application/x-www-form-urlencoded")\n\nres, _ := http.DefaultClient.Do(req)\n\ndefer res.Body.Close()\nbody, _ := ioutil.ReadAll(res.Body)\n\nfmt.Println(res)\nfmt.Println(string(body))')
   })
+
   it('should support checkErrors option', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
       checkErrors: true
     })
 
@@ -59,8 +58,9 @@ func main() {
 
 }`)
   })
+
   it('should support printBody option', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
       printBody: false
     })
 
@@ -91,8 +91,9 @@ func main() {
 
 }`)
   })
+
   it('should support timeout option', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
       timeout: 30
     })
 

--- a/test/targets/javascript/xhr.js
+++ b/test/targets/javascript/xhr.js
@@ -1,12 +1,10 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
   it('should not use cors', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('javascript', 'xhr', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('javascript', 'xhr', {
       cors: false
     })
 

--- a/test/targets/objc/nsurlsession.js
+++ b/test/targets/objc/nsurlsession.js
@@ -1,28 +1,28 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
   it('should support an indent option', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('objc', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('objc', {
       indent: '  '
     })
 
     result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:10.0];[request setHTTPMethod:@"GET"];NSURLSession *session = [NSURLSession sharedSession];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {                                              if (error) {                                                NSLog(@"%@", error);                                              } else {                                                NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;                                                NSLog(@"%@", httpResponse);                                              }                                            }];[dataTask resume];')
   })
+
   it('should support a timeout option', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('objc', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('objc', {
       timeout: 5
     })
 
     result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('#import <Foundation/Foundation.h>NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy                                                   timeoutInterval:5.0];[request setHTTPMethod:@"GET"];NSURLSession *session = [NSURLSession sharedSession];NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {                                                if (error) {                                                    NSLog(@"%@", error);                                                } else {                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;                                                    NSLog(@"%@", httpResponse);                                                }                                            }];[dataTask resume];')
   })
+
   it('should support pretty option', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('objc', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('objc', {
       pretty: false
     })
 
@@ -31,7 +31,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should support json object with null value', function () {
-    var result = new HTTPSnippet(fixtures.requests['jsonObj-null-value']).convert('objc', {
+    const result = new HTTPSnippet(fixtures.requests['jsonObj-null-value']).convert('objc', {
       pretty: false
     })
 

--- a/test/targets/python/python3.js
+++ b/test/targets/python/python3.js
@@ -2,5 +2,4 @@
 
 require('should')
 
-module.exports = function (snippet, fixtures) {
-}
+module.exports = function (snippet, fixtures) {}

--- a/test/targets/python/requests.js
+++ b/test/targets/python/requests.js
@@ -1,12 +1,10 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet) {
   it('should support query parameters provided in HAR\'s url', function () {
-    var result = new HTTPSnippet({ 'method': 'GET', 'url': 'http://mockbin.com/har?param=value' }).convert('python', 'requests', {
+    const result = new HTTPSnippet({ method: 'GET', url: 'http://mockbin.com/har?param=value' }).convert('python', 'requests', {
       showBoilerplate: false
     })
 

--- a/test/targets/r/httr.js
+++ b/test/targets/r/httr.js
@@ -2,5 +2,4 @@
 
 require('should')
 
-module.exports = function (snippet, fixtures) {
-}
+module.exports = function (snippet, fixtures) {}

--- a/test/targets/shell/curl.js
+++ b/test/targets/shell/curl.js
@@ -1,12 +1,10 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
   it('should use short options', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
       short: true,
       indent: false
     })
@@ -16,7 +14,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use binary option', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
       short: true,
       indent: false,
       binary: true
@@ -27,7 +25,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use --http1.0 for HTTP/1.0', function () {
-    var result = new HTTPSnippet(fixtures.curl.http1).convert('shell', 'curl', {
+    const result = new HTTPSnippet(fixtures.curl.http1).convert('shell', 'curl', {
       indent: false
     })
 
@@ -36,7 +34,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use custom indentation', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
       indent: '@'
     })
 

--- a/test/targets/shell/httpie.js
+++ b/test/targets/shell/httpie.js
@@ -1,12 +1,10 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
   it('should ask for verbose output', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'httpie', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'httpie', {
       indent: false,
       verbose: true
     })
@@ -16,7 +14,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use short flags', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'httpie', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'httpie', {
       body: true,
       cert: 'foo',
       headers: true,
@@ -35,7 +33,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use long flags', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'httpie', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'httpie', {
       body: true,
       cert: 'foo',
       headers: true,
@@ -53,7 +51,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use custom indentation', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'httpie', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'httpie', {
       indent: '@'
     })
 
@@ -62,7 +60,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use queryString parameters', function () {
-    var result = new HTTPSnippet(fixtures.requests.query).convert('shell', 'httpie', {
+    const result = new HTTPSnippet(fixtures.requests.query).convert('shell', 'httpie', {
       indent: false,
       queryParams: true
     })
@@ -72,7 +70,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should build parameterized output of query string', function () {
-    var result = new HTTPSnippet(fixtures.requests.query).convert('shell', 'httpie', {
+    const result = new HTTPSnippet(fixtures.requests.query).convert('shell', 'httpie', {
       indent: false,
       queryParams: true
     })
@@ -82,7 +80,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should build parameterized output of post data', function () {
-    var result = new HTTPSnippet(fixtures.requests['application-form-encoded']).convert('shell', 'httpie', {
+    const result = new HTTPSnippet(fixtures.requests['application-form-encoded']).convert('shell', 'httpie', {
       short: true,
       indent: false,
       queryParams: true

--- a/test/targets/shell/wget.js
+++ b/test/targets/shell/wget.js
@@ -1,12 +1,10 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
   it('should use short options', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'wget', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'wget', {
       short: true,
       indent: false
     })
@@ -16,7 +14,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should ask for -v output', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'wget', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'wget', {
       short: true,
       indent: false,
       verbose: true
@@ -27,7 +25,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should ask for --verbose output', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'wget', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('shell', 'wget', {
       short: false,
       indent: false,
       verbose: true
@@ -38,7 +36,7 @@ module.exports = function (HTTPSnippet, fixtures) {
   })
 
   it('should use custom indentation', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'wget', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'wget', {
       indent: '@'
     })
 

--- a/test/targets/swift/nsurlsession.js
+++ b/test/targets/swift/nsurlsession.js
@@ -1,36 +1,37 @@
-/* global it */
-
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
   it('should support an indent option', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('swift', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('swift', {
       indent: '    '
     })
 
     result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('import Foundationlet request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har")! as URL,                                        cachePolicy: .useProtocolCachePolicy,                                    timeoutInterval: 10.0)request.httpMethod = "GET"let session = URLSession.sharedlet dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in    if (error != nil) {        print(error)    } else {        let httpResponse = response as? HTTPURLResponse        print(httpResponse)    }})dataTask.resume()')
   })
+
   it('should support a timeout option', function () {
-    var result = new HTTPSnippet(fixtures.requests.short).convert('swift', {
+    const result = new HTTPSnippet(fixtures.requests.short).convert('swift', {
       timeout: 5
     })
 
     result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('import Foundationlet request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har")! as URL,                                        cachePolicy: .useProtocolCachePolicy,                                    timeoutInterval: 5.0)request.httpMethod = "GET"let session = URLSession.sharedlet dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in  if (error != nil) {    print(error)  } else {    let httpResponse = response as? HTTPURLResponse    print(httpResponse)  }})dataTask.resume()')
   })
+
   it('should support pretty option', function () {
-    var result = new HTTPSnippet(fixtures.requests.full).convert('swift', {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('swift', {
       pretty: false
     })
 
     result.should.be.a.String()
     result.replace(/\n/g, '').should.eql('import Foundationlet headers = ["cookie": "foo=bar; bar=baz", "accept": "application/json", "content-type": "application/x-www-form-urlencoded"]let postData = NSMutableData(data: "foo=bar".data(using: String.Encoding.utf8)!)let request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value")! as URL,                                        cachePolicy: .useProtocolCachePolicy,                                    timeoutInterval: 10.0)request.httpMethod = "POST"request.allHTTPHeaderFields = headersrequest.httpBody = postData as Datalet session = URLSession.sharedlet dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in  if (error != nil) {    print(error)  } else {    let httpResponse = response as? HTTPURLResponse    print(httpResponse)  }})dataTask.resume()')
   })
+
   it('should support json object with null value', function () {
-    var result = new HTTPSnippet(fixtures.requests['jsonObj-null-value']).convert('swift', {
+    const result = new HTTPSnippet(fixtures.requests['jsonObj-null-value']).convert('swift', {
       pretty: false
     })
 


### PR DESCRIPTION
The current earliest version of Node that HTTPSnippet targets is Node 4 which was EOL'd in 2018. Probably time to cut it loose.

* [x] Zero changes to library functionality or usage.
* [x] Changes the `engines` requirement to be >=10.
  * One thing that'll need to be addressed at some point is that `url.parse` was deprecated in Node 11, and `urlObj` is populated with that.
  * We might be able to eschew the `url` dependency all together since it's just being used for `url.parse` and `url.format`. The new [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL) should be able to be adequate.
* [x] Upgrades `mocha` and `standard` to their latest versions now that we're no longer blocked by the node@4 requirement.
* [x] Fixes a host of Standard issues that appeared with the upgrade.
* [x] Removes the `pinkie-promise` dependency as it's not used anywhere anymore.