### PR TITLE
Escape quotes in headers correctly in all languages

### DIFF
--- a/src/fixtures/requests/headers.json
+++ b/src/fixtures/requests/headers.json
@@ -11,8 +11,8 @@
       "value": "Bar"
     },
     {
-      "name": "x-bar",
-      "value": "Foo"
+      "name": "quoted-value",
+      "value": "\"quoted\" 'string'"
     }
   ]
 }

--- a/src/helpers/escape.test.ts
+++ b/src/helpers/escape.test.ts
@@ -1,0 +1,35 @@
+import { escapeString } from './escape';
+
+describe('Escape methods', () => {
+  describe('escapeString', () => {
+    it('does nothing to a safe string', () => {
+      expect(
+        escapeString("hello world")
+      ).toBe("hello world");
+    });
+
+    it('escapes double quotes by default', () => {
+      expect(
+        escapeString('"hello world"')
+      ).toBe('\\"hello world\\"');
+    });
+
+    it('escapes newlines by default', () => {
+      expect(
+        escapeString('hello\r\nworld')
+      ).toBe('hello\\r\\nworld');
+    });
+
+    it('escapes backslashes', () => {
+      expect(
+        escapeString('hello\\world')
+      ).toBe('hello\\\\world');
+    });
+
+    it('escapes unrepresentable characters', () => {
+      expect(
+        escapeString('hello \u0000') // 0 = ASCII 'null' character
+      ).toBe('hello \\u0000');
+    });
+  });
+});

--- a/src/helpers/escape.ts
+++ b/src/helpers/escape.ts
@@ -1,0 +1,81 @@
+export interface EscapeOptions {
+  /**
+   * The delimiter that will be used to wrap the string (and so must be escaped
+   * when used within the string).
+   * Defaults to "
+   */
+  delimiter?: string;
+
+  /**
+   * The char to use to escape the delimiter and other special characters.
+   * Defaults to \
+   */
+  escapeChar?: string;
+
+  /**
+   * Whether newlines (\n and \r) should be escaped within the string.
+   * Defaults to true.
+   */
+  escapeNewlines?: boolean;
+}
+
+/**
+ * Escape characters within a value to make it safe to insert directly into a
+ * snippet. Takes options which define the escape requirements.
+ *
+ * This is closely based on the JSON-stringify string serialization algorithm,
+ * but generalized for other string delimiters (e.g. " or ') and different escape
+ * characters (e.g. Powershell uses `)
+ *
+ * See https://tc39.es/ecma262/multipage/structured-data.html#sec-quotejsonstring
+ * for the complete original algorithm.
+ */
+export function escapeString(value: any, options: EscapeOptions = {}) {
+  const {
+    delimiter = '"',
+    escapeChar = '\\',
+    escapeNewlines = true
+  } = options;
+
+  value = value.toString();
+
+  return [...value].map((c) => {
+    if (c === '\b') {
+      return escapeChar + 'b';
+    } else if (c === '\t') {
+      return escapeChar + 't';
+    } else if (c === '\n') {
+      if (escapeNewlines) {
+        return escapeChar + 'n';
+      } else {
+        return c; // Don't just continue, or this is caught by < \u0020
+      }
+    } else if (c === '\f') {
+      return escapeChar + 'f';
+    } else if (c === '\r') {
+      if (escapeNewlines) {
+        return escapeChar + 'r';
+      } else {
+        return c; // Don't just continue, or this is caught by < \u0020
+      }
+    } else if (c === escapeChar) {
+      return escapeChar + escapeChar;
+    } else if (c === delimiter) {
+      return escapeChar + delimiter;
+    } else if (c < '\u0020' || c > '\u007E') {
+      // Delegate the trickier non-ASCII cases to the normal algorithm. Some of these
+      // are escaped as \uXXXX, whilst others are represented literally. Since we're
+      // using this primarily for header values that are generally (though not 100%
+      // strictly?) ASCII-only, this should almost never happen.
+      return JSON.stringify(c).slice(1, -1);
+    } else {
+      return c;
+    }
+  }).join('');
+}
+
+export const escapeForSingleQuotes = (value: any) =>
+  escapeString(value, { delimiter: "'" });
+
+export const escapeForDoubleQuotes = (value: any) =>
+  escapeString(value, { delimiter: '"' });

--- a/src/helpers/escape.ts
+++ b/src/helpers/escape.ts
@@ -74,8 +74,22 @@ export function escapeString(value: any, options: EscapeOptions = {}) {
   }).join('');
 }
 
+/**
+ * Make a string value safe to insert literally into a snippet within single quotes,
+ * by escaping problematic characters, including single quotes inside the string,
+ * backslashes, newlines, and other special characters.
+ *
+ * If value is not a string, it will be stringified with .toString() first.
+ */
 export const escapeForSingleQuotes = (value: any) =>
   escapeString(value, { delimiter: "'" });
 
+/**
+ * Make a string value safe to insert literally into a snippet within double quotes,
+ * by escaping problematic characters, including double quotes inside the string,
+ * backslashes, newlines, and other special characters.
+ *
+ * If value is not a string, it will be stringified with .toString() first.
+ */
 export const escapeForDoubleQuotes = (value: any) =>
   escapeString(value, { delimiter: '"' });

--- a/src/helpers/escape.ts
+++ b/src/helpers/escape.ts
@@ -30,16 +30,16 @@ export interface EscapeOptions {
  * See https://tc39.es/ecma262/multipage/structured-data.html#sec-quotejsonstring
  * for the complete original algorithm.
  */
-export function escapeString(value: any, options: EscapeOptions = {}) {
+export function escapeString(rawValue: any, options: EscapeOptions = {}) {
   const {
     delimiter = '"',
     escapeChar = '\\',
     escapeNewlines = true
   } = options;
 
-  value = value.toString();
+  const stringValue = rawValue.toString();
 
-  return [...value].map((c) => {
+  return [...stringValue].map((c) => {
     if (c === '\b') {
       return escapeChar + 'b';
     } else if (c === '\t') {

--- a/src/targets/c/libcurl/client.ts
+++ b/src/targets/c/libcurl/client.ts
@@ -1,4 +1,5 @@
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export const libcurl: Client = {
@@ -25,7 +26,7 @@ export const libcurl: Client = {
       push('struct curl_slist *headers = NULL;');
 
       headers.forEach(header => {
-        push(`headers = curl_slist_append(headers, "${header}: ${headersObj[header]}");`);
+        push(`headers = curl_slist_append(headers, "${header}: ${escapeForDoubleQuotes(headersObj[header])}");`);
       });
 
       push('curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);');

--- a/src/targets/c/libcurl/fixtures/headers.c
+++ b/src/targets/c/libcurl/fixtures/headers.c
@@ -6,7 +6,7 @@ curl_easy_setopt(hnd, CURLOPT_URL, "http://mockbin.com/har");
 struct curl_slist *headers = NULL;
 headers = curl_slist_append(headers, "accept: application/json");
 headers = curl_slist_append(headers, "x-foo: Bar");
-headers = curl_slist_append(headers, "x-bar: Foo");
+headers = curl_slist_append(headers, "quoted-value: \"quoted\" 'string'");
 curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
 CURLcode ret = curl_easy_perform(hnd);

--- a/src/targets/clojure/clj_http/fixtures/headers.clj
+++ b/src/targets/clojure/clj_http/fixtures/headers.clj
@@ -1,5 +1,5 @@
 (require '[clj-http.client :as client])
 
 (client/get "http://mockbin.com/har" {:headers {:x-foo "Bar"
-                                                :x-bar "Foo"}
+                                                :quoted-value "\"quoted\" 'string'"}
                                       :accept :json})

--- a/src/targets/csharp/httpclient/client.ts
+++ b/src/targets/csharp/httpclient/client.ts
@@ -1,4 +1,5 @@
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { getHeader } from '../../../helpers/headers';
 import { Request } from '../../../httpsnippet';
 import { Client } from '../../targets';
@@ -102,7 +103,7 @@ export const httpclient: Client = {
       push('Headers =', 1);
       push('{', 1);
       headers.forEach(key => {
-        push(`{ "${key}", "${allHeaders[key]}" },`, 2);
+        push(`{ "${key}", "${escapeForDoubleQuotes(allHeaders[key])}" },`, 2);
       });
       push('},', 1);
     }

--- a/src/targets/csharp/httpclient/fixtures/headers.cs
+++ b/src/targets/csharp/httpclient/fixtures/headers.cs
@@ -8,7 +8,7 @@ var request = new HttpRequestMessage
     {
         { "accept", "application/json" },
         { "x-foo", "Bar" },
-        { "x-bar", "Foo" },
+        { "quoted-value", "\"quoted\" 'string'" },
     },
 };
 using (var response = await client.SendAsync(request))

--- a/src/targets/csharp/restsharp/client.ts
+++ b/src/targets/csharp/restsharp/client.ts
@@ -1,4 +1,5 @@
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { getHeader } from '../../../helpers/headers';
 import { Client } from '../../targets';
 
@@ -25,7 +26,7 @@ export const restsharp: Client = {
     // Add headers, including the cookies
 
     Object.keys(headersObj).forEach(key => {
-      push(`request.AddHeader("${key}", "${headersObj[key]}");`);
+      push(`request.AddHeader("${key}", "${escapeForDoubleQuotes(headersObj[key])}");`);
     });
 
     cookies.forEach(({ name, value }) => {

--- a/src/targets/csharp/restsharp/fixtures/headers.cs
+++ b/src/targets/csharp/restsharp/fixtures/headers.cs
@@ -2,5 +2,5 @@ var client = new RestClient("http://mockbin.com/har");
 var request = new RestRequest(Method.GET);
 request.AddHeader("accept", "application/json");
 request.AddHeader("x-foo", "Bar");
-request.AddHeader("x-bar", "Foo");
+request.AddHeader("quoted-value", "\"quoted\" 'string'");
 IRestResponse response = client.Execute(request);

--- a/src/targets/go/native/client.ts
+++ b/src/targets/go/native/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export interface GoNativeOptions {
@@ -125,7 +126,7 @@ export const native: Client<GoNativeOptions> = {
     // Add headers
     if (Object.keys(allHeaders).length) {
       Object.keys(allHeaders).forEach(key => {
-        push(`req.Header.Add("${key}", "${allHeaders[key]}")`, indent);
+        push(`req.Header.Add("${key}", "${escapeForDoubleQuotes(allHeaders[key])}")`, indent);
       });
 
       blank();

--- a/src/targets/go/native/fixtures/headers.go
+++ b/src/targets/go/native/fixtures/headers.go
@@ -14,7 +14,7 @@ func main() {
 
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("x-foo", "Bar")
-	req.Header.Add("x-bar", "Foo")
+	req.Header.Add("quoted-value", "\"quoted\" 'string'")
 
 	res, _ := http.DefaultClient.Do(req)
 

--- a/src/targets/http/http1.1/fixtures/headers
+++ b/src/targets/http/http1.1/fixtures/headers
@@ -1,6 +1,6 @@
 GET /har HTTP/1.1
 Accept: application/json
 X-Foo: Bar
-X-Bar: Foo
+Quoted-Value: "quoted" 'string'
 Host: mockbin.com
 

--- a/src/targets/java/asynchttp/client.ts
+++ b/src/targets/java/asynchttp/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export const asynchttp: Client = {
@@ -31,7 +32,7 @@ export const asynchttp: Client = {
 
     // Add headers, including the cookies
     Object.keys(allHeaders).forEach(key => {
-      push(`.setHeader("${key}", "${allHeaders[key]}")`, 1);
+      push(`.setHeader("${key}", "${escapeForDoubleQuotes(allHeaders[key])}")`, 1);
     });
 
     if (postData.text) {

--- a/src/targets/java/asynchttp/fixtures/headers.java
+++ b/src/targets/java/asynchttp/fixtures/headers.java
@@ -2,7 +2,7 @@ AsyncHttpClient client = new DefaultAsyncHttpClient();
 client.prepare("GET", "http://mockbin.com/har")
   .setHeader("accept", "application/json")
   .setHeader("x-foo", "Bar")
-  .setHeader("x-bar", "Foo")
+  .setHeader("quoted-value", "\"quoted\" 'string'")
   .execute()
   .toCompletableFuture()
   .thenAccept(System.out::println)

--- a/src/targets/java/nethttp/client.ts
+++ b/src/targets/java/nethttp/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export interface NetHttpOptions {
@@ -34,7 +35,7 @@ export const nethttp: Client = {
     push(`.uri(URI.create("${fullUrl}"))`, 2);
 
     Object.keys(allHeaders).forEach(key => {
-      push(`.header("${key}", "${allHeaders[key]}")`, 2);
+      push(`.header("${key}", "${escapeForDoubleQuotes(allHeaders[key])}")`, 2);
     });
 
     if (postData.text) {

--- a/src/targets/java/nethttp/fixtures/headers.java
+++ b/src/targets/java/nethttp/fixtures/headers.java
@@ -2,7 +2,7 @@ HttpRequest request = HttpRequest.newBuilder()
     .uri(URI.create("http://mockbin.com/har"))
     .header("accept", "application/json")
     .header("x-foo", "Bar")
-    .header("x-bar", "Foo")
+    .header("quoted-value", "\"quoted\" 'string'")
     .method("GET", HttpRequest.BodyPublishers.noBody())
     .build();
 HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());

--- a/src/targets/java/okhttp/client.ts
+++ b/src/targets/java/okhttp/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export const okhttp: Client = {
@@ -62,7 +63,7 @@ export const okhttp: Client = {
 
     // Add headers, including the cookies
     Object.keys(allHeaders).forEach(key => {
-      push(`.addHeader("${key}", "${allHeaders[key]}")`, 1);
+      push(`.addHeader("${key}", "${escapeForDoubleQuotes(allHeaders[key])}")`, 1);
     });
 
     push('.build();', 1);

--- a/src/targets/java/okhttp/fixtures/headers.java
+++ b/src/targets/java/okhttp/fixtures/headers.java
@@ -5,7 +5,7 @@ Request request = new Request.Builder()
   .get()
   .addHeader("accept", "application/json")
   .addHeader("x-foo", "Bar")
-  .addHeader("x-bar", "Foo")
+  .addHeader("quoted-value", "\"quoted\" 'string'")
   .build();
 
 Response response = client.newCall(request).execute();

--- a/src/targets/java/unirest/client.ts
+++ b/src/targets/java/unirest/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export const unirest: Client = {
@@ -38,7 +39,7 @@ export const unirest: Client = {
 
     // Add headers, including the cookies
     Object.keys(allHeaders).forEach(key => {
-      push(`.header("${key}", "${allHeaders[key]}")`, 1);
+      push(`.header("${key}", "${escapeForDoubleQuotes(allHeaders[key])}")`, 1);
     });
 
     if (postData.text) {

--- a/src/targets/java/unirest/fixtures/headers.java
+++ b/src/targets/java/unirest/fixtures/headers.java
@@ -1,5 +1,5 @@
 HttpResponse<String> response = Unirest.get("http://mockbin.com/har")
   .header("accept", "application/json")
   .header("x-foo", "Bar")
-  .header("x-bar", "Foo")
+  .header("quoted-value", "\"quoted\" 'string'")
   .asString();

--- a/src/targets/javascript/axios/fixtures/headers.js
+++ b/src/targets/javascript/axios/fixtures/headers.js
@@ -3,7 +3,11 @@ import axios from 'axios';
 const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
-  headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
+  headers: {
+    accept: 'application/json',
+    'x-foo': 'Bar',
+    'quoted-value': '"quoted" \'string\''
+  }
 };
 
 try {

--- a/src/targets/javascript/fetch/fixtures/headers.js
+++ b/src/targets/javascript/fetch/fixtures/headers.js
@@ -1,7 +1,11 @@
 const url = 'http://mockbin.com/har';
 const options = {
   method: 'GET',
-  headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
+  headers: {
+    accept: 'application/json',
+    'x-foo': 'Bar',
+    'quoted-value': '"quoted" \'string\''
+  }
 };
 
 try {

--- a/src/targets/javascript/jquery/fixtures/headers.js
+++ b/src/targets/javascript/jquery/fixtures/headers.js
@@ -6,7 +6,7 @@ const settings = {
   headers: {
     accept: 'application/json',
     'x-foo': 'Bar',
-    'x-bar': 'Foo'
+    'quoted-value': '"quoted" \'string\''
   }
 };
 

--- a/src/targets/javascript/xhr/client.ts
+++ b/src/targets/javascript/xhr/client.ts
@@ -11,6 +11,7 @@
 import stringifyObject from 'stringify-object';
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForSingleQuotes } from '../../../helpers/escape';
 import { getHeader, getHeaderName, hasHeader } from '../../../helpers/headers';
 import { Client } from '../../targets';
 
@@ -89,7 +90,7 @@ export const xhr: Client = {
     push(`xhr.open('${method}', '${fullUrl}');`);
 
     Object.keys(allHeaders).forEach(key => {
-      push(`xhr.setRequestHeader('${key}', '${allHeaders[key]}');`);
+      push(`xhr.setRequestHeader('${key}', '${escapeForSingleQuotes(allHeaders[key])}');`);
     });
 
     blank();

--- a/src/targets/javascript/xhr/fixtures/headers.js
+++ b/src/targets/javascript/xhr/fixtures/headers.js
@@ -12,6 +12,6 @@ xhr.addEventListener('readystatechange', function () {
 xhr.open('GET', 'http://mockbin.com/har');
 xhr.setRequestHeader('accept', 'application/json');
 xhr.setRequestHeader('x-foo', 'Bar');
-xhr.setRequestHeader('x-bar', 'Foo');
+xhr.setRequestHeader('quoted-value', '"quoted" \'string\'');
 
 xhr.send(data);

--- a/src/targets/kotlin/okhttp/client.ts
+++ b/src/targets/kotlin/okhttp/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export const okhttp: Client = {
@@ -63,7 +64,7 @@ export const okhttp: Client = {
 
     // Add headers, including the cookies
     Object.keys(allHeaders).forEach(key => {
-      push(`.addHeader("${key}", "${allHeaders[key]}")`, 1);
+      push(`.addHeader("${key}", "${escapeForDoubleQuotes(allHeaders[key])}")`, 1);
     });
 
     push('.build()', 1);

--- a/src/targets/kotlin/okhttp/fixtures/headers.kt
+++ b/src/targets/kotlin/okhttp/fixtures/headers.kt
@@ -5,7 +5,7 @@ val request = Request.Builder()
   .get()
   .addHeader("accept", "application/json")
   .addHeader("x-foo", "Bar")
-  .addHeader("x-bar", "Foo")
+  .addHeader("quoted-value", "\"quoted\" 'string'")
   .build()
 
 val response = client.newCall(request).execute()

--- a/src/targets/node/axios/fixtures/headers.js
+++ b/src/targets/node/axios/fixtures/headers.js
@@ -3,7 +3,11 @@ const axios = require('axios').default;
 const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
-  headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
+  headers: {
+    accept: 'application/json',
+    'x-foo': 'Bar',
+    'quoted-value': '"quoted" \'string\''
+  }
 };
 
 try {

--- a/src/targets/node/fetch/fixtures/headers.js
+++ b/src/targets/node/fetch/fixtures/headers.js
@@ -3,7 +3,11 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har';
 const options = {
   method: 'GET',
-  headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
+  headers: {
+    accept: 'application/json',
+    'x-foo': 'Bar',
+    'quoted-value': '"quoted" \'string\''
+  }
 };
 
 try {

--- a/src/targets/node/native/fixtures/headers.js
+++ b/src/targets/node/native/fixtures/headers.js
@@ -8,7 +8,7 @@ const options = {
   headers: {
     accept: 'application/json',
     'x-foo': 'Bar',
-    'x-bar': 'Foo'
+    'quoted-value': '"quoted" \'string\''
   }
 };
 

--- a/src/targets/node/request/fixtures/headers.js
+++ b/src/targets/node/request/fixtures/headers.js
@@ -3,7 +3,11 @@ const request = require('request');
 const options = {
   method: 'GET',
   url: 'http://mockbin.com/har',
-  headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
+  headers: {
+    accept: 'application/json',
+    'x-foo': 'Bar',
+    'quoted-value': '"quoted" \'string\''
+  }
 };
 
 request(options, function (error, response, body) {

--- a/src/targets/node/unirest/fixtures/headers.js
+++ b/src/targets/node/unirest/fixtures/headers.js
@@ -5,7 +5,7 @@ const req = unirest('GET', 'http://mockbin.com/har');
 req.headers({
   accept: 'application/json',
   'x-foo': 'Bar',
-  'x-bar': 'Foo'
+  'quoted-value': '"quoted" \'string\''
 });
 
 req.end(function (res) {

--- a/src/targets/objc/nsurlsession/fixtures/headers.m
+++ b/src/targets/objc/nsurlsession/fixtures/headers.m
@@ -2,7 +2,7 @@
 
 NSDictionary *headers = @{ @"accept": @"application/json",
                            @"x-foo": @"Bar",
-                           @"x-bar": @"Foo" };
+                           @"quoted-value": @"\"quoted\" 'string'" };
 
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://mockbin.com/har"]
                                                        cachePolicy:NSURLRequestUseProtocolCachePolicy

--- a/src/targets/ocaml/cohttp/client.ts
+++ b/src/targets/ocaml/cohttp/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export const cohttp: Client = {
@@ -38,12 +39,12 @@ export const cohttp: Client = {
 
     if (headers.length === 1) {
       push(
-        `let headers = Header.add (Header.init ()) "${headers[0]}" "${allHeaders[headers[0]]}" in`,
+        `let headers = Header.add (Header.init ()) "${headers[0]}" "${escapeForDoubleQuotes(allHeaders[headers[0]])}" in`,
       );
     } else if (headers.length > 1) {
       push('let headers = Header.add_list (Header.init ()) [');
       headers.forEach(key => {
-        push(`("${key}", "${allHeaders[key]}");`, 1);
+        push(`("${key}", "${escapeForDoubleQuotes(allHeaders[key])}");`, 1);
       });
       push('] in');
     }

--- a/src/targets/ocaml/cohttp/fixtures/headers.ml
+++ b/src/targets/ocaml/cohttp/fixtures/headers.ml
@@ -6,7 +6,7 @@ let uri = Uri.of_string "http://mockbin.com/har" in
 let headers = Header.add_list (Header.init ()) [
   ("accept", "application/json");
   ("x-foo", "Bar");
-  ("x-bar", "Foo");
+  ("quoted-value", "\"quoted\" 'string'");
 ] in
 
 Client.call ~headers `GET uri

--- a/src/targets/php/curl/client.ts
+++ b/src/targets/php/curl/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 import { convertType } from '../helpers';
 
@@ -125,7 +126,7 @@ export const curl: Client<CurlOptions> = {
     // construct cookies
     const headers = Object.keys(headersObj)
       .sort()
-      .map(key => `"${key}: ${headersObj[key]}"`);
+      .map(key => `"${key}: ${escapeForDoubleQuotes(headersObj[key])}"`);
 
     if (headers.length) {
       curlopts.push('CURLOPT_HTTPHEADER => [');

--- a/src/targets/php/curl/fixtures/headers.php
+++ b/src/targets/php/curl/fixtures/headers.php
@@ -12,7 +12,7 @@ curl_setopt_array($curl, [
   CURLOPT_CUSTOMREQUEST => "GET",
   CURLOPT_HTTPHEADER => [
     "accept: application/json",
-    "x-bar: Foo",
+    "quoted-value: \"quoted\" 'string'",
     "x-foo: Bar"
   ],
 ]);

--- a/src/targets/php/guzzle/client.ts
+++ b/src/targets/php/guzzle/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForSingleQuotes } from '../../../helpers/escape';
 import { getHeader, getHeaderName, hasHeader } from '../../../helpers/headers';
 import { Client } from '../../targets';
 import { convertType } from '../helpers';
@@ -122,7 +123,7 @@ export const guzzle: Client<GuzzleOptions> = {
     const headers = Object.keys(headersObj)
       .sort()
       .map(function (key) {
-        return `${opts.indent}${opts.indent}'${key}' => '${headersObj[key]}',`;
+        return `${opts.indent}${opts.indent}'${key}' => '${escapeForSingleQuotes(headersObj[key])}',`;
       });
 
     // construct cookies
@@ -130,7 +131,7 @@ export const guzzle: Client<GuzzleOptions> = {
       .map(cookie => `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}`)
       .join('; ');
     if (cookieString.length) {
-      headers.push(`${opts.indent}${opts.indent}'cookie' => '${cookieString}',`);
+      headers.push(`${opts.indent}${opts.indent}'cookie' => '${escapeForSingleQuotes(cookieString)}',`);
     }
 
     if (headers.length) {

--- a/src/targets/php/guzzle/fixtures/headers.php
+++ b/src/targets/php/guzzle/fixtures/headers.php
@@ -5,7 +5,7 @@ $client = new \GuzzleHttp\Client();
 $response = $client->request('GET', 'http://mockbin.com/har', [
   'headers' => [
     'accept' => 'application/json',
-    'x-bar' => 'Foo',
+    'quoted-value' => '"quoted" \'string\'',
     'x-foo' => 'Bar',
   ],
 ]);

--- a/src/targets/php/helpers.ts
+++ b/src/targets/php/helpers.ts
@@ -1,3 +1,5 @@
+import { escapeString } from "../../helpers/escape";
+
 export const convertType = (obj: any[] | any, indent?: string, lastIndent?: string) => {
   lastIndent = lastIndent || '';
   indent = indent || '';
@@ -10,7 +12,7 @@ export const convertType = (obj: any[] | any, indent?: string, lastIndent?: stri
       return 'null';
 
     case '[object String]':
-      return `'${obj.replace(/\\/g, '\\\\').replace(/'/g, "'")}'`;
+      return `'${escapeString(obj, { delimiter: "'", escapeNewlines: false })}'`;
 
     case '[object Number]':
       return obj.toString();

--- a/src/targets/php/http1/fixtures/headers.php
+++ b/src/targets/php/http1/fixtures/headers.php
@@ -7,7 +7,7 @@ $request->setMethod(HTTP_METH_GET);
 $request->setHeaders([
   'accept' => 'application/json',
   'x-foo' => 'Bar',
-  'x-bar' => 'Foo'
+  'quoted-value' => '"quoted" \'string\''
 ]);
 
 try {

--- a/src/targets/php/http2/fixtures/headers.php
+++ b/src/targets/php/http2/fixtures/headers.php
@@ -8,7 +8,7 @@ $request->setRequestMethod('GET');
 $request->setHeaders([
   'accept' => 'application/json',
   'x-foo' => 'Bar',
-  'x-bar' => 'Foo'
+  'quoted-value' => '"quoted" \'string\''
 ]);
 
 $client->enqueue($request)->send();

--- a/src/targets/powershell/common.ts
+++ b/src/targets/powershell/common.ts
@@ -1,4 +1,5 @@
 import { CodeBuilder } from '../../helpers/code-builder';
+import { escapeString } from '../../helpers/escape';
 import { getHeader } from '../../helpers/headers';
 import { Converter } from '../targets';
 
@@ -32,7 +33,7 @@ export const generatePowershellConvert = (command: PowershellCommand) => {
       headers.forEach(key => {
         if (key !== 'connection') {
           // Not allowed
-          push(`$headers.Add("${key}", "${headersObj[key]}")`);
+          push(`$headers.Add("${key}", "${escapeString(headersObj[key], { escapeChar: '`' })}")`);
         }
       });
       commandOptions.push('-Headers $headers');
@@ -55,7 +56,9 @@ export const generatePowershellConvert = (command: PowershellCommand) => {
     }
 
     if (postData.text) {
-      commandOptions.push(`-ContentType '${getHeader(allHeaders, 'content-type')}'`);
+      commandOptions.push(`-ContentType '${
+        escapeString(getHeader(allHeaders, 'content-type'), { delimiter: "'", escapeChar: '`' })
+      }'`);
       commandOptions.push(`-Body '${postData.text}'`);
     }
 

--- a/src/targets/powershell/restmethod/fixtures/headers.ps1
+++ b/src/targets/powershell/restmethod/fixtures/headers.ps1
@@ -1,5 +1,5 @@
 $headers=@{}
 $headers.Add("accept", "application/json")
 $headers.Add("x-foo", "Bar")
-$headers.Add("x-bar", "Foo")
+$headers.Add("quoted-value", "`"quoted`" 'string'")
 $response = Invoke-RestMethod -Uri 'http://mockbin.com/har' -Method GET -Headers $headers

--- a/src/targets/powershell/webrequest/fixtures/headers.ps1
+++ b/src/targets/powershell/webrequest/fixtures/headers.ps1
@@ -1,5 +1,5 @@
 $headers=@{}
 $headers.Add("accept", "application/json")
 $headers.Add("x-foo", "Bar")
-$headers.Add("x-bar", "Foo")
+$headers.Add("quoted-value", "`"quoted`" 'string'")
 $response = Invoke-WebRequest -Uri 'http://mockbin.com/har' -Method GET -Headers $headers

--- a/src/targets/python/python3/client.ts
+++ b/src/targets/python/python3/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export interface Python3Options {
@@ -55,7 +56,7 @@ export const python3: Client<Python3Options> = {
     const headerCount = Object.keys(headers).length;
     if (headerCount === 1) {
       for (const header in headers) {
-        push(`headers = { '${header}': "${headers[header]}" }`);
+        push(`headers = { '${header}': "${escapeForDoubleQuotes(headers[header])}" }`);
         blank();
       }
     } else if (headerCount > 1) {
@@ -65,9 +66,9 @@ export const python3: Client<Python3Options> = {
 
       for (const header in headers) {
         if (count++ !== headerCount) {
-          push(`    '${header}': "${headers[header]}",`);
+          push(`    '${header}': "${escapeForDoubleQuotes(headers[header])}",`);
         } else {
-          push(`    '${header}': "${headers[header]}"`);
+          push(`    '${header}': "${escapeForDoubleQuotes(headers[header])}"`);
         }
       }
 

--- a/src/targets/python/python3/client.ts
+++ b/src/targets/python/python3/client.ts
@@ -72,7 +72,7 @@ export const python3: Client<Python3Options> = {
         }
       }
 
-      push('    }');
+      push('}');
       blank();
     }
 

--- a/src/targets/python/python3/fixtures/full.py
+++ b/src/targets/python/python3/fixtures/full.py
@@ -8,7 +8,7 @@ headers = {
     'cookie': "foo=bar; bar=baz",
     'accept': "application/json",
     'content-type': "application/x-www-form-urlencoded"
-    }
+}
 
 conn.request("POST", "/har?foo=bar&foo=baz&baz=abc&key=value", payload, headers)
 

--- a/src/targets/python/python3/fixtures/headers.py
+++ b/src/targets/python/python3/fixtures/headers.py
@@ -5,7 +5,7 @@ conn = http.client.HTTPConnection("mockbin.com")
 headers = {
     'accept': "application/json",
     'x-foo': "Bar",
-    'x-bar': "Foo"
+    'quoted-value': "\"quoted\" 'string'"
     }
 
 conn.request("GET", "/har", headers=headers)

--- a/src/targets/python/python3/fixtures/headers.py
+++ b/src/targets/python/python3/fixtures/headers.py
@@ -6,7 +6,7 @@ headers = {
     'accept': "application/json",
     'x-foo': "Bar",
     'quoted-value': "\"quoted\" 'string'"
-    }
+}
 
 conn.request("GET", "/har", headers=headers)
 

--- a/src/targets/python/requests/client.ts
+++ b/src/targets/python/requests/client.ts
@@ -9,6 +9,7 @@
  */
 
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { getHeaderName } from '../../../helpers/headers';
 import { Client } from '../../targets';
 import { literalRepresentation } from '../helpers';
@@ -130,7 +131,7 @@ export const requests: Client<RequestsOptions> = {
       blank();
     } else if (headerCount === 1) {
       for (const header in headers) {
-        push(`headers = {"${header}": "${headers[header]}"}`);
+        push(`headers = {"${header}": "${escapeForDoubleQuotes(headers[header])}"}`);
         blank();
       }
     } else if (headerCount > 1) {
@@ -140,9 +141,9 @@ export const requests: Client<RequestsOptions> = {
 
       for (const header in headers) {
         if (count !== headerCount) {
-          push(`"${header}": "${headers[header]}",`, 1);
+          push(`"${header}": "${escapeForDoubleQuotes(headers[header])}",`, 1);
         } else {
-          push(`"${header}": "${headers[header]}"`, 1);
+          push(`"${header}": "${escapeForDoubleQuotes(headers[header])}"`, 1);
         }
         count += 1;
       }

--- a/src/targets/python/requests/fixtures/headers.py
+++ b/src/targets/python/requests/fixtures/headers.py
@@ -5,7 +5,7 @@ url = "http://mockbin.com/har"
 headers = {
     "accept": "application/json",
     "x-foo": "Bar",
-    "x-bar": "Foo"
+    "quoted-value": "\"quoted\" 'string'"
 }
 
 response = requests.get(url, headers=headers)

--- a/src/targets/r/httr/fixtures/headers.r
+++ b/src/targets/r/httr/fixtures/headers.r
@@ -2,6 +2,6 @@ library(httr)
 
 url <- "http://mockbin.com/har"
 
-response <- VERB("GET", url, add_headers('x-foo' = 'Bar', 'x-bar' = 'Foo'), content_type("application/octet-stream"), accept("application/json"))
+response <- VERB("GET", url, add_headers('x-foo' = 'Bar', 'quoted-value' = '"quoted" \'string\''), content_type("application/octet-stream"), accept("application/json"))
 
 content(response, "text")

--- a/src/targets/ruby/native/client.ts
+++ b/src/targets/ruby/native/client.ts
@@ -1,4 +1,5 @@
 import { CodeBuilder } from '../../../helpers/code-builder';
+import { escapeForSingleQuotes } from '../../../helpers/escape';
 import { Client } from '../../targets';
 
 export interface RubyNativeOptions {
@@ -70,7 +71,7 @@ export const native: Client<RubyNativeOptions> = {
     const headers = Object.keys(allHeaders);
     if (headers.length) {
       headers.forEach(key => {
-        push(`request["${key}"] = '${allHeaders[key]}'`);
+        push(`request["${key}"] = '${escapeForSingleQuotes(allHeaders[key])}'`);
       });
     }
 

--- a/src/targets/ruby/native/fixtures/headers.rb
+++ b/src/targets/ruby/native/fixtures/headers.rb
@@ -8,7 +8,7 @@ http = Net::HTTP.new(url.host, url.port)
 request = Net::HTTP::Get.new(url)
 request["accept"] = 'application/json'
 request["x-foo"] = 'Bar'
-request["x-bar"] = 'Foo'
+request["quoted-value"] = '"quoted" \'string\''
 
 response = http.request(request)
 puts response.read_body

--- a/src/targets/shell/curl/fixtures/headers.sh
+++ b/src/targets/shell/curl/fixtures/headers.sh
@@ -1,5 +1,5 @@
 curl --request GET \
   --url http://mockbin.com/har \
   --header 'accept: application/json' \
-  --header 'x-bar: Foo' \
+  --header 'quoted-value: "quoted" '\''string'\''' \
   --header 'x-foo: Bar'

--- a/src/targets/shell/httpie/fixtures/headers.sh
+++ b/src/targets/shell/httpie/fixtures/headers.sh
@@ -1,4 +1,4 @@
 http GET http://mockbin.com/har \
   accept:application/json \
-  x-bar:Foo \
+  quoted-value:'"quoted" '\''string'\''' \
   x-foo:Bar

--- a/src/targets/shell/wget/fixtures/headers.sh
+++ b/src/targets/shell/wget/fixtures/headers.sh
@@ -2,6 +2,6 @@ wget --quiet \
   --method GET \
   --header 'accept: application/json' \
   --header 'x-foo: Bar' \
-  --header 'x-bar: Foo' \
+  --header 'quoted-value: "quoted" '\''string'\''' \
   --output-document \
   - http://mockbin.com/har

--- a/src/targets/swift/nsurlsession/fixtures/headers.swift
+++ b/src/targets/swift/nsurlsession/fixtures/headers.swift
@@ -3,7 +3,7 @@ import Foundation
 let headers = [
   "accept": "application/json",
   "x-foo": "Bar",
-  "x-bar": "Foo"
+  "quoted-value": "\"quoted\" 'string'"
 ]
 
 let request = NSMutableURLRequest(url: NSURL(string: "http://mockbin.com/har")! as URL,


### PR DESCRIPTION
As discussed in https://github.com/Kong/httpsnippet/issues/271#issuecomment-1185716335 - this ports the test changes from https://github.com/httptoolkit/httpsnippet into the new folder structure here, providing working examples for correct quote-escaping for every single language/format.

~~This does _not_ make the tests pass, we'll need to do that separately - currently this fails for 22 of the snippets, where they're currently not escaping quotes right now.~~

~~I think the base logic to fix this should look something like [this](https://github.com/httptoolkit/httpsnippet/blob/a10703297c8b03cbf62b8c5d282cbdf36596fa04/src/helpers/format.js#L3-L45), which we'll need to call in the appropriate places with the appropriate options (delimiter, escapeChar and escapeNewlines). You can see how it's used for each snippet [in the original commit](https://github.com/httptoolkit/httpsnippet/commit/a10703297c8b03cbf62b8c5d282cbdf36596fa04) to check which ones you need, but the tests here should be enough to confirm that's correct.~~

~~Happy for somebody else to look into fixing this, if anybody has time, or I should be able to migrate the fix for this myself late this week or early next if not.~~

EDIT: Now updated to add a working implementation, in addition to updating all the test fixtures to cover this.