### PR TITLE
fix: not sending form urlencoded properly in JS fetch snippets

### DIFF
--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -67,7 +67,17 @@ module.exports = function (source, options) {
       }
   }
 
-  code.push('const options = %s;', stringifyObject(options, { indent: opts.indent, inlineCharacterLimit: 80 }))
+  code.push('const options = %s;', stringifyObject(options, {
+    indent: opts.indent,
+    inlineCharacterLimit: 80,
+    transform: (object, property, originalResult) => {
+      if (property === 'body' && source.postData.mimeType === 'application/x-www-form-urlencoded') {
+        return `new URLSearchParams(${originalResult})`
+      }
+
+      return originalResult
+    }
+  }))
     .blank()
 
   if (source.postData.mimeType === 'multipart/form-data') {

--- a/test/fixtures/output/javascript/fetch/application-form-encoded.js
+++ b/test/fixtures/output/javascript/fetch/application-form-encoded.js
@@ -1,7 +1,7 @@
 const options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  body: {foo: 'bar', hello: 'world'}
+  body: new URLSearchParams({foo: 'bar', hello: 'world'})
 };
 
 fetch('http://mockbin.com/har', options)

--- a/test/fixtures/output/javascript/fetch/full.js
+++ b/test/fixtures/output/javascript/fetch/full.js
@@ -5,7 +5,7 @@ const options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  body: {foo: 'bar'}
+  body: new URLSearchParams({foo: 'bar'})
 };
 
 fetch('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', options)


### PR DESCRIPTION
JS `fetch` body needs to be a string, and we were sending objects on `x-www-url-formencoded` requests. This fixes that by wrapping those objects in `new URLSearchParams()`.