### PR TITLE
add header namesspace to prevent header errors

### DIFF
--- a/src/targets/csharp/httpclient/client.ts
+++ b/src/targets/csharp/httpclient/client.ts
@@ -48,6 +48,7 @@ export const httpclient: Client = {
 
     const { push, join } = new CodeBuilder({ indent: opts.indent });
 
+    push('using System.Net.Http.Headers;');
     let clienthandler = '';
     const cookies = Boolean(allHeaders.cookie);
     const decompressionMethods = getDecompressionMethods(allHeaders);

--- a/src/targets/csharp/httpclient/fixtures/application-form-encoded.cs
+++ b/src/targets/csharp/httpclient/fixtures/application-form-encoded.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/application-json.cs
+++ b/src/targets/csharp/httpclient/fixtures/application-json.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/cookies.cs
+++ b/src/targets/csharp/httpclient/fixtures/cookies.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var clientHandler = new HttpClientHandler
 {
     UseCookies = false,

--- a/src/targets/csharp/httpclient/fixtures/custom-method.cs
+++ b/src/targets/csharp/httpclient/fixtures/custom-method.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/full.cs
+++ b/src/targets/csharp/httpclient/fixtures/full.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var clientHandler = new HttpClientHandler
 {
     UseCookies = false,

--- a/src/targets/csharp/httpclient/fixtures/headers.cs
+++ b/src/targets/csharp/httpclient/fixtures/headers.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/https.cs
+++ b/src/targets/csharp/httpclient/fixtures/https.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/jsonObj-multiline.cs
+++ b/src/targets/csharp/httpclient/fixtures/jsonObj-multiline.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/jsonObj-null-value.cs
+++ b/src/targets/csharp/httpclient/fixtures/jsonObj-null-value.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/multipart-data.cs
+++ b/src/targets/csharp/httpclient/fixtures/multipart-data.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/multipart-file.cs
+++ b/src/targets/csharp/httpclient/fixtures/multipart-file.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/multipart-form-data-no-params.cs
+++ b/src/targets/csharp/httpclient/fixtures/multipart-form-data-no-params.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/multipart-form-data.cs
+++ b/src/targets/csharp/httpclient/fixtures/multipart-form-data.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/nested.cs
+++ b/src/targets/csharp/httpclient/fixtures/nested.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/query.cs
+++ b/src/targets/csharp/httpclient/fixtures/query.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/short.cs
+++ b/src/targets/csharp/httpclient/fixtures/short.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {

--- a/src/targets/csharp/httpclient/fixtures/text-plain.cs
+++ b/src/targets/csharp/httpclient/fixtures/text-plain.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {


### PR DESCRIPTION
## Description 

Currently, if I try to just run the snippets produced by this charp -> httpclient.js target then I will get errors similar to 
```
error CS0246: The type or namespace name 'ContentDispositionHeaderValue' could not be found
```

However, if I add the namespace `using System.Net.Http.Headers;` to the top then the snippet works as expected

This PR just adds that namespace to the top so that the snippet can run if just copied.

changelog(Fixes): Fixed an issue where C# snippets were missing a namespace in the generated code