### PR TITLE
fix: axios targets not sending `x-www-form-urlencoded` properly

### DIFF
--- a/src/helpers/code-builder.test.ts
+++ b/src/helpers/code-builder.test.ts
@@ -18,4 +18,25 @@ describe('codeBuilder', () => {
       expect(result).toBe(`${indent.repeat(2)}${line}`);
     });
   });
+
+  describe('addPostProcessor', () => {
+    it('replaces accordingly with one replacer', () => {
+      const indent = '\t';
+      const { join, addPostProcessor, push } = new CodeBuilder({ indent });
+      push('console.log("hello world")');
+      addPostProcessor(code => code.replace(/console/, 'REPLACED'));
+
+      expect(join()).toBe('REPLACED.log("hello world")');
+    });
+
+    it('replaces accordingly with multiple replacers', () => {
+      const indent = '\t';
+      const { join, addPostProcessor, push } = new CodeBuilder({ indent });
+      push('console.log("hello world")');
+      addPostProcessor(code => code.replace(/world/, 'nurse!!'));
+      addPostProcessor(code => code.toUpperCase());
+
+      expect(join()).toBe('CONSOLE.LOG("HELLO NURSE!!")');
+    });
+  });
 });

--- a/src/targets/javascript/axios/client.ts
+++ b/src/targets/javascript/axios/client.ts
@@ -26,7 +26,7 @@ export const axios: Client = {
       ...options,
     };
 
-    const { blank, push, join } = new CodeBuilder({ indent: opts.indent });
+    const { blank, push, join, addPostProcessor } = new CodeBuilder({ indent: opts.indent });
 
     push("import axios from 'axios';");
     blank();
@@ -55,6 +55,7 @@ export const axios: Client = {
           blank();
 
           requestOptions.data = 'encodedParams,';
+          addPostProcessor(code => code.replace(/'encodedParams,'/, 'encodedParams,'));
         }
 
         break;
@@ -103,6 +104,6 @@ export const axios: Client = {
     push('console.error(error);', 2);
     push('});', 1);
 
-    return join().replace(/'encodedParams,'/, 'encodedParams,');
+    return join();
   },
 };

--- a/src/targets/javascript/axios/client.ts
+++ b/src/targets/javascript/axios/client.ts
@@ -46,7 +46,17 @@ export const axios: Client = {
 
     switch (postData.mimeType) {
       case 'application/x-www-form-urlencoded':
-        requestOptions.data = postData.paramsObj;
+        if (postData.params) {
+          push('const encodedParams = new URLSearchParams();');
+          postData.params.forEach(param => {
+            push(`encodedParams.set('${param.name}', '${param.value}');`);
+          });
+
+          blank();
+
+          requestOptions.data = 'encodedParams,';
+        }
+
         break;
 
       case 'application/json':
@@ -93,6 +103,6 @@ export const axios: Client = {
     push('console.error(error);', 2);
     push('});', 1);
 
-    return join();
+    return join().replace(/'encodedParams,'/, 'encodedParams,');
   },
 };

--- a/src/targets/javascript/axios/fixtures/application-form-encoded.js
+++ b/src/targets/javascript/axios/fixtures/application-form-encoded.js
@@ -1,10 +1,14 @@
 import axios from 'axios';
 
+const encodedParams = new URLSearchParams();
+encodedParams.set('foo', 'bar');
+encodedParams.set('hello', 'world');
+
 const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  data: {foo: 'bar', hello: 'world'}
+  data: encodedParams,
 };
 
 axios

--- a/src/targets/javascript/axios/fixtures/full.js
+++ b/src/targets/javascript/axios/fixtures/full.js
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+const encodedParams = new URLSearchParams();
+encodedParams.set('foo', 'bar');
+
 const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
@@ -9,7 +12,7 @@ const options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  data: {foo: 'bar'}
+  data: encodedParams,
 };
 
 axios

--- a/src/targets/node/axios/client.ts
+++ b/src/targets/node/axios/client.ts
@@ -25,8 +25,7 @@ export const axios: Client = {
       indent: '  ',
       ...options,
     };
-
-    const { blank, join, push } = new CodeBuilder({ indent: opts.indent });
+    const { blank, join, push, addPostProcessor } = new CodeBuilder({ indent: opts.indent });
 
     push("const axios = require('axios').default;");
 
@@ -57,6 +56,7 @@ export const axios: Client = {
           blank();
 
           reqOpts.data = 'encodedParams,';
+          addPostProcessor(code => code.replace(/'encodedParams,'/, 'encodedParams,'));
         }
 
         break;
@@ -88,6 +88,6 @@ export const axios: Client = {
     push('console.error(error);', 2);
     push('});', 1);
 
-    return join().replace(/'encodedParams,'/, 'encodedParams,');
+    return join();
   },
 };

--- a/src/targets/node/axios/fixtures/application-form-encoded.js
+++ b/src/targets/node/axios/fixtures/application-form-encoded.js
@@ -1,10 +1,15 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
+const { URLSearchParams } = require('url');
 
-var options = {
+const encodedParams = new URLSearchParams();
+encodedParams.set('foo', 'bar');
+encodedParams.set('hello', 'world');
+
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  data: {foo: 'bar', hello: 'world'}
+  data: encodedParams,
 };
 
 axios

--- a/src/targets/node/axios/fixtures/application-json.js
+++ b/src/targets/node/axios/fixtures/application-json.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/src/targets/node/axios/fixtures/cookies.js
+++ b/src/targets/node/axios/fixtures/cookies.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {cookie: 'foo=bar; bar=baz'}

--- a/src/targets/node/axios/fixtures/custom-method.js
+++ b/src/targets/node/axios/fixtures/custom-method.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
+const options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
 
 axios
   .request(options)

--- a/src/targets/node/axios/fixtures/full.js
+++ b/src/targets/node/axios/fixtures/full.js
@@ -1,6 +1,10 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
+const { URLSearchParams } = require('url');
 
-var options = {
+const encodedParams = new URLSearchParams();
+encodedParams.set('foo', 'bar');
+
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   params: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'},
@@ -9,7 +13,7 @@ var options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  data: {foo: 'bar'}
+  data: encodedParams,
 };
 
 axios

--- a/src/targets/node/axios/fixtures/headers.js
+++ b/src/targets/node/axios/fixtures/headers.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   headers: {accept: 'application/json', 'x-foo': 'Bar'}

--- a/src/targets/node/axios/fixtures/https.js
+++ b/src/targets/node/axios/fixtures/https.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {method: 'GET', url: 'https://mockbin.com/har'};
+const options = {method: 'GET', url: 'https://mockbin.com/har'};
 
 axios
   .request(options)

--- a/src/targets/node/axios/fixtures/jsonObj-multiline.js
+++ b/src/targets/node/axios/fixtures/jsonObj-multiline.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/src/targets/node/axios/fixtures/jsonObj-null-value.js
+++ b/src/targets/node/axios/fixtures/jsonObj-null-value.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'application/json'},

--- a/src/targets/node/axios/fixtures/multipart-data.js
+++ b/src/targets/node/axios/fixtures/multipart-data.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/src/targets/node/axios/fixtures/multipart-file.js
+++ b/src/targets/node/axios/fixtures/multipart-file.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/src/targets/node/axios/fixtures/multipart-form-data-no-params.js
+++ b/src/targets/node/axios/fixtures/multipart-form-data-no-params.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'Content-Type': 'multipart/form-data'}

--- a/src/targets/node/axios/fixtures/multipart-form-data.js
+++ b/src/targets/node/axios/fixtures/multipart-form-data.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'},

--- a/src/targets/node/axios/fixtures/nested.js
+++ b/src/targets/node/axios/fixtures/nested.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   params: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}

--- a/src/targets/node/axios/fixtures/query.js
+++ b/src/targets/node/axios/fixtures/query.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
   params: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}

--- a/src/targets/node/axios/fixtures/short.js
+++ b/src/targets/node/axios/fixtures/short.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {method: 'GET', url: 'http://mockbin.com/har'};
+const options = {method: 'GET', url: 'http://mockbin.com/har'};
 
 axios
   .request(options)

--- a/src/targets/node/axios/fixtures/text-plain.js
+++ b/src/targets/node/axios/fixtures/text-plain.js
@@ -1,6 +1,6 @@
-var axios = require('axios').default;
+const axios = require('axios').default;
 
-var options = {
+const options = {
   method: 'POST',
   url: 'http://mockbin.com/har',
   headers: {'content-type': 'text/plain'},

--- a/src/targets/node/unirest/client.ts
+++ b/src/targets/node/unirest/client.ts
@@ -27,7 +27,9 @@ export const unirest: Client = {
     };
 
     let includeFS = false;
-    const { blank, join, push, unshift } = new CodeBuilder({ indent: opts.indent });
+    const { addPostProcessor, blank, join, push, unshift } = new CodeBuilder({
+      indent: opts.indent,
+    });
 
     push("const unirest = require('unirest');");
     blank();
@@ -89,6 +91,9 @@ export const unirest: Client = {
             includeFS = true;
 
             part.body = `fs.createReadStream('${param.fileName}')`;
+            addPostProcessor(code =>
+              code.replace(/'fs\.createReadStream\(\\'(.+)\\'\)'/, "fs.createReadStream('$1')"),
+            );
           } else if (param.value) {
             part.body = param.value;
           }
@@ -125,6 +130,6 @@ export const unirest: Client = {
     push('console.log(res.body);', 1);
     push('});');
 
-    return join().replace(/'fs\.createReadStream\(\\'(.+)\\'\)'/, "fs.createReadStream('$1')");
+    return join();
   },
 };


### PR DESCRIPTION
> This is a reworking of the my original PR for this in https://github.com/Kong/httpsnippet/pull/232 just against the new TS rewrite. 

This fixes a bug in both the Node and JS `axios` targets where they weren't sending `application/x-www-form-urlencoded` properly.

You can see this in action with the `application-form-encoded` fixture against https://httpbin.org/anything:

```js
var axios = require("axios").default;

var options = {
  method: 'POST',
  url: 'https://httpbin.org/anything',
  headers: {'content-type': 'application/x-www-form-urlencoded'},
  data: {foo: 'bar', hello: 'world'}
};

axios.request(options).then(function (response) {
  console.log(response.data);
}).catch(function (error) {
  console.error(error);
});
```

```js
{
  args: {},
  data: '',
  files: {},
  form: { '{"foo":"bar","hello":"world"}': '' },
  headers: {
    Accept: 'application/json, text/plain, */*',
    'Content-Length': '29',
    'Content-Type': 'application/x-www-form-urlencoded',
    Host: 'httpbin.org',
    'User-Agent': 'axios/0.21.4',
    'X-Amzn-Trace-Id': 'REDACTED'
  },
  json: null,
  method: 'POST',
  origin: 'REDACTED',
  url: 'https://httpbin.org/anything'
}
```

And with this fix:

```js
{
  args: {},
  data: '',
  files: {},
  form: { foo: 'bar', hello: 'world' },
  headers: {
    Accept: 'application/json, text/plain, */*',
    'Content-Length': '19',
    'Content-Type': 'application/x-www-form-urlencoded',
    Host: 'httpbin.org',
    'User-Agent': 'axios/0.21.4',
    'X-Amzn-Trace-Id': 'REDACTED'
  },
  json: null,
  method: 'POST',
  origin: 'REDACTED',
  url: 'https://httpbin.org/anything'
}
```

I've also modernized the Node `axios` target over to using `const` instead of `var` in snippets it generates.

changelog(Improvements): (internal) adds ability to add post processors to code builder