### PR TITLE
feat: add parameter to enable decode url for place holder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 node_modules
 coverage*
+.DS_Store

--- a/src/index.js
+++ b/src/index.js
@@ -220,21 +220,21 @@ HTTPSnippet.prototype.prepare = function (request) {
   // reset uriObj values for a clean url
   request.uriObj.query = null
   request.uriObj.search = null
-  request.uriObj.path = request.uriObj.pathname
+  request.uriObj.path = decodeURI(request.uriObj.pathname)
 
   // keep the base url clean of queryString
-  request.url = url.format(request.uriObj)
+  request.url = decodeURI(url.format(request.uriObj))
 
   // update the uri object
   request.uriObj.query = request.queryObj
   request.uriObj.search = qs.stringify(request.queryObj)
 
   if (request.uriObj.search) {
-    request.uriObj.path = request.uriObj.pathname + '?' + request.uriObj.search
+    request.uriObj.path = decodeURI(request.uriObj.pathname) + '?' + request.uriObj.search
   }
 
   // construct a full url
-  request.fullUrl = url.format(request.uriObj)
+  request.fullUrl = decodeURI(url.format(request.uriObj))
 
   return request
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ var validate = require('har-validator/lib/async')
 const { formDataIterator, isBlob } = require('./helpers/form-data.js')
 
 // constructor
-var HTTPSnippet = function (data) {
+var HTTPSnippet = function (data, encodeUri = true) {
   var entries
   var self = this
   var input = Object.assign({}, data)
@@ -50,12 +50,12 @@ var HTTPSnippet = function (data) {
         throw err
       }
 
-      self.requests.push(self.prepare(entry.request))
+      self.requests.push(self.prepare(entry.request, encodeUri))
     })
   })
 }
 
-HTTPSnippet.prototype.prepare = function (request) {
+HTTPSnippet.prototype.prepare = function (request, encodeUri = true) {
   // construct utility properties
   request.queryObj = {}
   request.headersObj = {}
@@ -220,21 +220,31 @@ HTTPSnippet.prototype.prepare = function (request) {
   // reset uriObj values for a clean url
   request.uriObj.query = null
   request.uriObj.search = null
-  request.uriObj.path = decodeURI(request.uriObj.pathname)
+  request.uriObj.path = request.uriObj.pathname
+  if (!encodeUri) {
+    request.uriObj.path = decodeURI(request.uriObj.pathname)
+  }
+  
 
   // keep the base url clean of queryString
-  request.url = decodeURI(url.format(request.uriObj))
+  request.url = url.format(request.uriObj)
+  if (!encodeUri) {
+    request.url = decodeURI(url.format(request.uriObj))
+  }
 
   // update the uri object
   request.uriObj.query = request.queryObj
   request.uriObj.search = qs.stringify(request.queryObj)
 
   if (request.uriObj.search) {
-    request.uriObj.path = decodeURI(request.uriObj.pathname) + '?' + request.uriObj.search
+    request.uriObj.path = request.uriObj.pathname + '?' + request.uriObj.search
   }
 
   // construct a full url
-  request.fullUrl = decodeURI(url.format(request.uriObj))
+  request.fullUrl = url.format(request.uriObj)
+  if (!encodeUri) {
+    request.fullUrl = decodeURI(url.format(request.uriObj))
+  }
 
   return request
 }

--- a/src/index.js
+++ b/src/index.js
@@ -167,21 +167,21 @@ HTTPSnippet.prototype.prepare = function (request) {
   // reset uriObj values for a clean url
   request.uriObj.query = null
   request.uriObj.search = null
-  request.uriObj.path = request.uriObj.pathname
+  request.uriObj.path = decodeURI(request.uriObj.pathname)
 
   // keep the base url clean of queryString
-  request.url = url.format(request.uriObj)
+  request.url = decodeURI(url.format(request.uriObj))
 
   // update the uri object
   request.uriObj.query = request.queryObj
   request.uriObj.search = qs.stringify(request.queryObj)
 
   if (request.uriObj.search) {
-    request.uriObj.path = request.uriObj.pathname + '?' + request.uriObj.search
+    request.uriObj.path = decodeURI(request.uriObj.pathname) + '?' + request.uriObj.search
   }
 
   // construct a full url
-  request.fullUrl = url.format(request.uriObj)
+  request.fullUrl = decodeURI(url.format(request.uriObj))
 
   return request
 }

--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,6 @@ HTTPSnippet.prototype.prepare = function (request, encodeUri = true) {
   if (!encodeUri) {
     request.uriObj.path = decodeURI(request.uriObj.pathname)
   }
-  
 
   // keep the base url clean of queryString
   request.url = url.format(request.uriObj)

--- a/src/index.js
+++ b/src/index.js
@@ -221,15 +221,9 @@ HTTPSnippet.prototype.prepare = function (request, encodeUri = true) {
   request.uriObj.query = null
   request.uriObj.search = null
   request.uriObj.path = request.uriObj.pathname
-  if (!encodeUri) {
-    request.uriObj.path = decodeURI(request.uriObj.pathname)
-  }
 
   // keep the base url clean of queryString
   request.url = url.format(request.uriObj)
-  if (!encodeUri) {
-    request.url = decodeURI(url.format(request.uriObj))
-  }
 
   // update the uri object
   request.uriObj.query = request.queryObj
@@ -241,8 +235,14 @@ HTTPSnippet.prototype.prepare = function (request, encodeUri = true) {
 
   // construct a full url
   request.fullUrl = url.format(request.uriObj)
+
+
   if (!encodeUri) {
-    request.fullUrl = decodeURI(url.format(request.uriObj))
+    request.fullUrl = decodeURI(request.fullUrl)
+    request.url = decodeURI(request.url)
+    request.uriObj.path = decodeURI(request.uriObj.path)
+    request.uriObj.pathname = decodeURI(request.uriObj.pathname)
+    request.uriObj.href = decodeURI(request.uriObj.href)
   }
 
   return request


### PR DESCRIPTION
Hi, forks.
I am experiencing some issues of using this library.
Say I have a url : http://mockbin.com/request/{id}, the {id} is a place holder. When generating snippets, I do not want the place holder to be uri encoded. 
If I use current code: there would be a  "http://mockbin.com/request/%7Bid%7D"
But I actually want "http://mockbin.com/request/{id}" here.

So I want to add a switch on httpSnippet to decide whether we should use uriencode here. (Default is yes, so this will not be a breaking change)  
