### PR TITLE
feat: addition of a PHP target for Guzzle

### DIFF
--- a/src/helpers/__snapshots__/utils.test.ts.snap
+++ b/src/helpers/__snapshots__/utils.test.ts.snap
@@ -231,10 +231,10 @@ Array [
         "title": "cURL",
       },
       Object {
-        "description": "PHP with guzzle v7",
+        "description": "PHP with Guzzle",
         "key": "guzzle",
         "link": "http://docs.guzzlephp.org/en/stable/",
-        "title": "Guzzle v7",
+        "title": "Guzzle",
       },
       Object {
         "description": "PHP with pecl/http v1",

--- a/src/helpers/__snapshots__/utils.test.ts.snap
+++ b/src/helpers/__snapshots__/utils.test.ts.snap
@@ -231,6 +231,12 @@ Array [
         "title": "cURL",
       },
       Object {
+        "description": "PHP with guzzle v7",
+        "key": "guzzle",
+        "link": "http://docs.guzzlephp.org/en/stable/",
+        "title": "Guzzle v7",
+      },
+      Object {
         "description": "PHP with pecl/http v1",
         "key": "http1",
         "link": "http://php.net/manual/en/book.http.php",

--- a/src/targets/php/guzzle/client.ts
+++ b/src/targets/php/guzzle/client.ts
@@ -25,7 +25,7 @@ export const guzzle: Client<GuzzleOptions> = {
     key: 'guzzle',
     title: 'Guzzle v7',
     link: 'http://docs.guzzlephp.org/en/stable/',
-    description: 'PHP with guzzle v7'
+    description: 'PHP with guzzle v7',
   },
   convert: ({ postData, fullUrl, method, cookies, headersObj }, options) => {
     const opts = {
@@ -37,7 +37,11 @@ export const guzzle: Client<GuzzleOptions> = {
     };
 
     const { push, blank, join } = new CodeBuilder({ indent: opts.indent });
-    const { code: requestCode, push: requestPush, join: requestJoin  } = new CodeBuilder({ indent: opts.indent });
+    const {
+      code: requestCode,
+      push: requestPush,
+      join: requestJoin,
+    } = new CodeBuilder({ indent: opts.indent });
 
     if (!opts.noTags) {
       push(opts.shortTags ? '<?' : '<?php');
@@ -47,10 +51,14 @@ export const guzzle: Client<GuzzleOptions> = {
     switch (postData.mimeType) {
       case 'application/x-www-form-urlencoded':
         requestPush(
-          `'form_params' => ${convertType(postData.paramsObj, opts.indent + opts.indent, opts.indent)},`,
+          `'form_params' => ${convertType(
+            postData.paramsObj,
+            opts.indent + opts.indent,
+            opts.indent,
+          )},`,
           1,
-        )
-        break
+        );
+        break;
 
       case 'multipart/form-data': {
         type MultipartField = {
@@ -60,7 +68,7 @@ export const guzzle: Client<GuzzleOptions> = {
           headers?: Record<string, string>;
         };
 
-        const fields: MultipartField[] = []
+        const fields: MultipartField[] = [];
 
         if (postData.params) {
           postData.params.forEach(function (param) {
@@ -68,28 +76,28 @@ export const guzzle: Client<GuzzleOptions> = {
               const field: MultipartField = {
                 name: param.name,
                 filename: param.fileName,
-                contents: param.value
-              }
+                contents: param.value,
+              };
 
               if (param.contentType) {
-                field.headers = { 'Content-Type': param.contentType }
+                field.headers = { 'Content-Type': param.contentType };
               }
 
-              fields.push(field)
+              fields.push(field);
             } else if (param.value) {
               fields.push({
                 name: param.name,
-                contents: param.value
-              })
+                contents: param.value,
+              });
             }
-          })
+          });
         }
 
         if (fields.length) {
           requestPush(
             `'multipart' => ${convertType(fields, opts.indent + opts.indent, opts.indent)}`,
             1,
-          )
+          );
         }
 
         // Guzzle adds its own boundary for multipart requests.
@@ -101,22 +109,26 @@ export const guzzle: Client<GuzzleOptions> = {
             }
           }
         }
-        break
+        break;
       }
 
       default:
         if (postData.text) {
-          requestPush(`'body' => ${convertType(postData.text)},`, 1)
+          requestPush(`'body' => ${convertType(postData.text)},`, 1);
         }
     }
 
     // construct headers
-    const headers = Object.keys(headersObj).sort().map(function (key) {
-      return `${opts.indent}${opts.indent}'${key}' => '${headersObj[key]}',`;
-    })
+    const headers = Object.keys(headersObj)
+      .sort()
+      .map(function (key) {
+        return `${opts.indent}${opts.indent}'${key}' => '${headersObj[key]}',`;
+      });
 
     // construct cookies
-    const cookieString = cookies.map(cookie => `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}`).join('; ')
+    const cookieString = cookies
+      .map(cookie => `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}`)
+      .join('; ');
     if (cookieString.length) {
       headers.push(`${opts.indent}${opts.indent}'cookie' => '${cookieString}',`);
     }

--- a/src/targets/php/guzzle/client.ts
+++ b/src/targets/php/guzzle/client.ts
@@ -1,0 +1,151 @@
+/**
+ * @description
+ * HTTP code snippet generator for PHP using Guzzle.
+ *
+ * @author @RobertoArruda
+ * @author @erunion
+ *
+ * for any questions or issues regarding the generated code snippet, please open an issue mentioning the author.
+ */
+
+import { CodeBuilder } from '../../../helpers/code-builder';
+import { getHeader, getHeaderName, hasHeader } from '../../../helpers/headers';
+import { Client } from '../../targets';
+import { convertType } from '../helpers';
+
+export interface GuzzleOptions {
+  closingTag?: boolean;
+  indent?: string;
+  noTags?: boolean;
+  shortTags?: boolean;
+}
+
+export const guzzle: Client<GuzzleOptions> = {
+  info: {
+    key: 'guzzle',
+    title: 'Guzzle v7',
+    link: 'http://docs.guzzlephp.org/en/stable/',
+    description: 'PHP with guzzle v7'
+  },
+  convert: ({ postData, fullUrl, method, cookies, headersObj }, options) => {
+    const opts = {
+      closingTag: false,
+      indent: '  ',
+      noTags: false,
+      shortTags: false,
+      ...options,
+    };
+
+    const { push, blank, join } = new CodeBuilder({ indent: opts.indent });
+    const { code: requestCode, push: requestPush, join: requestJoin  } = new CodeBuilder({ indent: opts.indent });
+
+    if (!opts.noTags) {
+      push(opts.shortTags ? '<?' : '<?php');
+      blank();
+    }
+
+    switch (postData.mimeType) {
+      case 'application/x-www-form-urlencoded':
+        requestPush(
+          `'form_params' => ${convertType(postData.paramsObj, opts.indent + opts.indent, opts.indent)},`,
+          1,
+        )
+        break
+
+      case 'multipart/form-data': {
+        type MultipartField = {
+          name: string;
+          filename?: string;
+          contents: string | undefined;
+          headers?: Record<string, string>;
+        };
+
+        const fields: MultipartField[] = []
+
+        if (postData.params) {
+          postData.params.forEach(function (param) {
+            if (param.fileName) {
+              const field: MultipartField = {
+                name: param.name,
+                filename: param.fileName,
+                contents: param.value
+              }
+
+              if (param.contentType) {
+                field.headers = { 'Content-Type': param.contentType }
+              }
+
+              fields.push(field)
+            } else if (param.value) {
+              fields.push({
+                name: param.name,
+                contents: param.value
+              })
+            }
+          })
+        }
+
+        if (fields.length) {
+          requestPush(
+            `'multipart' => ${convertType(fields, opts.indent + opts.indent, opts.indent)}`,
+            1,
+          )
+        }
+
+        // Guzzle adds its own boundary for multipart requests.
+        if (hasHeader(headersObj, 'content-type')) {
+          if (getHeader(headersObj, 'content-type')?.indexOf('boundary')) {
+            const headerName = getHeaderName(headersObj, 'content-type');
+            if (headerName) {
+              delete headersObj[headerName];
+            }
+          }
+        }
+        break
+      }
+
+      default:
+        if (postData.text) {
+          requestPush(`'body' => ${convertType(postData.text)},`, 1)
+        }
+    }
+
+    // construct headers
+    const headers = Object.keys(headersObj).sort().map(function (key) {
+      return `${opts.indent}${opts.indent}'${key}' => '${headersObj[key]}',`;
+    })
+
+    // construct cookies
+    const cookieString = cookies.map(cookie => `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}`).join('; ')
+    if (cookieString.length) {
+      headers.push(`${opts.indent}${opts.indent}'cookie' => '${cookieString}',`);
+    }
+
+    if (headers.length) {
+      requestPush("'headers' => [", 1);
+      requestPush(headers.join('\n'));
+      requestPush('],', 1);
+    }
+
+    push('$client = new \\GuzzleHttp\\Client();');
+    blank();
+
+    if (requestCode.length) {
+      push(`$response = $client->request('${method}', '${fullUrl}', [`);
+      push(requestJoin());
+      push(']);');
+    } else {
+      push(`$response = $client->request('${method}', '${fullUrl}');`);
+    }
+
+    blank();
+    push('echo $response->getBody();');
+
+    if (!opts.noTags && opts.closingTag) {
+      blank();
+      push('?>');
+    }
+
+    return join();
+  },
+};

--- a/src/targets/php/guzzle/client.ts
+++ b/src/targets/php/guzzle/client.ts
@@ -23,9 +23,9 @@ export interface GuzzleOptions {
 export const guzzle: Client<GuzzleOptions> = {
   info: {
     key: 'guzzle',
-    title: 'Guzzle v7',
+    title: 'Guzzle',
     link: 'http://docs.guzzlephp.org/en/stable/',
-    description: 'PHP with guzzle v7',
+    description: 'PHP with Guzzle',
   },
   convert: ({ postData, fullUrl, method, cookies, headersObj }, options) => {
     const opts = {
@@ -98,14 +98,14 @@ export const guzzle: Client<GuzzleOptions> = {
             `'multipart' => ${convertType(fields, opts.indent + opts.indent, opts.indent)}`,
             1,
           );
-        }
 
-        // Guzzle adds its own boundary for multipart requests.
-        if (hasHeader(headersObj, 'content-type')) {
-          if (getHeader(headersObj, 'content-type')?.indexOf('boundary')) {
-            const headerName = getHeaderName(headersObj, 'content-type');
-            if (headerName) {
-              delete headersObj[headerName];
+          // Guzzle adds its own boundary for multipart requests.
+          if (hasHeader(headersObj, 'content-type')) {
+            if (getHeader(headersObj, 'content-type')?.indexOf('boundary')) {
+              const headerName = getHeaderName(headersObj, 'content-type');
+              if (headerName) {
+                delete headersObj[headerName];
+              }
             }
           }
         }

--- a/src/targets/php/guzzle/fixtures/application-form-encoded.php
+++ b/src/targets/php/guzzle/fixtures/application-form-encoded.php
@@ -1,0 +1,15 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'form_params' => [
+    'foo' => 'bar',
+    'hello' => 'world'
+  ],
+  'headers' => [
+    'content-type' => 'application/x-www-form-urlencoded',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/application-json.php
+++ b/src/targets/php/guzzle/fixtures/application-json.php
@@ -1,0 +1,12 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'body' => '{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}',
+  'headers' => [
+    'content-type' => 'application/json',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/cookies.php
+++ b/src/targets/php/guzzle/fixtures/cookies.php
@@ -1,0 +1,11 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'headers' => [
+    'cookie' => 'foo=bar; bar=baz',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/custom-method.php
+++ b/src/targets/php/guzzle/fixtures/custom-method.php
@@ -1,0 +1,7 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('PROPFIND', 'http://mockbin.com/har');
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/full.php
+++ b/src/targets/php/guzzle/fixtures/full.php
@@ -1,0 +1,16 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', [
+  'form_params' => [
+    'foo' => 'bar'
+  ],
+  'headers' => [
+    'accept' => 'application/json',
+    'content-type' => 'application/x-www-form-urlencoded',
+    'cookie' => 'foo=bar; bar=baz',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/headers.php
+++ b/src/targets/php/guzzle/fixtures/headers.php
@@ -1,0 +1,12 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('GET', 'http://mockbin.com/har', [
+  'headers' => [
+    'accept' => 'application/json',
+    'x-foo' => 'Bar',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/https.php
+++ b/src/targets/php/guzzle/fixtures/https.php
@@ -1,0 +1,7 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('GET', 'https://mockbin.com/har');
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/jsonObj-multiline.php
+++ b/src/targets/php/guzzle/fixtures/jsonObj-multiline.php
@@ -1,0 +1,14 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'body' => '{
+  "foo": "bar"
+}',
+  'headers' => [
+    'content-type' => 'application/json',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/jsonObj-null-value.php
+++ b/src/targets/php/guzzle/fixtures/jsonObj-null-value.php
@@ -1,0 +1,12 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'body' => '{"foo":null}',
+  'headers' => [
+    'content-type' => 'application/json',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/multipart-data.php
+++ b/src/targets/php/guzzle/fixtures/multipart-data.php
@@ -1,0 +1,18 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'multipart' => [
+    [
+        'name' => 'foo',
+        'filename' => 'hello.txt',
+        'contents' => 'Hello World',
+        'headers' => [
+                'Content-Type' => 'text/plain'
+        ]
+    ]
+  ]
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/multipart-file.php
+++ b/src/targets/php/guzzle/fixtures/multipart-file.php
@@ -1,0 +1,18 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'multipart' => [
+    [
+        'name' => 'foo',
+        'filename' => 'test/fixtures/files/hello.txt',
+        'contents' => null,
+        'headers' => [
+                'Content-Type' => 'text/plain'
+        ]
+    ]
+  ]
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/multipart-form-data-no-params.php
+++ b/src/targets/php/guzzle/fixtures/multipart-form-data-no-params.php
@@ -2,6 +2,10 @@
 
 $client = new \GuzzleHttp\Client();
 
-$response = $client->request('POST', 'http://mockbin.com/har');
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'headers' => [
+    'Content-Type' => 'multipart/form-data',
+  ],
+]);
 
 echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/multipart-form-data-no-params.php
+++ b/src/targets/php/guzzle/fixtures/multipart-form-data-no-params.php
@@ -1,0 +1,7 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har');
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/multipart-form-data.php
+++ b/src/targets/php/guzzle/fixtures/multipart-form-data.php
@@ -1,0 +1,14 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'multipart' => [
+    [
+        'name' => 'foo',
+        'contents' => 'bar'
+    ]
+  ]
+]);
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/nested.php
+++ b/src/targets/php/guzzle/fixtures/nested.php
@@ -1,0 +1,7 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('GET', 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value');
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/query.php
+++ b/src/targets/php/guzzle/fixtures/query.php
@@ -1,0 +1,7 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('GET', 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value');
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/short.php
+++ b/src/targets/php/guzzle/fixtures/short.php
@@ -1,0 +1,7 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('GET', 'http://mockbin.com/har');
+
+echo $response->getBody();

--- a/src/targets/php/guzzle/fixtures/text-plain.php
+++ b/src/targets/php/guzzle/fixtures/text-plain.php
@@ -1,0 +1,12 @@
+<?php
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'http://mockbin.com/har', [
+  'body' => 'Hello World',
+  'headers' => [
+    'content-type' => 'text/plain',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/target.ts
+++ b/src/targets/php/target.ts
@@ -1,5 +1,6 @@
 import { Target } from '../targets';
 import { curl } from './curl/client';
+import { guzzle } from './guzzle/client';
 import { http1 } from './http1/client';
 import { http2 } from './http2/client';
 
@@ -12,6 +13,7 @@ export const php: Target = {
   },
   clientsById: {
     curl,
+    guzzle,
     http1,
     http2,
   },


### PR DESCRIPTION
> This is a replay of the work I did in https://github.com/Kong/httpsnippet/pull/228 just against the new TS rewrite.

This finishes up the work that @robertoarruda started in https://github.com/Kong/httpsnippet/pull/140 to add a new PHP target for [Guzzle](https://docs.guzzlephp.org/).

Differences between their PR and this one:

* Removed some unused/unimplemented options. 
* Fixed up all unit tests.
* Manually tested every Guzzle-generated snippet to ensure that it runs.
  * Some tweaks had to be made to multipart and cookie handling as a result of this.

Resolves #132 (and also #140).

changelog(New): adds PHP client for Guzzle