### PR TITLE
pass extra options to httpsnippet (pass through to the target)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --save httpsnippet
 
 ```
 
-  Usage: httpsnippet [options] <file>
+  Usage: httpsnippet [options] <files ...>
 
   Options:
 
@@ -32,6 +32,7 @@ npm install --save httpsnippet
     -t, --target <target>     target output
     -c, --client [client]     target client library
     -o, --output <directory>  write output to directory
+    -x, --extra [{"optionKey": "optionValue"}]  provide extra options for the target/client
 
 ```
 
@@ -62,6 +63,13 @@ snippets/
 ├── endpoint-2.js
 └── endpoint-3.js
 ```
+
+provide extra options:
+
+```shell
+httpsnippet example.json --target http --output ./snippets -x '{"autoHost": false, "autoContentLength": false}'
+```
+
 
 ## API
 

--- a/bin/httpsnippet
+++ b/bin/httpsnippet
@@ -17,10 +17,21 @@ cmd
   .option('-t, --target <target>', 'target output')
   .option('-c, --client [client]', 'target client library')
   .option('-o, --output <directory>', 'write output to directory')
+  .option('-x, --extra [{"optionKey": "optionValue"}]', 'provide extra options for the target/client')
   .parse(process.argv)
 
 if (!cmd.args.length || !cmd.target) {
   cmd.help()
+}
+
+let extraOptions
+if (cmd.extra) {
+  try {
+    extraOptions = JSON.parse(cmd.extra)
+  } catch (e) {
+    console.error('%s failed to parse options %s (should be JSON)', chalk.red('✖'), chalk.cyan.bold(cmd.extra))
+    process.exit()
+  }
 }
 
 let dir
@@ -53,7 +64,7 @@ cmd.args.forEach(function (fileName) {
     })
 
     .then(function (snippet) {
-      return snippet.convert(cmd.target, cmd.client)
+      return snippet.convert(cmd.target, cmd.client, extraOptions)
     })
 
     .then(function (output) {


### PR DESCRIPTION
Hi! I could not find an option to provide extra options to the target. For example if I don't need Host or ContentLength at the http target. Added an option to provide extra options to the target, updated readme

Example:

```shell
httpsnippet example.json --target http --output ./snippets -x '{"autoHost": false, "autoContentLength": false}'
```