### PR TITLE
fix: compatibility issues on node 14 with `Object.hasOwn()`

### DIFF
--- a/src/targets/php/helpers.ts
+++ b/src/targets/php/helpers.ts
@@ -25,7 +25,7 @@ export const convertType = (obj: any[] | any, indent?: string, lastIndent?: stri
     case '[object Object]': {
       const result: string[] = [];
       for (const i in obj) {
-        if (Object.hasOwn(obj, i)) {
+        if (Object.prototype.hasOwnProperty.call(obj, i)) {
           result.push(
             `${convertType(i, indent)} => ${convertType(obj[i], `${indent}${indent}`, indent)}`,
           );

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -83,11 +83,11 @@ export const isTarget = (target: Target): target is Target => {
     throw new Error(`you tried to add a target which is not an object, got type: "${got}"`);
   }
 
-  if (!Object.hasOwn(target, 'info')) {
+  if (!Object.prototype.hasOwnProperty.call(target, 'info')) {
     throw new Error('targets must contain an `info` object');
   }
 
-  if (!Object.hasOwn(target.info, 'key')) {
+  if (!Object.prototype.hasOwnProperty.call(target.info, 'key')) {
     throw new Error('targets must have an `info` object with the property `key`');
   }
 
@@ -95,11 +95,11 @@ export const isTarget = (target: Target): target is Target => {
     throw new Error('target key must be a unique string');
   }
 
-  if (Object.hasOwn(targets, target.info.key)) {
+  if (Object.prototype.hasOwnProperty.call(targets, target.info.key)) {
     throw new Error(`a target already exists with this key, \`${target.info.key}\``);
   }
 
-  if (!Object.hasOwn(target.info, 'title')) {
+  if (!Object.prototype.hasOwnProperty.call(target.info, 'title')) {
     throw new Error('targets must have an `info` object with the property `title`');
   }
 
@@ -107,12 +107,12 @@ export const isTarget = (target: Target): target is Target => {
     throw new Error('target title must be a non-zero-length string');
   }
 
-  if (!Object.hasOwn(target.info, 'extname')) {
+  if (!Object.prototype.hasOwnProperty.call(target.info, 'extname')) {
     throw new Error('targets must have an `info` object with the property `extname`');
   }
 
   if (
-    !Object.hasOwn(target, 'clientsById') ||
+    !Object.prototype.hasOwnProperty.call(target, 'clientsById') ||
     !target.clientsById ||
     Object.keys(target.clientsById).length === 0
   ) {
@@ -121,11 +121,11 @@ export const isTarget = (target: Target): target is Target => {
     );
   }
 
-  if (!Object.hasOwn(target.info, 'default')) {
+  if (!Object.prototype.hasOwnProperty.call(target.info, 'default')) {
     throw new Error('targets must have an `info` object with the property `default`');
   }
 
-  if (!Object.hasOwn(target.clientsById, target.info.default)) {
+  if (!Object.prototype.hasOwnProperty.call(target.clientsById, target.info.default)) {
     throw new Error(
       `target ${target.info.key} is configured with a default client ${
         target.info.default
@@ -152,11 +152,11 @@ export const isClient = (client: Client): client is Client => {
     throw new Error('clients must be objects');
   }
 
-  if (!Object.hasOwn(client, 'info')) {
+  if (!Object.prototype.hasOwnProperty.call(client, 'info')) {
     throw new Error('targets client must contain an `info` object');
   }
 
-  if (!Object.hasOwn(client.info, 'key')) {
+  if (!Object.prototype.hasOwnProperty.call(client.info, 'key')) {
     throw new Error('targets client must have an `info` object with property `key`');
   }
 
@@ -164,19 +164,19 @@ export const isClient = (client: Client): client is Client => {
     throw new Error('client.info.key must contain an identifier unique to this target');
   }
 
-  if (!Object.hasOwn(client.info, 'title')) {
+  if (!Object.prototype.hasOwnProperty.call(client.info, 'title')) {
     throw new Error('targets client must have an `info` object with property `title`');
   }
 
-  if (!Object.hasOwn(client.info, 'description')) {
+  if (!Object.prototype.hasOwnProperty.call(client.info, 'description')) {
     throw new Error('targets client must have an `info` object with property `description`');
   }
 
-  if (!Object.hasOwn(client.info, 'link')) {
+  if (!Object.prototype.hasOwnProperty.call(client.info, 'link')) {
     throw new Error('targets client must have an `info` object with property `link`');
   }
 
-  if (!Object.hasOwn(client, 'convert') || typeof client.convert !== 'function') {
+  if (!Object.prototype.hasOwnProperty.call(client, 'convert') || typeof client.convert !== 'function') {
     throw new Error(
       'targets client must have a `convert` property containing a conversion function',
     );
@@ -190,11 +190,11 @@ export const addTargetClient = (targetId: TargetId, client: Client) => {
     return;
   }
 
-  if (!Object.hasOwn(targets, targetId)) {
+  if (!Object.prototype.hasOwnProperty.call(targets, targetId)) {
     throw new Error(`Sorry, but no ${targetId} target exists to add clients to`);
   }
 
-  if (Object.hasOwn(targets[targetId], client.info.key)) {
+  if (Object.prototype.hasOwnProperty.call(targets[targetId], client.info.key)) {
     throw new Error(
       `the target ${targetId} already has a client with the key ${client.info.key}, please use a different key`,
     );


### PR DESCRIPTION
This resolves a compatibility issue with the new TS rewrite on Node 14 where tests, and the library, fail because [`Object.hasOwn()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) was introduced in Node 16.9.

Running tests on Node 14 prior to this fix:

![Screen Shot 2022-04-29 at 3 02 44 PM](https://user-images.githubusercontent.com/33762/166074779-2338b6db-3cf0-4483-8f8e-97d788688b22.png)

And after:

![Screen Shot 2022-04-29 at 3 05 00 PM](https://user-images.githubusercontent.com/33762/166074797-1eed8176-4229-47bf-8b53-b5f686d66edb.png)

changelog(Fixes): Fixed a compatibility issue with the new TS rewrite on Node 14 where tests, and the library, fail because [`Object.hasOwn()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) was introduced in Node 16.9