### PR TITLE
feat: PHP JSON body encoding

### DIFF
--- a/src/targets/php/curl/client.ts
+++ b/src/targets/php/curl/client.ts
@@ -10,11 +10,12 @@
 
 import { CodeBuilder } from '../../../helpers/code-builder';
 import { Client } from '../../targets';
+import { convertType } from '../helpers';
 
 export interface CurlOptions {
   closingTag?: boolean;
   maxRedirects?: number;
-  nameErrors?: boolean;
+  namedErrors?: boolean;
   noTags?: boolean;
   shortTags?: boolean;
   timeout?: number;
@@ -27,22 +28,24 @@ export const curl: Client<CurlOptions> = {
     link: 'http://php.net/manual/en/book.curl.php',
     description: 'PHP with ext-curl',
   },
-  convert: ({ uriObj, postData, fullUrl, method, httpVersion, cookies, headersObj }, options) => {
-    const opts = {
-      closingTag: false,
-      indent: '  ',
-      maxRedirects: 10,
-      namedErrors: false,
-      noTags: false,
-      shortTags: false,
-      timeout: 30,
-      ...options,
-    };
+  convert: (
+    { uriObj, postData, fullUrl, method, httpVersion, cookies, headersObj },
+    options = {},
+  ) => {
+    const {
+      closingTag = false,
+      indent = '  ',
+      maxRedirects = 10,
+      namedErrors = false,
+      noTags = false,
+      shortTags = false,
+      timeout = 30,
+    } = options;
 
-    const { push, blank, join } = new CodeBuilder({ indent: opts.indent });
+    const { push, blank, join } = new CodeBuilder({ indent });
 
-    if (!opts.noTags) {
-      push(opts.shortTags ? '<?' : '<?php');
+    if (!noTags) {
+      push(shortTags ? '<?' : '<?php');
       blank();
     }
 
@@ -73,12 +76,12 @@ export const curl: Client<CurlOptions> = {
       {
         escape: false,
         name: 'CURLOPT_MAXREDIRS',
-        value: opts.maxRedirects,
+        value: maxRedirects,
       },
       {
         escape: false,
         name: 'CURLOPT_TIMEOUT',
-        value: opts.timeout,
+        value: timeout,
       },
       {
         escape: false,
@@ -91,15 +94,19 @@ export const curl: Client<CurlOptions> = {
         value: method,
       },
       {
-        escape: true,
+        escape: !postData.jsonObj,
         name: 'CURLOPT_POSTFIELDS',
-        value: postData ? postData.text : undefined,
+        value: postData
+          ? postData.jsonObj
+            ? `json_encode(${convertType(postData.jsonObj, indent.repeat(2), indent)})`
+            : postData.text
+          : undefined,
       },
     ];
 
     push('curl_setopt_array($curl, [');
 
-    const curlopts = new CodeBuilder({ indent: opts.indent, join: `\n${opts.indent}` });
+    const curlopts = new CodeBuilder({ indent, join: `\n${indent}` });
 
     curlOptions.forEach(({ value, name, escape }) => {
       if (value !== null && value !== undefined) {
@@ -122,7 +129,7 @@ export const curl: Client<CurlOptions> = {
 
     if (headers.length) {
       curlopts.push('CURLOPT_HTTPHEADER => [');
-      curlopts.push(headers.join(`,\n${opts.indent}${opts.indent}`), 1);
+      curlopts.push(headers.join(`,\n${indent}${indent}`), 1);
       curlopts.push('],');
     }
 
@@ -136,7 +143,7 @@ export const curl: Client<CurlOptions> = {
     blank();
     push('if ($err) {');
 
-    if (opts.namedErrors) {
+    if (namedErrors) {
       push('echo array_flip(get_defined_constants(true)["curl"])[$err];', 1);
     } else {
       push('echo "cURL Error #:" . $err;', 1);
@@ -146,7 +153,7 @@ export const curl: Client<CurlOptions> = {
     push('echo $response;', 1);
     push('}');
 
-    if (!opts.noTags && opts.closingTag) {
+    if (!noTags && closingTag) {
       blank();
       push('?>');
     }

--- a/src/targets/php/curl/fixtures/application-json.php
+++ b/src/targets/php/curl/fixtures/application-json.php
@@ -10,7 +10,28 @@ curl_setopt_array($curl, [
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
-  CURLOPT_POSTFIELDS => "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}",
+  CURLOPT_POSTFIELDS => json_encode([
+    'number' => 1,
+    'string' => 'f"oo',
+    'arr' => [
+        1,
+        2,
+        3
+    ],
+    'nested' => [
+        'a' => 'b'
+    ],
+    'arr_mix' => [
+        1,
+        'a',
+        [
+                'arr_mix_nested' => [
+                                
+                ]
+        ]
+    ],
+    'boolean' => null
+  ]),
   CURLOPT_HTTPHEADER => [
     "content-type: application/json"
   ],

--- a/src/targets/php/curl/fixtures/jsonObj-multiline.php
+++ b/src/targets/php/curl/fixtures/jsonObj-multiline.php
@@ -10,7 +10,9 @@ curl_setopt_array($curl, [
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
-  CURLOPT_POSTFIELDS => "{\n  \"foo\": \"bar\"\n}",
+  CURLOPT_POSTFIELDS => json_encode([
+    'foo' => 'bar'
+  ]),
   CURLOPT_HTTPHEADER => [
     "content-type: application/json"
   ],

--- a/src/targets/php/curl/fixtures/jsonObj-null-value.php
+++ b/src/targets/php/curl/fixtures/jsonObj-null-value.php
@@ -10,7 +10,9 @@ curl_setopt_array($curl, [
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
   CURLOPT_CUSTOMREQUEST => "POST",
-  CURLOPT_POSTFIELDS => "{\"foo\":null}",
+  CURLOPT_POSTFIELDS => json_encode([
+    'foo' => null
+  ]),
   CURLOPT_HTTPHEADER => [
     "content-type: application/json"
   ],

--- a/src/targets/php/http1/fixtures/application-json.php
+++ b/src/targets/php/http1/fixtures/application-json.php
@@ -8,7 +8,29 @@ $request->setHeaders([
   'content-type' => 'application/json'
 ]);
 
-$request->setBody('{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}');
+$request->setContentType('application/json');
+$request->setBody(json_encode([
+  'number' => 1,
+  'string' => 'f"oo',
+  'arr' => [
+    1,
+    2,
+    3
+  ],
+  'nested' => [
+    'a' => 'b'
+  ],
+  'arr_mix' => [
+    1,
+    'a',
+    [
+        'arr_mix_nested' => [
+                
+        ]
+    ]
+  ],
+  'boolean' => null
+]));
 
 try {
   $response = $request->send();

--- a/src/targets/php/http1/fixtures/jsonObj-multiline.php
+++ b/src/targets/php/http1/fixtures/jsonObj-multiline.php
@@ -8,9 +8,10 @@ $request->setHeaders([
   'content-type' => 'application/json'
 ]);
 
-$request->setBody('{
-  "foo": "bar"
-}');
+$request->setContentType('application/json');
+$request->setBody(json_encode([
+  'foo' => 'bar'
+]));
 
 try {
   $response = $request->send();

--- a/src/targets/php/http1/fixtures/jsonObj-null-value.php
+++ b/src/targets/php/http1/fixtures/jsonObj-null-value.php
@@ -8,7 +8,10 @@ $request->setHeaders([
   'content-type' => 'application/json'
 ]);
 
-$request->setBody('{"foo":null}');
+$request->setContentType('application/json');
+$request->setBody(json_encode([
+  'foo' => null
+]));
 
 try {
   $response = $request->send();

--- a/src/targets/php/http2/fixtures/application-json.php
+++ b/src/targets/php/http2/fixtures/application-json.php
@@ -4,8 +4,28 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append('{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}');
-
+$body->append(json_encode([
+  'number' => 1,
+  'string' => 'f"oo',
+  'arr' => [
+    1,
+    2,
+    3
+  ],
+  'nested' => [
+    'a' => 'b'
+  ],
+  'arr_mix' => [
+    1,
+    'a',
+    [
+        'arr_mix_nested' => [
+                
+        ]
+    ]
+  ],
+  'boolean' => null
+]));
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);

--- a/src/targets/php/http2/fixtures/jsonObj-multiline.php
+++ b/src/targets/php/http2/fixtures/jsonObj-multiline.php
@@ -4,10 +4,9 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append('{
-  "foo": "bar"
-}');
-
+$body->append(json_encode([
+  'foo' => 'bar'
+]));
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);

--- a/src/targets/php/http2/fixtures/jsonObj-null-value.php
+++ b/src/targets/php/http2/fixtures/jsonObj-null-value.php
@@ -4,8 +4,9 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append('{"foo":null}');
-
+$body->append(json_encode([
+  'foo' => null
+]));
 $request->setRequestUrl('http://mockbin.com/har');
 $request->setRequestMethod('POST');
 $request->setBody($body);


### PR DESCRIPTION
this is a direct port of https://github.com/Kong/httpsnippet/pull/130

The only thing not included here is the python3 and ruby/native updates, because those used the Node internal `child_process` package (https://nodejs.org/api/child_process.html) which we can't include in a library like this which is used in the browser, despite that it could work in certain node contexts.  We'd definitely be happy to see other solutions to the problem if someone would like to find a way to tackle it without calling out to Node internals.