### PR TITLE
feat: use curl's --compressed option for requests that accept it

### DIFF
--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -40,6 +40,10 @@ module.exports = function (source, options) {
     code.push(opts.short ? '-0' : '--http1.0')
   }
 
+  if (headerHelpers.getHeader(source.allHeaders, 'accept-encoding')) {
+    code.push('--compressed')
+  }
+
   // if multipart form data, we want to remove the boundary
   if (source.postData.mimeType === 'multipart/form-data') {
     const contentTypeHeaderName = headerHelpers.getHeaderName(source.headersObj, 'content-type')

--- a/test/fixtures/curl/compression.json
+++ b/test/fixtures/curl/compression.json
@@ -1,0 +1,10 @@
+{
+  "method": "GET",
+  "url": "http://mockbin.com/har",
+  "headers": [
+    {
+      "name": "accept-encoding",
+      "value": "deflate, gzip, br"
+    }
+  ]
+}

--- a/test/targets/shell/curl.js
+++ b/test/targets/shell/curl.js
@@ -64,6 +64,15 @@ module.exports = function (HTTPSnippet, fixtures) {
     result.should.eql('curl --request GET --url http://mockbin.com/request --http1.0')
   })
 
+  it('should use --compressed for requests that accept encodings', function () {
+    const result = new HTTPSnippet(fixtures.curl.compression).convert('shell', 'curl', {
+      indent: false
+    })
+
+    result.should.be.a.String()
+    result.should.eql("curl --request GET --url http://mockbin.com/har --compressed --header 'accept-encoding: deflate, gzip, br'")
+  })
+
   it('should use custom indentation', function () {
     const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
       indent: '@'


### PR DESCRIPTION
Generating a curl snippet from the example here previously produced this:

```
$ curl --request GET --url http://mockbin.com/request --header 'accept-encoding: deflate, gzip, br'
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
```

That happens because the server sends gzipped data (as requested) but curl isn't expecting it.

This PR enables the `--compressed` flag, if an accept-encoding header has been set, which enables automatic decoding of responses so that this works:

```
$ curl --request GET --url http://mockbin.com/request --compressed --header 'accept-encoding: deflate, gzip, br'
{
  "startedDateTime": "2021-12-08T17:46:00.197Z",
  "clientIPAddress": "...",
  "method": "GET",
  "url": "http://mockbin.com/request",
  "httpVersion": "HTTP/1.1",
  "cookies": {},
  "headers": {
  ...
```