### PR TITLE
fix: bug in the node request target where cookies weren't sent at all

### DIFF
--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -115,7 +115,7 @@ module.exports = function (source, options) {
     .push('});')
     .blank()
 
-  return code.join().replace('"JAR"', 'jar').replace(/'fs\.createReadStream\("(.+)"\)'/g, "fs.createReadStream('$1')")
+  return code.join().replace("'JAR'", 'jar').replace(/'fs\.createReadStream\("(.+)"\)'/g, "fs.createReadStream('$1')")
 }
 
 module.exports.info = {

--- a/test/fixtures/output/node/request/cookies.js
+++ b/test/fixtures/output/node/request/cookies.js
@@ -4,7 +4,7 @@ const jar = request.jar();
 jar.setCookie(request.cookie('foo=bar'), 'http://mockbin.com/har');
 jar.setCookie(request.cookie('bar=baz'), 'http://mockbin.com/har');
 
-const options = {method: 'POST', url: 'http://mockbin.com/har', jar: 'JAR'};
+const options = {method: 'POST', url: 'http://mockbin.com/har', jar: jar};
 
 request(options, function (error, response, body) {
   if (error) throw new Error(error);

--- a/test/fixtures/output/node/request/full.js
+++ b/test/fixtures/output/node/request/full.js
@@ -13,7 +13,7 @@ const options = {
     'content-type': 'application/x-www-form-urlencoded'
   },
   form: {foo: 'bar'},
-  jar: 'JAR'
+  jar: jar
 };
 
 request(options, function (error, response, body) {


### PR DESCRIPTION
This fixes a typo in some string replace code within the Node `request` target that was causing cookies to not be sent.