### PR TITLE
new target: Elixir HTTPoison

### DIFF
--- a/src/targets/elixir/httpoison.js
+++ b/src/targets/elixir/httpoison.js
@@ -1,0 +1,136 @@
+/**
+ * @description
+ * HTTPoison Elixir HTTP client code snippet generator.
+ *
+ * @author
+ * @danirukun
+ *
+ * For any questions or issues regarding the generated code snippet,
+ * please open an issue mentioning the author.
+ */
+
+'use strict'
+
+const CodeBuilder = require('../../helpers/code-builder')
+
+/**
+   Converts an ES6 list of objects to an Elixir KW list
+*/
+const jsListToKwList = (jsList) => {
+  if (jsList.length === 0) return '[]'
+
+  const kwList = jsList
+    .map(obj => `{"${obj.name}", "${obj.value}"}`)
+    .join(', ')
+  return `[${kwList}]`
+}
+
+/**
+   Converts a list containing cookies objects into an
+   HTTPoison `cookie` parameter argument.
+*/
+const jsCookiesToExBin = (jsCookiesList) => {
+  if (jsCookiesList.length === 0) return '""'
+
+  const exBinary = jsCookiesList
+    .map(cookie => `${cookie.name}=${cookie.value}`)
+    .join('; ')
+  return `"${exBinary}"`
+}
+
+/**
+   Converts a list of params to a Poison multipart form payload.
+*/
+const jsMultiPartParamsToPoisonPayload = (jsMultiParams) => {
+  const [params] = jsMultiParams
+  const isFileUpload = 'fileName' in params
+  let multiPart
+
+  if (isFileUpload) {
+    const { fileName, name } = params
+    const formData = [
+      { name: 'name', value: name },
+      { name: 'filename', value: fileName }]
+    const formDataKwList = jsListToKwList(formData)
+    const headers = jsListToKwList([{ name: 'content-type', value: 'multipart/form-data' }])
+
+    multiPart = `[{:file, "${fileName}", {"form-data", ${formDataKwList}}, ${headers}}]`
+  } else {
+    multiPart = jsListToKwList(jsMultiParams)
+  }
+
+  return `{:multipart, ${multiPart}}`
+}
+
+const isJson = (mimeType) => {
+  return [
+    'application/json',
+    'application/x-json',
+    'text/json'
+  ].includes(mimeType)
+}
+
+const isMultiPartForm = (mimeType) => {
+  return mimeType === 'multipart/form-data'
+}
+
+const escapeExString = (text) => {
+  return `~s(${text})`
+}
+
+module.exports = (source, _options) => {
+  const code = new CodeBuilder()
+
+  const { method, headers, cookies, postData: { mimeType, params } } = source
+  const text = `"${(source.postData.text || '')}"`
+  const escapedText = isJson(mimeType)
+    ? escapeExString(text)
+    : text
+  const payload = isMultiPartForm(mimeType)
+    ? jsMultiPartParamsToPoisonPayload(params)
+    : escapedText
+
+  function appendHeaders (headers) {
+    const exHeaders = jsListToKwList(headers)
+
+    argPlaceholders += ',\n  %s'
+    poisonArgs = poisonArgs.concat([exHeaders])
+  }
+
+  function appendCookies (cookies) {
+    const exCookies = jsCookiesToExBin(cookies)
+    const poisonOpts = `hackney: [cookie: ${exCookies}]`
+
+    argPlaceholders += ',\n  %s'
+    poisonArgs = poisonArgs.concat([poisonOpts])
+  }
+
+  function appendPayload (payload) {
+    argPlaceholders += ',\n  %s'
+    poisonArgs = poisonArgs.concat([payload])
+  }
+
+  let argPlaceholders = '\n  :%s,\n  "%s"'
+  let poisonArgs = [method.toLowerCase(), source.fullUrl]
+
+  appendPayload(payload)
+
+  if (headers.length > 0) appendHeaders(headers)
+  if (cookies.length > 0) {
+    if (headers.length === 0) appendHeaders([])
+    appendCookies(cookies)
+  }
+
+  argPlaceholders += '\n'
+
+  code.push(`HTTPoison.request(${argPlaceholders})`, ...poisonArgs)
+
+  return code.join()
+}
+
+module.exports.info = {
+  key: 'httpoison',
+  title: 'HTTPoison',
+  link: 'https://github.com/edgurgel/httpoison',
+  description: 'HTTP client for Elixir, based on HTTPotion.'
+}

--- a/src/targets/elixir/index.js
+++ b/src/targets/elixir/index.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  info: {
+    key: 'elixir',
+    title: 'Elixir',
+    extname: '.ex',
+    default: 'httpoison'
+  },
+  httpoison: require('./httpoison')
+}

--- a/src/targets/index.js
+++ b/src/targets/index.js
@@ -4,6 +4,7 @@ module.exports = {
   c: require('./c'),
   clojure: require('./clojure'),
   csharp: require('./csharp'),
+  elixir: require('./elixir'),
   go: require('./go'),
   http: require('./http'),
   java: require('./java'),

--- a/test/fixtures/available-targets.json
+++ b/test/fixtures/available-targets.json
@@ -242,6 +242,20 @@
         "description": "Ruby HTTP client"
       }
     ]
+	},
+  {
+    "key": "elixir",
+    "title": "Elixir",
+    "extname": ".ex",
+    "default": "httpoison",
+    "clients": [
+      {
+        "key": "httpoison",
+        "title": "HTTPoison",
+        "link": "https://github.com/edgurgel/httpoison",
+        "description": "HTTP client for Elixir, based on HTTPotion."
+      }
+    ]
   },
   {
     "key": "csharp",

--- a/test/fixtures/output/elixir/httpoison/application-form-encoded.ex
+++ b/test/fixtures/output/elixir/httpoison/application-form-encoded.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  "foo=bar&hello=world",
+  [{"content-type", "application/x-www-form-urlencoded"}]
+)

--- a/test/fixtures/output/elixir/httpoison/application-json.ex
+++ b/test/fixtures/output/elixir/httpoison/application-json.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  ~s("{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}"),
+  [{"content-type", "application/json"}]
+)

--- a/test/fixtures/output/elixir/httpoison/cookies.ex
+++ b/test/fixtures/output/elixir/httpoison/cookies.ex
@@ -1,0 +1,7 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  "",
+  [],
+  hackney: [cookie: "foo=bar; bar=baz"]
+)

--- a/test/fixtures/output/elixir/httpoison/custom-method.ex
+++ b/test/fixtures/output/elixir/httpoison/custom-method.ex
@@ -1,0 +1,5 @@
+HTTPoison.request(
+  :propfind,
+  "http://mockbin.com/har",
+  ""
+)

--- a/test/fixtures/output/elixir/httpoison/full.ex
+++ b/test/fixtures/output/elixir/httpoison/full.ex
@@ -1,0 +1,7 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value",
+  "foo=bar",
+  [{"accept", "application/json"}, {"content-type", "application/x-www-form-urlencoded"}],
+  hackney: [cookie: "foo=bar; bar=baz"]
+)

--- a/test/fixtures/output/elixir/httpoison/headers.ex
+++ b/test/fixtures/output/elixir/httpoison/headers.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :get,
+  "http://mockbin.com/har",
+  "",
+  [{"accept", "application/json"}, {"x-foo", "Bar"}]
+)

--- a/test/fixtures/output/elixir/httpoison/https.ex
+++ b/test/fixtures/output/elixir/httpoison/https.ex
@@ -1,0 +1,5 @@
+HTTPoison.request(
+  :get,
+  "https://mockbin.com/har",
+  ""
+)

--- a/test/fixtures/output/elixir/httpoison/jsonObj-multiline.ex
+++ b/test/fixtures/output/elixir/httpoison/jsonObj-multiline.ex
@@ -1,0 +1,8 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  ~s("{
+  "foo": "bar"
+}"),
+  [{"content-type", "application/json"}]
+)

--- a/test/fixtures/output/elixir/httpoison/jsonObj-null-value.ex
+++ b/test/fixtures/output/elixir/httpoison/jsonObj-null-value.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  ~s("{"foo":null}"),
+  [{"content-type", "application/json"}]
+)

--- a/test/fixtures/output/elixir/httpoison/multipart-data.ex
+++ b/test/fixtures/output/elixir/httpoison/multipart-data.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  {:multipart, [{:file, "hello.txt", {"form-data", [{"name", "foo"}, {"filename", "hello.txt"}]}, [{"content-type", "multipart/form-data"}]}]},
+  [{"content-type", "multipart/form-data"}]
+)

--- a/test/fixtures/output/elixir/httpoison/multipart-file.ex
+++ b/test/fixtures/output/elixir/httpoison/multipart-file.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  {:multipart, [{:file, "test/fixtures/files/hello.txt", {"form-data", [{"name", "foo"}, {"filename", "test/fixtures/files/hello.txt"}]}, [{"content-type", "multipart/form-data"}]}]},
+  [{"content-type", "multipart/form-data"}]
+)

--- a/test/fixtures/output/elixir/httpoison/multipart-form-data.ex
+++ b/test/fixtures/output/elixir/httpoison/multipart-form-data.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  {:multipart, [{"foo", "bar"}]},
+  [{"Content-Type", "multipart/form-data"}]
+)

--- a/test/fixtures/output/elixir/httpoison/nested.ex
+++ b/test/fixtures/output/elixir/httpoison/nested.ex
@@ -1,0 +1,5 @@
+HTTPoison.request(
+  :get,
+  "http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value",
+  ""
+)

--- a/test/fixtures/output/elixir/httpoison/query.ex
+++ b/test/fixtures/output/elixir/httpoison/query.ex
@@ -1,0 +1,5 @@
+HTTPoison.request(
+  :get,
+  "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value",
+  ""
+)

--- a/test/fixtures/output/elixir/httpoison/short.ex
+++ b/test/fixtures/output/elixir/httpoison/short.ex
@@ -1,0 +1,5 @@
+HTTPoison.request(
+  :get,
+  "http://mockbin.com/har",
+  ""
+)

--- a/test/fixtures/output/elixir/httpoison/text-plain.ex
+++ b/test/fixtures/output/elixir/httpoison/text-plain.ex
@@ -1,0 +1,6 @@
+HTTPoison.request(
+  :post,
+  "http://mockbin.com/har",
+  "Hello World",
+  [{"content-type", "text/plain"}]
+)

--- a/test/targets/elixir/httpoison.js
+++ b/test/targets/elixir/httpoison.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = function (snippet, fixtures) {}


### PR DESCRIPTION
This PR implement a target for the [Elixir HTTPoison HTTP client](https://github.com/edgurgel/httpoison).

Closes #234 

Example generated snippet:

```elixir
HTTPoison.request(:post, "http://mockbin.com/har", "foo=bar&hello=world", [{"content-type", "application/x-www-form-urlencoded"}])
```