### PR TITLE
chore: minor cleanup

### DIFF
--- a/src/httpsnippet.test.ts
+++ b/src/httpsnippet.test.ts
@@ -126,7 +126,7 @@ describe('hTTPSnippet', () => {
         });
       });
 
-      it('should fix the `path` propety of uriObj to match queryString', () => {
+      it('should fix the `path` property of uriObj to match queryString', () => {
         const snippet = new HTTPSnippet(query as Request);
         const request = snippet.requests[0];
 
@@ -200,7 +200,7 @@ describe('hTTPSnippet', () => {
     });
 
     describe('url', () => {
-      it('shoudl modify the original url to strip query string', () => {
+      it('should modify the original url to strip query string', () => {
         const snippet = new HTTPSnippet(query as Request);
         const request = snippet.requests[0];
 

--- a/src/targets/node/fetch/client.ts
+++ b/src/targets/node/fetch/client.ts
@@ -97,8 +97,8 @@ export const fetch: Client = {
     // construct cookies argument
     if (cookies.length) {
       const cookiesString = cookies
-        .map(cookie => `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}; `)
-        .join('');
+        .map(cookie => `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}`)
+        .join('; ');
       if (reqOpts.headers) {
         reqOpts.headers.cookie = cookiesString;
       } else {
@@ -107,8 +107,7 @@ export const fetch: Client = {
       }
     }
     blank();
-    push(`let url = '${url}';`);
-    blank();
+    push(`const url = '${url}';`);
 
     // If we ultimately don't have any headers to send then we shouldn't add an empty object into the request options.
     if (reqOpts.headers && !Object.keys(reqOpts.headers).length) {
@@ -116,7 +115,7 @@ export const fetch: Client = {
     }
 
     const stringifiedOptions = stringifyObject(reqOpts, { indent: '  ', inlineCharacterLimit: 80 });
-    push(`let options = ${stringifiedOptions};`);
+    push(`const options = ${stringifiedOptions};`);
     blank();
 
     if (includeFS) {

--- a/src/targets/node/fetch/fixtures/application-form-encoded.js
+++ b/src/targets/node/fetch/fixtures/application-form-encoded.js
@@ -5,9 +5,8 @@ const encodedParams = new URLSearchParams();
 encodedParams.set('foo', 'bar');
 encodedParams.set('hello', 'world');
 
-let url = 'http://mockbin.com/har';
-
-let options = {
+const url = 'http://mockbin.com/har';
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
   body: encodedParams

--- a/src/targets/node/fetch/fixtures/application-json.js
+++ b/src/targets/node/fetch/fixtures/application-json.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {
+const url = 'http://mockbin.com/har';
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'

--- a/src/targets/node/fetch/fixtures/cookies.js
+++ b/src/targets/node/fetch/fixtures/cookies.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz; '}};
+const url = 'http://mockbin.com/har';
+const options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz'}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/node/fetch/fixtures/custom-method.js
+++ b/src/targets/node/fetch/fixtures/custom-method.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'PROPFIND'};
+const url = 'http://mockbin.com/har';
+const options = {method: 'PROPFIND'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/node/fetch/fixtures/full.js
+++ b/src/targets/node/fetch/fixtures/full.js
@@ -4,14 +4,13 @@ const encodedParams = new URLSearchParams();
 
 encodedParams.set('foo', 'bar');
 
-let url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
-
-let options = {
+const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
+const options = {
   method: 'POST',
   headers: {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded',
-    cookie: 'foo=bar; bar=baz; '
+    cookie: 'foo=bar; bar=baz'
   },
   body: encodedParams
 };

--- a/src/targets/node/fetch/fixtures/headers.js
+++ b/src/targets/node/fetch/fixtures/headers.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {
+const url = 'http://mockbin.com/har';
+const options = {
   method: 'GET',
   headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };

--- a/src/targets/node/fetch/fixtures/https.js
+++ b/src/targets/node/fetch/fixtures/https.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'https://mockbin.com/har';
-
-let options = {method: 'GET'};
+const url = 'https://mockbin.com/har';
+const options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/node/fetch/fixtures/jsonObj-multiline.js
+++ b/src/targets/node/fetch/fixtures/jsonObj-multiline.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {
+const url = 'http://mockbin.com/har';
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"foo":"bar"}'

--- a/src/targets/node/fetch/fixtures/jsonObj-null-value.js
+++ b/src/targets/node/fetch/fixtures/jsonObj-null-value.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {
+const url = 'http://mockbin.com/har';
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"foo":null}'

--- a/src/targets/node/fetch/fixtures/multipart-data.js
+++ b/src/targets/node/fetch/fixtures/multipart-data.js
@@ -6,9 +6,8 @@ const formData = new FormData();
 formData.append('foo', fs.createReadStream('hello.txt'));
 formData.append('bar', 'Bonjour le monde');
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'POST'};
+const url = 'http://mockbin.com/har';
+const options = {method: 'POST'};
 
 options.body = formData;
 

--- a/src/targets/node/fetch/fixtures/multipart-file.js
+++ b/src/targets/node/fetch/fixtures/multipart-file.js
@@ -5,9 +5,8 @@ const formData = new FormData();
 
 formData.append('foo', fs.createReadStream('test/fixtures/files/hello.txt'));
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'POST'};
+const url = 'http://mockbin.com/har';
+const options = {method: 'POST'};
 
 options.body = formData;
 

--- a/src/targets/node/fetch/fixtures/multipart-form-data-no-params.js
+++ b/src/targets/node/fetch/fixtures/multipart-form-data-no-params.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'POST', headers: {'Content-Type': 'multipart/form-data'}};
+const url = 'http://mockbin.com/har';
+const options = {method: 'POST', headers: {'Content-Type': 'multipart/form-data'}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/node/fetch/fixtures/multipart-form-data.js
+++ b/src/targets/node/fetch/fixtures/multipart-form-data.js
@@ -4,9 +4,8 @@ const formData = new FormData();
 
 formData.append('foo', 'bar');
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'POST'};
+const url = 'http://mockbin.com/har';
+const options = {method: 'POST'};
 
 options.body = formData;
 

--- a/src/targets/node/fetch/fixtures/nested.js
+++ b/src/targets/node/fetch/fixtures/nested.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value';
-
-let options = {method: 'GET'};
+const url = 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value';
+const options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/node/fetch/fixtures/query.js
+++ b/src/targets/node/fetch/fixtures/query.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
-
-let options = {method: 'GET'};
+const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
+const options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/node/fetch/fixtures/short.js
+++ b/src/targets/node/fetch/fixtures/short.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'GET'};
+const url = 'http://mockbin.com/har';
+const options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/node/fetch/fixtures/text-plain.js
+++ b/src/targets/node/fetch/fixtures/text-plain.js
@@ -1,8 +1,7 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
-
-let options = {method: 'POST', headers: {'content-type': 'text/plain'}, body: 'Hello World'};
+const url = 'http://mockbin.com/har';
+const options = {method: 'POST', headers: {'content-type': 'text/plain'}, body: 'Hello World'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/src/targets/targets.test.ts
+++ b/src/targets/targets.test.ts
@@ -1,9 +1,10 @@
 import { readdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 
+import short from '../fixtures/requests/short.json';
 import { availableTargets, extname } from '../helpers/utils';
 import { HTTPSnippet, Request } from '../httpsnippet';
-import { ClientId, isClient, isTarget, TargetId } from './targets';
+import { addTarget, addTargetClient, Client, ClientId, isClient, isTarget, Target, TargetId, targets } from './targets';
 
 const expectedBasePath = ['src', 'fixtures', 'requests'];
 
@@ -243,5 +244,59 @@ describe('isClient', () => {
         convert: () => '',
       }),
     ).toBeTruthy();
+  });
+});
+
+describe('addTarget', () => {
+  it('should add a new custom target', async () => {
+    const { fetch: fetchClient } = await import('./node/fetch/client');
+
+    const deno: Target = {
+      info: {
+        // @ts-expect-error intentionally incorrect
+        key: 'deno',
+        title: 'Deno',
+        extname: '.js',
+        default: 'fetch',
+      },
+      clientsById: {
+        fetch: fetchClient,
+      },
+    };
+
+    addTarget(deno);
+
+    // @ts-expect-error intentionally incorrect
+    expect(targets.deno).toBeDefined();
+    // @ts-expect-error intentionally incorrect
+    expect(targets.deno).toStrictEqual(deno);
+
+    // @ts-expect-error intentionally incorrect
+    delete targets.deno;
+  });
+});
+
+describe('addTargetClient', () => {
+  it('should add a new custom target', () => {
+    const customClient: Client = {
+      info: {
+        key: 'custom',
+        title: 'Custom HTTP library',
+        link: 'https://example.com',
+        description: 'A custom HTTP library',
+      },
+      convert: () => {
+        return 'This was generated from a custom client.';
+      },
+    };
+
+    addTargetClient('node', customClient);
+
+    const { convert } = new HTTPSnippet(short as Request);
+    const result = convert('node', 'custom');
+
+    expect(result).toBe('This was generated from a custom client.');
+
+    delete targets.node.clientsById.custom;
   });
 });


### PR DESCRIPTION
* [x] Changing `let` variable instantiations in the Node Fetch client to `const`. This now matches the JS Fetch target.
* [x] Removing an unnecessary trailing space at the end of cookie declarations in Node Fetch. 
* [x] Adding missing test cases for the `addTarget` and `addTargetClient` APIs that didn't get ported over in the TS rewrite.
* [x] Finally, I found and fixed a few typos some tests.