### PR TITLE
feat: use curl's --compressed option for requests that accept it

### DIFF
--- a/src/targets/shell/curl/client.test.ts
+++ b/src/targets/shell/curl/client.test.ts
@@ -147,5 +147,20 @@ runCustomFixtures({
       },
       expected: 'application-json-prettified.sh',
     },
+    {
+      it: 'should use --compressed for requests that accept encodings',
+      input: {
+        method: 'GET',
+        url: 'http://mockbin.com/har',
+        headers: [
+          {
+            name: 'accept-encoding',
+            value: 'deflate, gzip, br',
+          },
+        ],
+      } as Request,
+      options: {},
+      expected: 'accept-encoding-compressed.sh',
+    },
   ],
 });

--- a/src/targets/shell/curl/client.ts
+++ b/src/targets/shell/curl/client.ts
@@ -10,7 +10,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
-import { getHeaderName, isMimeTypeJSON } from '../../../helpers/headers';
+import { getHeader, getHeaderName, isMimeTypeJSON } from '../../../helpers/headers';
 import { quote } from '../../../helpers/shell';
 import { Client } from '../../targets';
 
@@ -88,6 +88,11 @@ export const curl: Client<CurlOptions> = {
 
     if (httpVersion === 'HTTP/1.0') {
       push(arg('http1.0'));
+    }
+
+    if (getHeader(allHeaders, 'accept-encoding')) {
+      // note: there is no shorthand for this cURL option
+      push('--compressed');
     }
 
     // if multipart form data, we want to remove the boundary

--- a/src/targets/shell/curl/fixtures/accept-encoding-compressed.sh
+++ b/src/targets/shell/curl/fixtures/accept-encoding-compressed.sh
@@ -1,0 +1,4 @@
+curl --request GET \
+  --url http://mockbin.com/har \
+  --compressed \
+  --header 'accept-encoding: deflate, gzip, br'


### PR DESCRIPTION
closes #237

this is a direct port of https://github.com/Kong/httpsnippet/pull/237, which we can't push to because the original fork (httptoolkit) has been deleted