### PR TITLE
fix: clj-http handling of literal null JSON bodies

### DIFF
--- a/src/targets/clojure/clj_http/client.ts
+++ b/src/targets/clojure/clj_http/client.ts
@@ -30,17 +30,32 @@ class File {
   toString = () => `(clojure.java.io/file "${this.path}")`;
 }
 
-const jsType = (x?: any) => (typeof x !== 'undefined' ? x.constructor.name.toLowerCase() : null);
+const jsType = (input?: any) => {
+  if (input === undefined) {
+    return null;
+  }
 
-const objEmpty = (x?: any) => (jsType(x) === 'object' ? Object.keys(x).length === 0 : false);
+  if (input === null) {
+    return 'null';
+  }
 
-const filterEmpty = (m: Record<string, any>) => {
-  Object.keys(m)
-    .filter(x => objEmpty(m[x]))
+  return input.constructor.name.toLowerCase();
+};
+
+const objEmpty = (input?: any) => {
+  if (jsType(input) === 'object') {
+    return Object.keys(input).length === 0;
+  }
+  return false;
+};
+
+const filterEmpty = (input: Record<string, any>) => {
+  Object.keys(input)
+    .filter(x => objEmpty(input[x]))
     .forEach(x => {
-      delete m[x];
+      delete input[x];
     });
-  return m;
+  return input;
 };
 
 const padBlock = (padSize: number, input: string) => {

--- a/src/targets/clojure/clj_http/fixtures/jsonObj-multiline.clj
+++ b/src/targets/clojure/clj_http/fixtures/jsonObj-multiline.clj
@@ -1,1 +1,4 @@
-<MISSING>
+(require '[clj-http.client :as client])
+
+(client/post "http://mockbin.com/har" {:content-type :json
+                                       :form-params {:foo "bar"}})

--- a/src/targets/clojure/clj_http/fixtures/jsonObj-null-value.clj
+++ b/src/targets/clojure/clj_http/fixtures/jsonObj-null-value.clj
@@ -1,1 +1,4 @@
-<MISSING>
+(require '[clj-http.client :as client])
+
+(client/post "http://mockbin.com/har" {:content-type :json
+                                       :form-params {:foo nil}})

--- a/src/targets/targets.test.ts
+++ b/src/targets/targets.test.ts
@@ -61,11 +61,6 @@ availableTargets()
           );
           try {
             const expected = readFileSync(expectedPath).toString();
-            if (expected === '<MISSING>') {
-              console.log(`known missing test for ${targetId}:${clientId} "${fixture}"`);
-              return;
-            }
-
             const { convert } = new HTTPSnippet(request);
             const result = convert(targetId, clientId); //?
 


### PR DESCRIPTION
this PR is just a port of https://github.com/Kong/httpsnippet/pull/191, but since I can't push to the fork (digtalloggers) in order to update the tests, I had to push here instead.

closes #191 