### PR TITLE
fix: issue where query strings in R wouldn't be properly concatenated

### DIFF
--- a/src/helpers/code-builder.ts
+++ b/src/helpers/code-builder.ts
@@ -29,7 +29,7 @@ export class CodeBuilder {
    */
   constructor({ indent, join }: CodeBuilderOptions = {}) {
     this.indentationCharacter = indent || DEFAULT_INDENTATION_CHARACTER;
-    this.lineJoin = join || DEFAULT_LINE_JOIN;
+    this.lineJoin = join ?? DEFAULT_LINE_JOIN;
   }
 
   /**

--- a/src/targets/r/httr/client.test.ts
+++ b/src/targets/r/httr/client.test.ts
@@ -9,7 +9,7 @@ runCustomFixtures({
       it: "should properly concatenate query strings that aren't nested",
       input: {
         method: 'GET',
-        url: "http://mockbin.com/har",
+        url: 'http://mockbin.com/har',
         httpVersion: 'HTTP/1.1',
         queryString: [
           {
@@ -22,7 +22,7 @@ runCustomFixtures({
           },
         ],
       } as Request,
-      options: { short: true, indent: false },
+      options: {},
       expected: 'query-two-params.r',
     },
   ],

--- a/src/targets/r/httr/client.test.ts
+++ b/src/targets/r/httr/client.test.ts
@@ -1,0 +1,29 @@
+import { runCustomFixtures } from '../../../fixtures/runCustomFixtures';
+import { Request } from '../../../httpsnippet';
+
+runCustomFixtures({
+  targetId: 'r',
+  clientId: 'httr',
+  tests: [
+    {
+      it: "should properly concatenate query strings that aren't nested",
+      input: {
+        method: 'GET',
+        url: "http://mockbin.com/har",
+        httpVersion: 'HTTP/1.1',
+        queryString: [
+          {
+            name: 'perPage',
+            value: '100',
+          },
+          {
+            name: 'page',
+            value: '1',
+          },
+        ],
+      } as Request,
+      options: { short: true, indent: false },
+      expected: 'query-two-params.r',
+    },
+  ],
+});

--- a/src/targets/r/httr/client.ts
+++ b/src/targets/r/httr/client.ts
@@ -8,6 +8,11 @@
  * for any questions or issues regarding the generated code snippet, please open an issue mentioning the author.
  */
 
+export interface HttrOptions {
+  /** @default '  ' */
+  indent?: string;
+}
+
 import { CodeBuilder } from '../../../helpers/code-builder';
 import { Client } from '../../targets';
 
@@ -18,9 +23,11 @@ export const httr: Client = {
     link: 'https://cran.r-project.org/web/packages/httr/vignettes/quickstart.html',
     description: 'httr: Tools for Working with URLs and HTTP',
   },
-  convert: ({ url, queryObj, queryString, postData, allHeaders, method }) => {
+  convert: ({ url, queryObj, queryString, postData, allHeaders, method }, options = {}) => {
     // Start snippet
-    const { push, blank, join } = new CodeBuilder();
+    const { push, blank, join } = new CodeBuilder({
+      indent: options.indent ?? '  ',
+    });
 
     // Import httr
     push('library(httr)');
@@ -34,19 +41,20 @@ export const httr: Client = {
     const qs = queryObj;
     delete queryObj.key;
 
-    const queryCount = Object.keys(qs).length;
-    if (queryCount === 1) {
-      push(`queryString <- list(${Object.keys(qs)} = "${Object.values(qs).toString()}")`);
+    const entries = Object.entries(qs);
+    const entriesCount = entries.length;
+
+    if (entriesCount === 1) {
+      const entry = entries[0];
+      push(`queryString <- list(${entry[0]} = "${entry[1]}")`);
       blank();
-    } else if (queryCount > 1) {
+    } else if (entriesCount > 1) {
       push('queryString <- list(');
 
-      Object.keys(qs).forEach((query, i) => {
-        if (i !== queryCount - 1) {
-          push(`  ${query} = "${qs[query].toString()}",`);
-        } else {
-          push(`  ${query} = "${qs[query].toString()}"`);
-        }
+      entries.forEach(([key, value], i) => {
+        const isLastItem = i !== entriesCount - 1;
+        const maybeComma = isLastItem ? ',' : '';
+        push(`${key} = "${value}"${maybeComma}`, 1);
       });
 
       push(')');

--- a/src/targets/r/httr/client.ts
+++ b/src/targets/r/httr/client.ts
@@ -32,24 +32,22 @@ export const httr: Client = {
 
     // Construct query string
     const qs = queryObj;
-    const queryCount = Object.keys(qs).length;
     delete queryObj.key;
 
-    if (queryString.length === 1) {
+    const queryCount = Object.keys(qs).length;
+    if (queryCount === 1) {
       push(`queryString <- list(${Object.keys(qs)} = "${Object.values(qs).toString()}")`);
       blank();
-    } else if (queryString.length > 1) {
-      let count = 1;
-
+    } else if (queryCount > 1) {
       push('queryString <- list(');
 
-      for (const query in qs) {
-        if (count++ !== queryCount - 1) {
+      Object.keys(qs).forEach((query, i) => {
+        if (i !== queryCount - 1) {
           push(`  ${query} = "${qs[query].toString()}",`);
         } else {
           push(`  ${query} = "${qs[query].toString()}"`);
         }
-      }
+      });
 
       push(')');
       blank();

--- a/src/targets/r/httr/fixtures/query-two-params.r
+++ b/src/targets/r/httr/fixtures/query-two-params.r
@@ -1,0 +1,12 @@
+library(httr)
+
+url <- "http://mockbin.com/har"
+
+queryString <- list(
+  perPage = "100",
+  page = "1"
+)
+
+response <- VERB("GET", url, query = queryString, content_type("application/octet-stream"))
+
+content(response, "text")


### PR DESCRIPTION
A user reported this issue to us on our docs where query strings for R wouldn't be properly concatenated with a comma:

```r
library(httr)

url <- "https://dash.readme.com/api/v1/categories"

queryString <- list(
  perPage = "10"    # this is missing a comma
  page = "1",       # this shouldn't have a comma
)

response <- VERB("GET", url, add_headers('Authorization' = 'Basic REDACTED'), query = queryString, content_type("application/octet-stream"))

content(response, "text")
```

Digging into it, because the `httr` target was calculating the total number of query strings before removing the `key` the count would always be off for a query string of two parameters.

Reason the existing `query` fixture tests didn't have this problem was because its query string evaluates to `{ foo: [ 'bar', 'baz' ], baz: 'abc' }`, but with a total of `3` prior to deleting `queryObj.key`.  Because 3 is greater than the number of entries it'd *actually* run through, it wouldn't ever add a comma on the last entry because it would stop running at the 2nd mark.

Super weird bug! 

Changelog(Fixes): Fixed an issue where query strings in R wouldn't be properly concatenated