### PR TITLE
feat: make Python snippets simpler, clearer & more consistent

### DIFF
--- a/src/targets/python/helpers.js
+++ b/src/targets/python/helpers.js
@@ -25,6 +25,8 @@ function concatValues (concatType, values, pretty, indentation, indentLevel) {
 
   if (pretty) {
     return openingBrace + '\n' + currentIndent + values.join(join) + '\n' + closingBraceIndent + closingBrace
+  } else if (concatType === 'object' && values.length > 0) {
+    return openingBrace + ' ' + values.join(join) + ' ' + closingBrace
   } else {
     return openingBrace + values.join(join) + closingBrace
   }

--- a/src/targets/python/python3.js
+++ b/src/targets/python/python3.js
@@ -40,7 +40,7 @@ module.exports = function (source, options) {
   const headerCount = Object.keys(headers).length
   if (headerCount === 1) {
     for (const header in headers) {
-      code.push('headers = { \'%s\': "%s" }', header, headers[header])
+      code.push('headers = { "%s": "%s" }', header, headers[header])
         .blank()
     }
   } else if (headerCount > 1) {
@@ -50,9 +50,9 @@ module.exports = function (source, options) {
 
     for (const header in headers) {
       if (count++ !== headerCount) {
-        code.push('    \'%s\': "%s",', header, headers[header])
+        code.push('    "%s": "%s",', header, headers[header])
       } else {
-        code.push('    \'%s\': "%s"', header, headers[header])
+        code.push('    "%s": "%s"', header, headers[header])
       }
     }
 

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -14,6 +14,16 @@ const util = require('util')
 const CodeBuilder = require('../../helpers/code-builder')
 const helpers = require('./helpers')
 
+const builtInMethods = [
+  'HEAD',
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'OPTIONS'
+]
+
 module.exports = function (source, options) {
   const opts = Object.assign({
     indent: '    ',
@@ -89,7 +99,10 @@ module.exports = function (source, options) {
 
   // Construct request
   const method = source.method
-  let request = util.format('response = requests.request("%s", url', method)
+
+  let request = builtInMethods.includes(method)
+    ? util.format('response = requests.%s(url', method.toLowerCase())
+    : util.format('response = requests.request("%s", url', method)
 
   if (hasPayload) {
     if (jsonPayload) {

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -62,6 +62,14 @@ module.exports = function (source, options) {
       }
       break
 
+    case 'application/x-www-form-urlencoded':
+      if (source.postData.paramsObj) {
+        code.push('payload = %s', helpers.literalRepresentation(source.postData.paramsObj, opts))
+        hasPayload = true
+        break
+      }
+      // Otherwise, fall through to treat as plain text:
+
     default: {
       const payload = JSON.stringify(source.postData.text)
       if (payload) {

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -34,7 +34,7 @@ module.exports = function (source, options) {
   // Construct query string
   let qs
   if (Object.keys(source.queryObj).length) {
-    qs = 'querystring = ' + JSON.stringify(source.queryObj)
+    qs = 'querystring = ' + helpers.literalRepresentation(source.queryObj, opts)
 
     code.push(qs)
       .blank()
@@ -67,7 +67,7 @@ module.exports = function (source, options) {
 
   if (headerCount === 1) {
     for (const header in headers) {
-      code.push('headers = {"%s": "%s"}', header, headers[header])
+      code.push('headers = { "%s": "%s" }', header, headers[header])
         .blank()
     }
   } else if (headerCount > 1) {

--- a/test/fixtures/output/python/python3/application-form-encoded.py
+++ b/test/fixtures/output/python/python3/application-form-encoded.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "foo=bar&hello=world"
 
-headers = { 'content-type': "application/x-www-form-urlencoded" }
+headers = { "content-type": "application/x-www-form-urlencoded" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/python3/application-json.py
+++ b/test/fixtures/output/python/python3/application-json.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"
 
-headers = { 'content-type': "application/json" }
+headers = { "content-type": "application/json" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/python3/cookies.py
+++ b/test/fixtures/output/python/python3/cookies.py
@@ -2,7 +2,7 @@ import http.client
 
 conn = http.client.HTTPConnection("mockbin.com")
 
-headers = { 'cookie': "foo=bar; bar=baz" }
+headers = { "cookie": "foo=bar; bar=baz" }
 
 conn.request("POST", "/har", headers=headers)
 

--- a/test/fixtures/output/python/python3/full.py
+++ b/test/fixtures/output/python/python3/full.py
@@ -5,9 +5,9 @@ conn = http.client.HTTPConnection("mockbin.com")
 payload = "foo=bar"
 
 headers = {
-    'cookie': "foo=bar; bar=baz",
-    'accept': "application/json",
-    'content-type': "application/x-www-form-urlencoded"
+    "cookie": "foo=bar; bar=baz",
+    "accept": "application/json",
+    "content-type": "application/x-www-form-urlencoded"
     }
 
 conn.request("POST", "/har?foo=bar&foo=baz&baz=abc&key=value", payload, headers)

--- a/test/fixtures/output/python/python3/headers.py
+++ b/test/fixtures/output/python/python3/headers.py
@@ -3,8 +3,8 @@ import http.client
 conn = http.client.HTTPConnection("mockbin.com")
 
 headers = {
-    'accept': "application/json",
-    'x-foo': "Bar"
+    "accept": "application/json",
+    "x-foo": "Bar"
     }
 
 conn.request("GET", "/har", headers=headers)

--- a/test/fixtures/output/python/python3/jsonObj-multiline.py
+++ b/test/fixtures/output/python/python3/jsonObj-multiline.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "{\n  \"foo\": \"bar\"\n}"
 
-headers = { 'content-type': "application/json" }
+headers = { "content-type": "application/json" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/python3/jsonObj-null-value.py
+++ b/test/fixtures/output/python/python3/jsonObj-null-value.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "{\"foo\":null}"
 
-headers = { 'content-type': "application/json" }
+headers = { "content-type": "application/json" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/python3/multipart-data.py
+++ b/test/fixtures/output/python/python3/multipart-data.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n"
 
-headers = { 'content-type': "multipart/form-data; boundary=---011000010111000001101001" }
+headers = { "content-type": "multipart/form-data; boundary=---011000010111000001101001" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/python3/multipart-file.py
+++ b/test/fixtures/output/python/python3/multipart-file.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n"
 
-headers = { 'content-type': "multipart/form-data; boundary=---011000010111000001101001" }
+headers = { "content-type": "multipart/form-data; boundary=---011000010111000001101001" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/python3/multipart-form-data.py
+++ b/test/fixtures/output/python/python3/multipart-form-data.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n"
 
-headers = { 'Content-Type': "multipart/form-data; boundary=---011000010111000001101001" }
+headers = { "Content-Type": "multipart/form-data; boundary=---011000010111000001101001" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/python3/text-plain.py
+++ b/test/fixtures/output/python/python3/text-plain.py
@@ -4,7 +4,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 
 payload = "Hello World"
 
-headers = { 'content-type': "text/plain" }
+headers = { "content-type": "text/plain" }
 
 conn.request("POST", "/har", payload, headers)
 

--- a/test/fixtures/output/python/requests/application-form-encoded.py
+++ b/test/fixtures/output/python/requests/application-form-encoded.py
@@ -2,7 +2,10 @@ import requests
 
 url = "http://mockbin.com/har"
 
-payload = "foo=bar&hello=world"
+payload = {
+    "foo": "bar",
+    "hello": "world"
+}
 headers = { "content-type": "application/x-www-form-urlencoded" }
 
 response = requests.post(url, data=payload, headers=headers)

--- a/test/fixtures/output/python/requests/application-form-encoded.py
+++ b/test/fixtures/output/python/requests/application-form-encoded.py
@@ -5,6 +5,6 @@ url = "http://mockbin.com/har"
 payload = "foo=bar&hello=world"
 headers = { "content-type": "application/x-www-form-urlencoded" }
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/application-form-encoded.py
+++ b/test/fixtures/output/python/requests/application-form-encoded.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "foo=bar&hello=world"
-headers = {"content-type": "application/x-www-form-urlencoded"}
+headers = { "content-type": "application/x-www-form-urlencoded" }
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/application-json.py
+++ b/test/fixtures/output/python/requests/application-json.py
@@ -12,6 +12,6 @@ payload = {
 }
 headers = { "content-type": "application/json" }
 
-response = requests.request("POST", url, json=payload, headers=headers)
+response = requests.post(url, json=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/application-json.py
+++ b/test/fixtures/output/python/requests/application-json.py
@@ -6,11 +6,11 @@ payload = {
     "number": 1,
     "string": "f\"oo",
     "arr": [1, 2, 3],
-    "nested": {"a": "b"},
-    "arr_mix": [1, "a", {"arr_mix_nested": {}}],
+    "nested": { "a": "b" },
+    "arr_mix": [1, "a", { "arr_mix_nested": {} }],
     "boolean": False
 }
-headers = {"content-type": "application/json"}
+headers = { "content-type": "application/json" }
 
 response = requests.request("POST", url, json=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/cookies.py
+++ b/test/fixtures/output/python/requests/cookies.py
@@ -4,6 +4,6 @@ url = "http://mockbin.com/har"
 
 headers = { "cookie": "foo=bar; bar=baz" }
 
-response = requests.request("POST", url, headers=headers)
+response = requests.post(url, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/cookies.py
+++ b/test/fixtures/output/python/requests/cookies.py
@@ -2,7 +2,7 @@ import requests
 
 url = "http://mockbin.com/har"
 
-headers = {"cookie": "foo=bar; bar=baz"}
+headers = { "cookie": "foo=bar; bar=baz" }
 
 response = requests.request("POST", url, headers=headers)
 

--- a/test/fixtures/output/python/requests/full.py
+++ b/test/fixtures/output/python/requests/full.py
@@ -2,7 +2,11 @@ import requests
 
 url = "http://mockbin.com/har"
 
-querystring = {"foo":["bar","baz"],"baz":"abc","key":"value"}
+querystring = {
+    "foo": ["bar", "baz"],
+    "baz": "abc",
+    "key": "value"
+}
 
 payload = "foo=bar"
 headers = {

--- a/test/fixtures/output/python/requests/full.py
+++ b/test/fixtures/output/python/requests/full.py
@@ -15,6 +15,6 @@ headers = {
     "content-type": "application/x-www-form-urlencoded"
 }
 
-response = requests.request("POST", url, data=payload, headers=headers, params=querystring)
+response = requests.post(url, data=payload, headers=headers, params=querystring)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/full.py
+++ b/test/fixtures/output/python/requests/full.py
@@ -8,7 +8,7 @@ querystring = {
     "key": "value"
 }
 
-payload = "foo=bar"
+payload = { "foo": "bar" }
 headers = {
     "cookie": "foo=bar; bar=baz",
     "accept": "application/json",

--- a/test/fixtures/output/python/requests/headers.py
+++ b/test/fixtures/output/python/requests/headers.py
@@ -7,6 +7,6 @@ headers = {
     "x-foo": "Bar"
 }
 
-response = requests.request("GET", url, headers=headers)
+response = requests.get(url, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/https.py
+++ b/test/fixtures/output/python/requests/https.py
@@ -2,6 +2,6 @@ import requests
 
 url = "https://mockbin.com/har"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/jsonObj-multiline.py
+++ b/test/fixtures/output/python/requests/jsonObj-multiline.py
@@ -5,6 +5,6 @@ url = "http://mockbin.com/har"
 payload = { "foo": "bar" }
 headers = { "content-type": "application/json" }
 
-response = requests.request("POST", url, json=payload, headers=headers)
+response = requests.post(url, json=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/jsonObj-multiline.py
+++ b/test/fixtures/output/python/requests/jsonObj-multiline.py
@@ -2,8 +2,8 @@ import requests
 
 url = "http://mockbin.com/har"
 
-payload = {"foo": "bar"}
-headers = {"content-type": "application/json"}
+payload = { "foo": "bar" }
+headers = { "content-type": "application/json" }
 
 response = requests.request("POST", url, json=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/jsonObj-null-value.py
+++ b/test/fixtures/output/python/requests/jsonObj-null-value.py
@@ -2,8 +2,8 @@ import requests
 
 url = "http://mockbin.com/har"
 
-payload = {"foo": None}
-headers = {"content-type": "application/json"}
+payload = { "foo": None }
+headers = { "content-type": "application/json" }
 
 response = requests.request("POST", url, json=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/jsonObj-null-value.py
+++ b/test/fixtures/output/python/requests/jsonObj-null-value.py
@@ -5,6 +5,6 @@ url = "http://mockbin.com/har"
 payload = { "foo": None }
 headers = { "content-type": "application/json" }
 
-response = requests.request("POST", url, json=payload, headers=headers)
+response = requests.post(url, json=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/multipart-data.py
+++ b/test/fixtures/output/python/requests/multipart-data.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n"
-headers = {"content-type": "multipart/form-data; boundary=---011000010111000001101001"}
+headers = { "content-type": "multipart/form-data; boundary=---011000010111000001101001" }
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/multipart-data.py
+++ b/test/fixtures/output/python/requests/multipart-data.py
@@ -5,6 +5,6 @@ url = "http://mockbin.com/har"
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n"
 headers = { "content-type": "multipart/form-data; boundary=---011000010111000001101001" }
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/multipart-file.py
+++ b/test/fixtures/output/python/requests/multipart-file.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n"
-headers = {"content-type": "multipart/form-data; boundary=---011000010111000001101001"}
+headers = { "content-type": "multipart/form-data; boundary=---011000010111000001101001" }
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/multipart-file.py
+++ b/test/fixtures/output/python/requests/multipart-file.py
@@ -5,6 +5,6 @@ url = "http://mockbin.com/har"
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n"
 headers = { "content-type": "multipart/form-data; boundary=---011000010111000001101001" }
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/multipart-form-data.py
+++ b/test/fixtures/output/python/requests/multipart-form-data.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n"
-headers = {"Content-Type": "multipart/form-data; boundary=---011000010111000001101001"}
+headers = { "Content-Type": "multipart/form-data; boundary=---011000010111000001101001" }
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/multipart-form-data.py
+++ b/test/fixtures/output/python/requests/multipart-form-data.py
@@ -5,6 +5,6 @@ url = "http://mockbin.com/har"
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n"
 headers = { "Content-Type": "multipart/form-data; boundary=---011000010111000001101001" }
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/nested.py
+++ b/test/fixtures/output/python/requests/nested.py
@@ -2,7 +2,11 @@ import requests
 
 url = "http://mockbin.com/har"
 
-querystring = {"foo[bar]":"baz,zap","fiz":"buz","key":"value"}
+querystring = {
+    "foo[bar]": "baz,zap",
+    "fiz": "buz",
+    "key": "value"
+}
 
 response = requests.request("GET", url, params=querystring)
 

--- a/test/fixtures/output/python/requests/nested.py
+++ b/test/fixtures/output/python/requests/nested.py
@@ -8,6 +8,6 @@ querystring = {
     "key": "value"
 }
 
-response = requests.request("GET", url, params=querystring)
+response = requests.get(url, params=querystring)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/query.py
+++ b/test/fixtures/output/python/requests/query.py
@@ -2,7 +2,11 @@ import requests
 
 url = "http://mockbin.com/har"
 
-querystring = {"foo":["bar","baz"],"baz":"abc","key":"value"}
+querystring = {
+    "foo": ["bar", "baz"],
+    "baz": "abc",
+    "key": "value"
+}
 
 response = requests.request("GET", url, params=querystring)
 

--- a/test/fixtures/output/python/requests/query.py
+++ b/test/fixtures/output/python/requests/query.py
@@ -8,6 +8,6 @@ querystring = {
     "key": "value"
 }
 
-response = requests.request("GET", url, params=querystring)
+response = requests.get(url, params=querystring)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/short.py
+++ b/test/fixtures/output/python/requests/short.py
@@ -2,6 +2,6 @@ import requests
 
 url = "http://mockbin.com/har"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/text-plain.py
+++ b/test/fixtures/output/python/requests/text-plain.py
@@ -5,6 +5,6 @@ url = "http://mockbin.com/har"
 payload = "Hello World"
 headers = { "content-type": "text/plain" }
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/text-plain.py
+++ b/test/fixtures/output/python/requests/text-plain.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "Hello World"
-headers = {"content-type": "text/plain"}
+headers = { "content-type": "text/plain" }
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/targets/python/requests.js
+++ b/test/targets/python/requests.js
@@ -13,7 +13,7 @@ module.exports = function (HTTPSnippet) {
 
 url = "http://mockbin.com/har"
 
-querystring = {"param":"value"}
+querystring = { "param": "value" }
 
 response = requests.request("GET", url, params=querystring)
 

--- a/test/targets/python/requests.js
+++ b/test/targets/python/requests.js
@@ -15,7 +15,7 @@ url = "http://mockbin.com/har"
 
 querystring = { "param": "value" }
 
-response = requests.request("GET", url, params=querystring)
+response = requests.get(url, params=querystring)
 
 print(response.text)`)
   })


### PR DESCRIPTION
This PR does three things (split into 3 commits):

* Previously the Python snippets used a mixture of single & double quotes, with a mixture of dictionary literal formats: e.g. `{'a':"b"}` vs `{ "a": "b" }`. It's now consistent, so there's spaces and nice formatting for all dictionary literals, and double quotes everywhere (that seemed to be the smaller change, Python community doesn't seem to have a strong preference on single/double, other than 'be consistent').
* Python Requests has built-in methods for most standard HTTP methods. The code now simplifies code by using those where possible, changing `requests.request("POST", ...)` for `requests.post(...)`.
* Python Requests can accept dictionary literals for form-encoded bodies, so we now do that when `source.postData.paramsObj` is available, to make that body content more readable.