### PR TITLE
feat: Add support for insecureSkipVerify

### DIFF
--- a/src/targets/node/native.js
+++ b/src/targets/node/native.js
@@ -28,6 +28,10 @@ module.exports = function (source, options) {
     headers: source.allHeaders
   }
 
+  if (options.insecureSkipVerify) {
+    reqOpts.rejectUnauthorized = false
+  }
+
   code.push('const http = require("%s");', source.uriObj.protocol.replace(':', ''))
 
   code.blank()

--- a/src/targets/python/python3.js
+++ b/src/targets/python/python3.js
@@ -16,13 +16,25 @@ module.exports = function (source, options) {
   const code = new CodeBuilder()
   // Start Request
   code.push('import http.client')
-    .blank()
+
+  if (options.insecureSkipVerify) {
+    code.push('import ssl')
+  }
+
+  code.blank()
 
   // Check which protocol to be used for the client connection
   const protocol = source.uriObj.protocol
   if (protocol === 'https:') {
-    code.push('conn = http.client.HTTPSConnection("%s")', source.uriObj.host)
-      .blank()
+    if (options.insecureSkipVerify) {
+      code.push(
+        'conn = http.client.HTTPSConnection("%s", context = ssl._create_unverified_context())',
+        source.uriObj.host
+      ).blank()
+    } else {
+      code.push('conn = http.client.HTTPSConnection("%s")', source.uriObj.host)
+        .blank()
+    }
   } else {
     code.push('conn = http.client.HTTPConnection("%s")', source.uriObj.host)
       .blank()

--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -34,7 +34,10 @@ module.exports = function (source, options) {
 
   if (source.uriObj.protocol === 'https:') {
     code.push('http.use_ssl = true')
-      .push('http.verify_mode = OpenSSL::SSL::VERIFY_NONE')
+
+    if (options.insecureSkipVerify) {
+      code.push('http.verify_mode = OpenSSL::SSL::VERIFY_NONE')
+    }
   }
 
   code.blank()

--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -36,6 +36,10 @@ module.exports = function (source, options) {
   }
   code.push(util.format('%s%s', opts.short ? '' : '--url ', formattedUrl))
 
+  if (opts.insecureSkipVerify) {
+    code.push(opts.short ? '-k' : '--insecure')
+  }
+
   if (source.httpVersion === 'HTTP/1.0') {
     code.push(opts.short ? '-0' : '--http1.0')
   }

--- a/test/fixtures/output/ruby/native/https.rb
+++ b/test/fixtures/output/ruby/native/https.rb
@@ -6,7 +6,6 @@ url = URI("https://mockbin.com/har")
 
 http = Net::HTTP.new(url.host, url.port)
 http.use_ssl = true
-http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
 request = Net::HTTP::Get.new(url)
 

--- a/test/targets/go/native.js
+++ b/test/targets/go/native.js
@@ -134,4 +134,49 @@ func main() {
 
 }`)
   })
+
+  it('should support insecureSkipVerify option', function () {
+    const result = new HTTPSnippet(fixtures.requests.full).convert('go', 'native', {
+      insecureSkipVerify: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`package main
+
+import (
+\t"fmt"
+\t"crypto/tls"
+\t"strings"
+\t"net/http"
+\t"io/ioutil"
+)
+
+func main() {
+
+\tinsecureTransport := http.DefaultTransport.(*http.Transport).Clone()
+\tinsecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+\tclient := http.Client{
+\t\tTransport: insecureTransport,
+\t}
+
+\turl := "http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value"
+
+\tpayload := strings.NewReader("foo=bar")
+
+\treq, _ := http.NewRequest("POST", url, payload)
+
+\treq.Header.Add("cookie", "foo=bar; bar=baz")
+\treq.Header.Add("accept", "application/json")
+\treq.Header.Add("content-type", "application/x-www-form-urlencoded")
+
+\tres, _ := client.Do(req)
+
+\tdefer res.Body.Close()
+\tbody, _ := ioutil.ReadAll(res.Body)
+
+\tfmt.Println(res)
+\tfmt.Println(string(body))
+
+}`)
+  })
 }

--- a/test/targets/node/native.js
+++ b/test/targets/node/native.js
@@ -1,3 +1,36 @@
 'use strict'
 
-module.exports = function (snippet, fixtures) {}
+module.exports = function (HTTPSnippet, fixtures) {
+  it('should support the insecureSkipVerify option', function () {
+    const result = new HTTPSnippet(fixtures.requests.https).convert('node', 'native', {
+      insecureSkipVerify: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`const http = require("https");
+
+const options = {
+  "method": "GET",
+  "hostname": "mockbin.com",
+  "port": null,
+  "path": "/har",
+  "headers": {},
+  "rejectUnauthorized": false
+};
+
+const req = http.request(options, function (res) {
+  const chunks = [];
+
+  res.on("data", function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on("end", function () {
+    const body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.end();`)
+  })
+}

--- a/test/targets/python/python3.js
+++ b/test/targets/python/python3.js
@@ -2,4 +2,23 @@
 
 require('should')
 
-module.exports = function (snippet, fixtures) {}
+module.exports = function (HTTPSnippet, fixtures) {
+  it('should support insecureSkipVerify', function () {
+    const result = new HTTPSnippet(fixtures.requests.https).convert('python', 'python3', {
+      insecureSkipVerify: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`import http.client
+import ssl
+
+conn = http.client.HTTPSConnection("mockbin.com", context = ssl._create_unverified_context())
+
+conn.request("GET", "/har")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
+  })
+}

--- a/test/targets/ruby/native.js
+++ b/test/targets/ruby/native.js
@@ -1,3 +1,25 @@
 'use strict'
 
-module.exports = function (snippet, fixtures) {}
+module.exports = function (HTTPSnippet, fixtures) {
+  it('should support insecureSkipVerify', function () {
+    const result = new HTTPSnippet(fixtures.requests.https).convert('ruby', 'native', {
+      insecureSkipVerify: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`require 'uri'
+require 'net/http'
+require 'openssl'
+
+url = URI("https://mockbin.com/har")
+
+http = Net::HTTP.new(url.host, url.port)
+http.use_ssl = true
+http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+request = Net::HTTP::Get.new(url)
+
+response = http.request(request)
+puts response.read_body`)
+  })
+}

--- a/test/targets/shell/curl.js
+++ b/test/targets/shell/curl.js
@@ -55,6 +55,16 @@ module.exports = function (HTTPSnippet, fixtures) {
     result.should.eql("curl --request GET --url 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value'")
   })
 
+  it('should support insecureSkipVerify', function () {
+    const result = new HTTPSnippet(fixtures.requests.https).convert('shell', 'curl', {
+      indent: false,
+      insecureSkipVerify: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql('curl --request GET --url https://mockbin.com/har --insecure')
+  })
+
   it('should use --http1.0 for HTTP/1.0', function () {
     const result = new HTTPSnippet(fixtures.curl.http1).convert('shell', 'curl', {
       indent: false


### PR DESCRIPTION
This fixes #110 by:

* Removing `http.verify_mode = OpenSSL::SSL::VERIFY_NONE` from the default Ruby output
* Adding a new `insecureSkipVerify` option to Ruby, curl, Go, Python and Node which optionally disables certificate verification in the generated snippets