### PR TITLE
fix: `multipart/form-data` header issues with node/js fetch targets

### DIFF
--- a/src/targets/javascript/fetch/client.ts
+++ b/src/targets/javascript/fetch/client.ts
@@ -11,6 +11,7 @@
 import stringifyObject from 'stringify-object';
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { getHeaderName } from '../../../helpers/headers';
 import { Client } from '../../targets';
 
 interface FetchOptions {
@@ -36,6 +37,15 @@ export const fetch: Client<FetchOptions> = {
     const options: Record<string, any> = {
       method,
     };
+
+    // The FormData API automatically adds a `Content-Type` header for `multipart/form-data`
+    // content and if we add our own here data won't be correctly transmitted.
+    if (postData.mimeType === 'multipart/form-data') {
+      const contentTypeHeader = getHeaderName(allHeaders, 'content-type');
+      if (contentTypeHeader) {
+        delete allHeaders[contentTypeHeader];
+      }
+    }
 
     if (Object.keys(allHeaders).length) {
       options.headers = allHeaders;

--- a/src/targets/javascript/fetch/client.ts
+++ b/src/targets/javascript/fetch/client.ts
@@ -60,8 +60,7 @@ export const fetch: Client<FetchOptions> = {
           break;
         }
 
-        // The FormData API automatically adds a `Content-Type` header for `multipart/form-data`
-        // content and if we add our own here data won't be correctly transmitted.
+        // The FormData API automatically adds a `Content-Type` header for `multipart/form-data` content and if we add our own here data won't be correctly transmitted.
         // eslint-disable-next-line no-case-declarations -- We're only using `contentTypeHeader` within this block.
         const contentTypeHeader = getHeaderName(allHeaders, 'content-type');
         if (contentTypeHeader) {
@@ -83,8 +82,7 @@ export const fetch: Client<FetchOptions> = {
         }
     }
 
-    // If we ultimately don't have any headers to send then we shouldn't add an empty object into
-    // the request options.
+    // If we ultimately don't have any headers to send then we shouldn't add an empty object into the request options.
     if (options.headers && !Object.keys(options.headers).length) {
       delete options.headers;
     }

--- a/src/targets/javascript/fetch/client.ts
+++ b/src/targets/javascript/fetch/client.ts
@@ -38,15 +38,6 @@ export const fetch: Client<FetchOptions> = {
       method,
     };
 
-    // The FormData API automatically adds a `Content-Type` header for `multipart/form-data`
-    // content and if we add our own here data won't be correctly transmitted.
-    if (postData.mimeType === 'multipart/form-data') {
-      const contentTypeHeader = getHeaderName(allHeaders, 'content-type');
-      if (contentTypeHeader) {
-        delete allHeaders[contentTypeHeader];
-      }
-    }
-
     if (Object.keys(allHeaders).length) {
       options.headers = allHeaders;
     }
@@ -69,6 +60,14 @@ export const fetch: Client<FetchOptions> = {
           break;
         }
 
+        // The FormData API automatically adds a `Content-Type` header for `multipart/form-data`
+        // content and if we add our own here data won't be correctly transmitted.
+        // eslint-disable-next-line no-case-declarations -- We're only using `contentTypeHeader` within this block.
+        const contentTypeHeader = getHeaderName(allHeaders, 'content-type');
+        if (contentTypeHeader) {
+          delete allHeaders[contentTypeHeader];
+        }
+
         push('const form = new FormData();');
 
         postData.params.forEach(param => {
@@ -82,6 +81,12 @@ export const fetch: Client<FetchOptions> = {
         if (postData.text) {
           options.body = postData.text;
         }
+    }
+
+    // If we ultimately don't have any headers to send then we shouldn't add an empty object into
+    // the request options.
+    if (options.headers && !Object.keys(options.headers).length) {
+      delete options.headers;
     }
 
     push(

--- a/src/targets/javascript/fetch/fixtures/multipart-data.js
+++ b/src/targets/javascript/fetch/fixtures/multipart-data.js
@@ -2,10 +2,7 @@ const form = new FormData();
 form.append('foo', 'Hello World');
 form.append('bar', 'Bonjour le monde');
 
-const options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+const options = {method: 'POST'};
 
 options.body = form;
 

--- a/src/targets/javascript/fetch/fixtures/multipart-file.js
+++ b/src/targets/javascript/fetch/fixtures/multipart-file.js
@@ -1,10 +1,7 @@
 const form = new FormData();
 form.append('foo', 'test/fixtures/files/hello.txt');
 
-const options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+const options = {method: 'POST'};
 
 options.body = form;
 

--- a/src/targets/javascript/fetch/fixtures/multipart-form-data.js
+++ b/src/targets/javascript/fetch/fixtures/multipart-form-data.js
@@ -1,10 +1,7 @@
 const form = new FormData();
 form.append('foo', 'bar');
 
-const options = {
-  method: 'POST',
-  headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+const options = {method: 'POST'};
 
 options.body = form;
 

--- a/src/targets/node/fetch/client.ts
+++ b/src/targets/node/fetch/client.ts
@@ -11,6 +11,7 @@
 import stringifyObject from 'stringify-object';
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { getHeaderName } from '../../../helpers/headers';
 import { Client } from '../../targets';
 
 export const fetch: Client = {
@@ -34,6 +35,15 @@ export const fetch: Client = {
     const reqOpts: Record<string, any> = {
       method,
     };
+
+    // The `form-data` module automatically adds a `Content-Type` header for `multipart/form-data`
+    // content and if we add our own here data won't be correctly transmitted.
+    if (postData.mimeType === 'multipart/form-data') {
+      const contentTypeHeader = getHeaderName(headersObj, 'content-type');
+      if (contentTypeHeader) {
+        delete headersObj[contentTypeHeader];
+      }
+    }
 
     if (Object.keys(headersObj).length) {
       reqOpts.headers = headersObj;

--- a/src/targets/node/fetch/client.ts
+++ b/src/targets/node/fetch/client.ts
@@ -36,15 +36,6 @@ export const fetch: Client = {
       method,
     };
 
-    // The `form-data` module automatically adds a `Content-Type` header for `multipart/form-data`
-    // content and if we add our own here data won't be correctly transmitted.
-    if (postData.mimeType === 'multipart/form-data') {
-      const contentTypeHeader = getHeaderName(headersObj, 'content-type');
-      if (contentTypeHeader) {
-        delete headersObj[contentTypeHeader];
-      }
-    }
-
     if (Object.keys(headersObj).length) {
       reqOpts.headers = headersObj;
     }
@@ -71,6 +62,15 @@ export const fetch: Client = {
       case 'multipart/form-data':
         if (!postData.params) {
           break;
+        }
+
+        // The `form-data` module automatically adds a `Content-Type` header for
+        // `multipart/form-data` content and if we add our own here data won't be correctly
+        // transmitted.
+        // eslint-disable-next-line no-case-declarations -- We're only using `contentTypeHeader` within this block.
+        const contentTypeHeader = getHeaderName(headersObj, 'content-type');
+        if (contentTypeHeader) {
+          delete headersObj[contentTypeHeader];
         }
 
         unshift("const FormData = require('form-data');");
@@ -111,6 +111,12 @@ export const fetch: Client = {
     blank();
     push(`let url = '${url}';`);
     blank();
+
+    // If we ultimately don't have any headers to send then we shouldn't add an empty object into
+    // the request options.
+    if (reqOpts.headers && !Object.keys(reqOpts.headers).length) {
+      delete reqOpts.headers;
+    }
 
     const stringifiedOptions = stringifyObject(reqOpts, { indent: '  ', inlineCharacterLimit: 80 });
     push(`let options = ${stringifiedOptions};`);

--- a/src/targets/node/fetch/client.ts
+++ b/src/targets/node/fetch/client.ts
@@ -64,9 +64,7 @@ export const fetch: Client = {
           break;
         }
 
-        // The `form-data` module automatically adds a `Content-Type` header for
-        // `multipart/form-data` content and if we add our own here data won't be correctly
-        // transmitted.
+        // The `form-data` module automatically adds a `Content-Type` header for `multipart/form-data` content and if we add our own here data won't be correctly transmitted.
         // eslint-disable-next-line no-case-declarations -- We're only using `contentTypeHeader` within this block.
         const contentTypeHeader = getHeaderName(headersObj, 'content-type');
         if (contentTypeHeader) {
@@ -112,8 +110,7 @@ export const fetch: Client = {
     push(`let url = '${url}';`);
     blank();
 
-    // If we ultimately don't have any headers to send then we shouldn't add an empty object into
-    // the request options.
+    // If we ultimately don't have any headers to send then we shouldn't add an empty object into the request options.
     if (reqOpts.headers && !Object.keys(reqOpts.headers).length) {
       delete reqOpts.headers;
     }

--- a/src/targets/node/fetch/fixtures/multipart-data.js
+++ b/src/targets/node/fetch/fixtures/multipart-data.js
@@ -8,10 +8,7 @@ formData.append('bar', 'Bonjour le monde');
 
 let url = 'http://mockbin.com/har';
 
-let options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+let options = {method: 'POST'};
 
 options.body = formData;
 

--- a/src/targets/node/fetch/fixtures/multipart-file.js
+++ b/src/targets/node/fetch/fixtures/multipart-file.js
@@ -7,10 +7,7 @@ formData.append('foo', fs.createReadStream('test/fixtures/files/hello.txt'));
 
 let url = 'http://mockbin.com/har';
 
-let options = {
-  method: 'POST',
-  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+let options = {method: 'POST'};
 
 options.body = formData;
 

--- a/src/targets/node/fetch/fixtures/multipart-form-data.js
+++ b/src/targets/node/fetch/fixtures/multipart-form-data.js
@@ -6,10 +6,7 @@ formData.append('foo', 'bar');
 
 let url = 'http://mockbin.com/har';
 
-let options = {
-  method: 'POST',
-  headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
-};
+let options = {method: 'POST'};
 
 options.body = formData;
 


### PR DESCRIPTION
> This is a reworking of my original PR for this in https://github.com/Kong/httpsnippet/pull/230, just against the new TS rewrite.

Since #227 has us a bit spooked we've started testing other targets that may also have issues with `multipart/form-data` requests and found that both of the `fetch` targets for Node and JS are not currently transferring data properly because the custom header that is being added is clashing with the auto-generated header from the `FormData` API and `form-data` module.

You can see this problem in action with the `multipart-form-data` snippet against https://httpbin.org/anything:

```js
const FormData = require('form-data');
const fetch = require('node-fetch');
const formData = new FormData();

formData.append('foo', 'bar');

let url = 'https://httpbin.org/anything';

const options = {
  method: 'POST',
  headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
};

options.body = formData;

fetch(url, options)
  .then(res => res.json())
  .then(json => console.log(json))
  .catch(err => console.error('error:' + err));
```

```js
{
  args: {},
  data: '',
  files: {},
  form: {},
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'gzip,deflate',
    'Content-Length': '161',
    'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001',
    Host: 'httpbin.org',
    'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
    'X-Amzn-Trace-Id': 'REDACTED'
  },
  json: null,
  method: 'POST',
  origin: 'REDACTED',
  url: 'https://httpbin.org/anything'
}
```

After removing the `multipart/form-data` header:

```js
{
  args: {},
  data: '',
  files: {},
  form: { foo: 'bar' },
  headers: {
    Accept: '*/*',
    'Accept-Encoding': 'gzip,deflate',
    'Content-Length': '161',
    'Content-Type': 'multipart/form-data;boundary=--------------------------635295776437093815404580',
    Host: 'httpbin.org',
    'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
    'X-Amzn-Trace-Id': 'REDACTED'
  },
  json: null,
  method: 'POST',
  origin: '98.42.248.146',
  url: 'https://httpbin.org/anything'
}
```

Changelog(Fixes): Fixed `multipart/form-data` header issues with node/js fetch targets