### PR TITLE
fix(curl) remove boundary form content-type header

### DIFF
--- a/test/fixtures/output/shell/curl/multipart-data.sh
+++ b/test/fixtures/output/shell/curl/multipart-data.sh
@@ -1,4 +1,4 @@
 curl --request POST \
   --url http://mockbin.com/har \
-  --header 'content-type: multipart/form-data; boundary=---011000010111000001101001' \
+  --header 'content-type: multipart/form-data' \
   --form foo=@hello.txt

--- a/test/fixtures/output/shell/curl/multipart-file.sh
+++ b/test/fixtures/output/shell/curl/multipart-file.sh
@@ -1,4 +1,4 @@
 curl --request POST \
   --url http://mockbin.com/har \
-  --header 'content-type: multipart/form-data; boundary=---011000010111000001101001' \
+  --header 'content-type: multipart/form-data' \
   --form foo=@test/fixtures/files/hello.txt

--- a/test/fixtures/output/shell/curl/multipart-form-data.sh
+++ b/test/fixtures/output/shell/curl/multipart-form-data.sh
@@ -1,4 +1,4 @@
 curl --request POST \
   --url http://mockbin.com/har \
-  --header 'Content-Type: multipart/form-data; boundary=---011000010111000001101001' \
+  --header 'Content-Type: multipart/form-data' \
   --form foo=bar


### PR DESCRIPTION
Resolves https://github.com/Kong/httpsnippet/issues/226

This PR removes the boundary from the content-type header for curl multipart request. Curl appends its own boundary when using `--form`, resulting in a double boundary.
