### PR TITLE
fix: multipart/form-data header issues with node/js fetch targets

### DIFF
--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -10,7 +10,7 @@
 
 'use strict'
 
-const headerHelpers = require('../../helpers/headers');
+const headerHelpers = require('../../helpers/headers')
 const CodeBuilder = require('../../helpers/code-builder')
 const stringifyObject = require('stringify-object')
 
@@ -32,10 +32,10 @@ module.exports = function (source, options) {
   // The `form-data` library automatically adds a `Content-Type` header for `multipart/form-data` content and if we
   // add our own here, data won't be correctly transferred.
   if (source.postData.mimeType === 'multipart/form-data') {
-    const contentTypeHeader = headerHelpers.getHeaderName(source.allHeaders, 'content-type');
+    const contentTypeHeader = headerHelpers.getHeaderName(source.allHeaders, 'content-type')
     if (contentTypeHeader) {
       // eslint-disable-next-line no-param-reassign
-      delete source.allHeaders[contentTypeHeader];
+      delete source.allHeaders[contentTypeHeader]
     }
   }
 

--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -10,7 +10,7 @@
 
 'use strict'
 
-const headerHelpers = require('../../helpers/headers');
+const headerHelpers = require('../../helpers/headers')
 const stringifyObject = require('stringify-object')
 const CodeBuilder = require('../../helpers/code-builder')
 
@@ -31,10 +31,10 @@ module.exports = function (source, options) {
   // The `form-data` library automatically adds a `Content-Type` header for `multipart/form-data` content and if we
   // add our own here, data won't be correctly transferred.
   if (source.postData.mimeType === 'multipart/form-data') {
-    const contentTypeHeader = headerHelpers.getHeaderName(source.headersObj, 'content-type');
+    const contentTypeHeader = headerHelpers.getHeaderName(source.headersObj, 'content-type')
     if (contentTypeHeader) {
       // eslint-disable-next-line no-param-reassign
-      delete source.headersObj[contentTypeHeader];
+      delete source.headersObj[contentTypeHeader]
     }
   }
 

--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -10,6 +10,7 @@
 
 'use strict'
 
+const headerHelpers = require('../../helpers/headers');
 const stringifyObject = require('stringify-object')
 const CodeBuilder = require('../../helpers/code-builder')
 
@@ -25,6 +26,16 @@ module.exports = function (source, options) {
   const url = source.fullUrl
   const reqOpts = {
     method: source.method
+  }
+
+  // The `form-data` library automatically adds a `Content-Type` header for `multipart/form-data` content and if we
+  // add our own here, data won't be correctly transferred.
+  if (source.postData.mimeType === 'multipart/form-data') {
+    const contentTypeHeader = headerHelpers.getHeaderName(source.headersObj, 'content-type');
+    if (contentTypeHeader) {
+      // eslint-disable-next-line no-param-reassign
+      delete source.headersObj[contentTypeHeader];
+    }
   }
 
   if (Object.keys(source.headersObj).length) {

--- a/test/fixtures/output/javascript/fetch/multipart-data.js
+++ b/test/fixtures/output/javascript/fetch/multipart-data.js
@@ -1,10 +1,7 @@
 const form = new FormData();
 form.append("foo", "Hello World");
 
-const options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+const options = {method: 'POST'};
 
 options.body = form;
 

--- a/test/fixtures/output/javascript/fetch/multipart-file.js
+++ b/test/fixtures/output/javascript/fetch/multipart-file.js
@@ -1,10 +1,7 @@
 const form = new FormData();
 form.append("foo", "test/fixtures/files/hello.txt");
 
-const options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+const options = {method: 'POST'};
 
 options.body = form;
 

--- a/test/fixtures/output/javascript/fetch/multipart-form-data.js
+++ b/test/fixtures/output/javascript/fetch/multipart-form-data.js
@@ -1,10 +1,7 @@
 const form = new FormData();
 form.append("foo", "bar");
 
-const options = {
-  method: 'POST',
-  headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+const options = {method: 'POST'};
 
 options.body = form;
 

--- a/test/fixtures/output/node/fetch/multipart-data.js
+++ b/test/fixtures/output/node/fetch/multipart-data.js
@@ -7,10 +7,7 @@ formData.append('foo', fs.createReadStream('hello.txt'));
 
 let url = 'http://mockbin.com/har';
 
-let options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+let options = {method: 'POST'};
 
 options.body = formData;
 

--- a/test/fixtures/output/node/fetch/multipart-file.js
+++ b/test/fixtures/output/node/fetch/multipart-file.js
@@ -7,10 +7,7 @@ formData.append('foo', fs.createReadStream('test/fixtures/files/hello.txt'));
 
 let url = 'http://mockbin.com/har';
 
-let options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+let options = {method: 'POST'};
 
 options.body = formData;
 

--- a/test/fixtures/output/node/fetch/multipart-form-data.js
+++ b/test/fixtures/output/node/fetch/multipart-form-data.js
@@ -6,10 +6,7 @@ formData.append('foo', 'bar');
 
 let url = 'http://mockbin.com/har';
 
-let options = {
-  method: 'POST',
-  headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+let options = {method: 'POST'};
 
 options.body = formData;
 


### PR DESCRIPTION
Since #227 has us a bit spooked we've started testing other targets that may also have issues with `multipart/form-data` requests and found that both of the `fetch` targets for Node and JS are not currently transferring data properly because the custom header that is being added is clashing with the auto-generated header from the `FormData` API and `form-data` module.

You can see this problem in action with the `multipart-form-data` snippet against https://httpbin.org/anything:

```js
const FormData = require('form-data');
const fetch = require('node-fetch');
const formData = new FormData();

formData.append('foo', 'bar');

let url = 'https://httpbin.org/anything';

const options = {
  method: 'POST',
  headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
};

options.body = formData;

fetch(url, options)
  .then(res => res.json())
  .then(json => console.log(json))
  .catch(err => console.error('error:' + err));
```

```js
{
  args: {},
  data: '',
  files: {},
  form: {},
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'gzip,deflate',
    'Content-Length': '161',
    'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001',
    Host: 'httpbin.org',
    'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
    'X-Amzn-Trace-Id': 'Root=1-61428408-5a6abe107e16c34466e8e6ba'
  },
  json: null,
  method: 'POST',
  origin: 'REDACTED',
  url: 'https://httpbin.org/anything'
}
```

After removing the `multipart/form-data` header:

```js
{
  args: {},
  data: '',
  files: {},
  form: { foo: 'bar' },
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'gzip,deflate',
    'Content-Length': '161',
    'Content-Type': 'multipart/form-data;boundary=--------------------------635295776437093815404580',
    Host: 'httpbin.org',
    'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
    'X-Amzn-Trace-Id': 'Root=1-6142841e-4c789faa2a1d423452674f13'
  },
  json: null,
  method: 'POST',
  origin: '98.42.248.146',
  url: 'https://httpbin.org/anything'
}
```