### PR TITLE
fix: node-fetch doesn't support the `qs` option

### DIFF
--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -22,13 +22,9 @@ module.exports = function (source, options) {
   var code = new CodeBuilder(opts.indent)
 
   code.push('const fetch = require(\'node-fetch\');')
-  var url = source.url
+  var url = source.fullUrl
   var reqOpts = {
     method: source.method
-  }
-
-  if (Object.keys(source.queryObj).length) {
-    reqOpts.qs = source.queryObj
   }
 
   if (Object.keys(source.headersObj).length) {

--- a/test/fixtures/output/node/fetch/full.js
+++ b/test/fixtures/output/node/fetch/full.js
@@ -4,11 +4,10 @@ const encodedParams = new URLSearchParams();
 
 encodedParams.set('foo', 'bar');
 
-let url = 'http://mockbin.com/har';
+let url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
 
 let options = {
   method: 'POST',
-  qs: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'},
   headers: {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded',

--- a/test/fixtures/output/node/fetch/query.js
+++ b/test/fixtures/output/node/fetch/query.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+let url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
 
-let options = {method: 'GET', qs: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}};
+let options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())


### PR DESCRIPTION
This fixes the Node `fetch` target to no longer supply query params through the `qs` option (which it does not support).

Fixes https://github.com/Kong/httpsnippet/issues/201