### PR TITLE
Fix build workflow dispatch rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: Build
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This should fix the fact Build pipeline wasn't properly being triggered on pull requests. It will now mimic same behavior as with `build_recurring` for Insomnia.