### PR TITLE
fix: axios targets not sending application/x-www-form-urlencoded properly

### DIFF
--- a/src/targets/javascript/axios.js
+++ b/src/targets/javascript/axios.js
@@ -38,7 +38,7 @@ module.exports = function (source, options) {
 
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
-      code.push('var encodedParams = new URLSearchParams();')
+      code.push('const encodedParams = new URLSearchParams();')
       code.blank()
 
       source.postData.params.forEach(function (param) {

--- a/src/targets/javascript/axios.js
+++ b/src/targets/javascript/axios.js
@@ -38,7 +38,16 @@ module.exports = function (source, options) {
 
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
-      reqOpts.data = source.postData.paramsObj
+      code.push('var encodedParams = new URLSearchParams();')
+      code.blank()
+
+      source.postData.params.forEach(function (param) {
+        code.push(`encodedParams.set('${param.name}', '${param.value}');`)
+      })
+
+      code.blank()
+
+      reqOpts.data = 'encodedParams'
       break
 
     case 'application/json':
@@ -78,7 +87,7 @@ module.exports = function (source, options) {
     .push(1, 'console.error(error);')
     .push('});')
 
-  return code.join()
+  return code.join().replace(/'encodedParams'/, 'encodedParams')
 }
 
 module.exports.info = {

--- a/src/targets/node/axios.js
+++ b/src/targets/node/axios.js
@@ -20,7 +20,7 @@ module.exports = function (source, options) {
 
   const code = new CodeBuilder(opts.indent)
 
-  code.push('var axios = require("axios").default;')
+  code.push('const axios = require("axios").default;')
     .blank()
 
   const reqOpts = {
@@ -38,8 +38,8 @@ module.exports = function (source, options) {
 
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
-      code.push("var { URLSearchParams } = require('url');")
-      code.push('var encodedParams = new URLSearchParams();')
+      code.push("const { URLSearchParams } = require('url');")
+      code.push('const encodedParams = new URLSearchParams();')
       code.blank()
 
       source.postData.params.forEach(function (param) {
@@ -63,7 +63,7 @@ module.exports = function (source, options) {
       }
   }
 
-  code.push('var options = %s;', stringifyObject(reqOpts, { indent: '  ', inlineCharacterLimit: 80 }))
+  code.push('const options = %s;', stringifyObject(reqOpts, { indent: '  ', inlineCharacterLimit: 80 }))
     .blank()
 
   code.push(util.format('axios.request(options).then(%s', 'function (response) {'))

--- a/src/targets/node/axios.js
+++ b/src/targets/node/axios.js
@@ -38,7 +38,17 @@ module.exports = function (source, options) {
 
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
-      reqOpts.data = source.postData.paramsObj
+      code.push("var { URLSearchParams } = require('url');")
+      code.push('var encodedParams = new URLSearchParams();')
+      code.blank()
+
+      source.postData.params.forEach(function (param) {
+        code.push(`encodedParams.set('${param.name}', '${param.value}');`)
+      })
+
+      code.blank()
+
+      reqOpts.data = 'encodedParams'
       break
 
     case 'application/json':
@@ -62,7 +72,7 @@ module.exports = function (source, options) {
     .push(1, 'console.error(error);')
     .push('});')
 
-  return code.join()
+  return code.join().replace(/'encodedParams'/, 'encodedParams')
 }
 
 module.exports.info = {

--- a/test/fixtures/output/javascript/axios/application-form-encoded.js
+++ b/test/fixtures/output/javascript/axios/application-form-encoded.js
@@ -1,10 +1,15 @@
 import axios from "axios";
 
+var encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
+encodedParams.set('hello', 'world');
+
 const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  data: {foo: 'bar', hello: 'world'}
+  data: encodedParams
 };
 
 axios.request(options).then(function (response) {

--- a/test/fixtures/output/javascript/axios/application-form-encoded.js
+++ b/test/fixtures/output/javascript/axios/application-form-encoded.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-var encodedParams = new URLSearchParams();
+const encodedParams = new URLSearchParams();
 
 encodedParams.set('foo', 'bar');
 encodedParams.set('hello', 'world');

--- a/test/fixtures/output/javascript/axios/full.js
+++ b/test/fixtures/output/javascript/axios/full.js
@@ -1,5 +1,9 @@
 import axios from "axios";
 
+var encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
+
 const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
@@ -9,7 +13,7 @@ const options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  data: {foo: 'bar'}
+  data: encodedParams
 };
 
 axios.request(options).then(function (response) {

--- a/test/fixtures/output/javascript/axios/full.js
+++ b/test/fixtures/output/javascript/axios/full.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-var encodedParams = new URLSearchParams();
+const encodedParams = new URLSearchParams();
 
 encodedParams.set('foo', 'bar');
 

--- a/test/fixtures/output/node/axios/application-form-encoded.js
+++ b/test/fixtures/output/node/axios/application-form-encoded.js
@@ -1,10 +1,16 @@
 var axios = require("axios").default;
 
+var { URLSearchParams } = require('url');
+var encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
+encodedParams.set('hello', 'world');
+
 var options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  data: {foo: 'bar', hello: 'world'}
+  data: encodedParams
 };
 
 axios.request(options).then(function (response) {

--- a/test/fixtures/output/node/axios/application-form-encoded.js
+++ b/test/fixtures/output/node/axios/application-form-encoded.js
@@ -1,12 +1,12 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var { URLSearchParams } = require('url');
-var encodedParams = new URLSearchParams();
+const { URLSearchParams } = require('url');
+const encodedParams = new URLSearchParams();
 
 encodedParams.set('foo', 'bar');
 encodedParams.set('hello', 'world');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/x-www-form-urlencoded'},

--- a/test/fixtures/output/node/axios/application-json.js
+++ b/test/fixtures/output/node/axios/application-json.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/test/fixtures/output/node/axios/cookies.js
+++ b/test/fixtures/output/node/axios/cookies.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {cookie: 'foo=bar; bar=baz'}

--- a/test/fixtures/output/node/axios/custom-method.js
+++ b/test/fixtures/output/node/axios/custom-method.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
+const options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
 
 axios.request(options).then(function (response) {
   console.log(response.data);

--- a/test/fixtures/output/node/axios/full.js
+++ b/test/fixtures/output/node/axios/full.js
@@ -1,5 +1,10 @@
 var axios = require("axios").default;
 
+var { URLSearchParams } = require('url');
+var encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
+
 var options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
@@ -9,7 +14,7 @@ var options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  data: {foo: 'bar'}
+  data: encodedParams
 };
 
 axios.request(options).then(function (response) {

--- a/test/fixtures/output/node/axios/full.js
+++ b/test/fixtures/output/node/axios/full.js
@@ -1,11 +1,11 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var { URLSearchParams } = require('url');
-var encodedParams = new URLSearchParams();
+const { URLSearchParams } = require('url');
+const encodedParams = new URLSearchParams();
 
 encodedParams.set('foo', 'bar');
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   params: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'},

--- a/test/fixtures/output/node/axios/headers.js
+++ b/test/fixtures/output/node/axios/headers.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   headers: {accept: 'application/json', 'x-foo': 'Bar'}

--- a/test/fixtures/output/node/axios/https.js
+++ b/test/fixtures/output/node/axios/https.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {method: 'GET', url: 'https://mockbin.com/har'};
+const options = {method: 'GET', url: 'https://mockbin.com/har'};
 
 axios.request(options).then(function (response) {
   console.log(response.data);

--- a/test/fixtures/output/node/axios/jsonObj-multiline.js
+++ b/test/fixtures/output/node/axios/jsonObj-multiline.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/test/fixtures/output/node/axios/jsonObj-null-value.js
+++ b/test/fixtures/output/node/axios/jsonObj-null-value.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/test/fixtures/output/node/axios/multipart-data.js
+++ b/test/fixtures/output/node/axios/multipart-data.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/test/fixtures/output/node/axios/multipart-file.js
+++ b/test/fixtures/output/node/axios/multipart-file.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/test/fixtures/output/node/axios/multipart-form-data.js
+++ b/test/fixtures/output/node/axios/multipart-form-data.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/test/fixtures/output/node/axios/nested.js
+++ b/test/fixtures/output/node/axios/nested.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   params: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}

--- a/test/fixtures/output/node/axios/query.js
+++ b/test/fixtures/output/node/axios/query.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   params: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}

--- a/test/fixtures/output/node/axios/short.js
+++ b/test/fixtures/output/node/axios/short.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {method: 'GET', url: 'http://mockbin.com/har'};
+const options = {method: 'GET', url: 'http://mockbin.com/har'};
 
 axios.request(options).then(function (response) {
   console.log(response.data);

--- a/test/fixtures/output/node/axios/text-plain.js
+++ b/test/fixtures/output/node/axios/text-plain.js
@@ -1,6 +1,6 @@
-var axios = require("axios").default;
+const axios = require("axios").default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'text/plain'},


### PR DESCRIPTION
This fixes a bug in both the Node and JS `axios` targets where they weren't sending `application/x-www-form-urlencoded` properly.

You can see this in action with the `application-form-encoded` fixture against https://httpbin.org/anything:

```js
var axios = require("axios").default;

var options = {
  method: 'POST',
  url: 'https://httpbin.org/anything',
  headers: {'content-type': 'application/x-www-form-urlencoded'},
  data: {foo: 'bar', hello: 'world'}
};

axios.request(options).then(function (response) {
  console.log(response.data);
}).catch(function (error) {
  console.error(error);
});
```

```js
{
  args: {},
  data: '',
  files: {},
  form: { '{"foo":"bar","hello":"world"}': '' },
  headers: {
    Accept: 'application/json, text/plain, */*',
    'Content-Length': '29',
    'Content-Type': 'application/x-www-form-urlencoded',
    Host: 'httpbin.org',
    'User-Agent': 'axios/0.21.4',
    'X-Amzn-Trace-Id': 'Root=1-614287bd-3485f1b902452a8c14f09f1f'
  },
  json: null,
  method: 'POST',
  origin: 'REDACTED',
  url: 'https://httpbin.org/anything'
}
```

And with this fix:

```js
{
  args: {},
  data: '',
  files: {},
  form: { foo: 'bar', hello: 'world' },
  headers: {
    Accept: 'application/json, text/plain, */*',
    'Content-Length': '19',
    'Content-Type': 'application/x-www-form-urlencoded',
    Host: 'httpbin.org',
    'User-Agent': 'axios/0.21.4',
    'X-Amzn-Trace-Id': 'Root=1-61428901-61fa539a66f4cac66a67db3e'
  },
  json: null,
  method: 'POST',
  origin: 'REDACTED',
  url: 'https://httpbin.org/anything'
}
```

I've also modernized the Node `axios` target over to using `const` instead of `var` in snippets it generates.