### PR TITLE
Async/Await (top level) support in JavaScript snippets

### DIFF
--- a/src/targets/javascript/axios/client.ts
+++ b/src/targets/javascript/axios/client.ts
@@ -95,14 +95,12 @@ export const axios: Client = {
     push(`const options = ${optionString};`);
     blank();
 
-    push('axios');
-    push('.request(options)', 1);
-    push('.then(function (response) {', 1);
-    push('console.log(response.data);', 2);
-    push('})', 1);
-    push('.catch(function (error) {', 1);
-    push('console.error(error);', 2);
-    push('});', 1);
+    push('try {');
+    push('const { data } = await axios.request(options);', 1);
+    push('console.log(data);', 1);
+    push('} catch (error) {');
+    push('console.error(error);', 1);
+    push('}');
 
     return join();
   },

--- a/src/targets/javascript/axios/fixtures/application-form-encoded.js
+++ b/src/targets/javascript/axios/fixtures/application-form-encoded.js
@@ -11,11 +11,9 @@ const options = {
   data: encodedParams,
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/application-json.js
+++ b/src/targets/javascript/axios/fixtures/application-json.js
@@ -14,11 +14,9 @@ const options = {
   }
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/cookies.js
+++ b/src/targets/javascript/axios/fixtures/cookies.js
@@ -6,11 +6,9 @@ const options = {
   headers: {cookie: 'foo=bar; bar=baz'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/custom-method.js
+++ b/src/targets/javascript/axios/fixtures/custom-method.js
@@ -2,11 +2,9 @@ import axios from 'axios';
 
 const options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/full.js
+++ b/src/targets/javascript/axios/fixtures/full.js
@@ -15,11 +15,9 @@ const options = {
   data: encodedParams,
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/headers.js
+++ b/src/targets/javascript/axios/fixtures/headers.js
@@ -6,11 +6,9 @@ const options = {
   headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/https.js
+++ b/src/targets/javascript/axios/fixtures/https.js
@@ -2,11 +2,9 @@ import axios from 'axios';
 
 const options = {method: 'GET', url: 'https://mockbin.com/har'};
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/jsonObj-multiline.js
+++ b/src/targets/javascript/axios/fixtures/jsonObj-multiline.js
@@ -7,11 +7,9 @@ const options = {
   data: {foo: 'bar'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/jsonObj-null-value.js
+++ b/src/targets/javascript/axios/fixtures/jsonObj-null-value.js
@@ -7,11 +7,9 @@ const options = {
   data: {foo: null}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/multipart-data.js
+++ b/src/targets/javascript/axios/fixtures/multipart-data.js
@@ -11,11 +11,9 @@ const options = {
   data: '[form]'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/multipart-file.js
+++ b/src/targets/javascript/axios/fixtures/multipart-file.js
@@ -10,11 +10,9 @@ const options = {
   data: '[form]'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/multipart-form-data-no-params.js
+++ b/src/targets/javascript/axios/fixtures/multipart-form-data-no-params.js
@@ -6,11 +6,9 @@ const options = {
   headers: {'Content-Type': 'multipart/form-data'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/multipart-form-data.js
+++ b/src/targets/javascript/axios/fixtures/multipart-form-data.js
@@ -10,11 +10,9 @@ const options = {
   data: '[form]'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/nested.js
+++ b/src/targets/javascript/axios/fixtures/nested.js
@@ -6,11 +6,9 @@ const options = {
   params: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/query.js
+++ b/src/targets/javascript/axios/fixtures/query.js
@@ -6,11 +6,9 @@ const options = {
   params: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/short.js
+++ b/src/targets/javascript/axios/fixtures/short.js
@@ -2,11 +2,9 @@ import axios from 'axios';
 
 const options = {method: 'GET', url: 'http://mockbin.com/har'};
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/axios/fixtures/text-plain.js
+++ b/src/targets/javascript/axios/fixtures/text-plain.js
@@ -7,11 +7,9 @@ const options = {
   data: 'Hello World'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/client.ts
+++ b/src/targets/javascript/fetch/client.ts
@@ -46,6 +46,8 @@ export const fetch: Client<FetchOptions> = {
       options.credentials = opts.credentials;
     }
 
+    push(`const url = '${fullUrl}';`);
+
     switch (postData.mimeType) {
       case 'application/x-www-form-urlencoded':
         options.body = postData.paramsObj ? postData.paramsObj : postData.text;
@@ -106,10 +108,13 @@ export const fetch: Client<FetchOptions> = {
       blank();
     }
 
-    push(`fetch('${fullUrl}', options)`);
-    push('.then(response => response.json())', 1);
-    push('.then(response => console.log(response))', 1);
-    push('.catch(err => console.error(err));', 1);
+    push('try {');
+    push(`const response = await fetch(url, options);`, 1);
+    push('const data = await response.json();', 1);
+    push('console.log(data);', 1);
+    push('} catch (error) {');
+    push('console.error(error);', 1);
+    push('}');
 
     return join();
   },

--- a/src/targets/javascript/fetch/fixtures/application-form-encoded.js
+++ b/src/targets/javascript/fetch/fixtures/application-form-encoded.js
@@ -1,10 +1,14 @@
+const url = 'http://mockbin.com/har';
 const options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
   body: new URLSearchParams({foo: 'bar', hello: 'world'})
 };
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/application-json.js
+++ b/src/targets/javascript/fetch/fixtures/application-json.js
@@ -1,10 +1,14 @@
+const url = 'http://mockbin.com/har';
 const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'
 };
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/cookies.js
+++ b/src/targets/javascript/fetch/fixtures/cookies.js
@@ -1,6 +1,10 @@
+const url = 'http://mockbin.com/har';
 const options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz'}};
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/custom-method.js
+++ b/src/targets/javascript/fetch/fixtures/custom-method.js
@@ -1,6 +1,10 @@
+const url = 'http://mockbin.com/har';
 const options = {method: 'PROPFIND'};
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/full.js
+++ b/src/targets/javascript/fetch/fixtures/full.js
@@ -1,3 +1,4 @@
+const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
 const options = {
   method: 'POST',
   headers: {
@@ -8,7 +9,10 @@ const options = {
   body: new URLSearchParams({foo: 'bar'})
 };
 
-fetch('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/headers.js
+++ b/src/targets/javascript/fetch/fixtures/headers.js
@@ -1,9 +1,13 @@
+const url = 'http://mockbin.com/har';
 const options = {
   method: 'GET',
   headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/https.js
+++ b/src/targets/javascript/fetch/fixtures/https.js
@@ -1,6 +1,10 @@
+const url = 'https://mockbin.com/har';
 const options = {method: 'GET'};
 
-fetch('https://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/jsonObj-multiline.js
+++ b/src/targets/javascript/fetch/fixtures/jsonObj-multiline.js
@@ -1,10 +1,14 @@
+const url = 'http://mockbin.com/har';
 const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"foo":"bar"}'
 };
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/jsonObj-null-value.js
+++ b/src/targets/javascript/fetch/fixtures/jsonObj-null-value.js
@@ -1,10 +1,14 @@
+const url = 'http://mockbin.com/har';
 const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"foo":null}'
 };
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/multipart-data.js
+++ b/src/targets/javascript/fetch/fixtures/multipart-data.js
@@ -1,3 +1,4 @@
+const url = 'http://mockbin.com/har';
 const form = new FormData();
 form.append('foo', 'Hello World');
 form.append('bar', 'Bonjour le monde');
@@ -6,7 +7,10 @@ const options = {method: 'POST'};
 
 options.body = form;
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/multipart-file.js
+++ b/src/targets/javascript/fetch/fixtures/multipart-file.js
@@ -1,3 +1,4 @@
+const url = 'http://mockbin.com/har';
 const form = new FormData();
 form.append('foo', 'test/fixtures/files/hello.txt');
 
@@ -5,7 +6,10 @@ const options = {method: 'POST'};
 
 options.body = form;
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/multipart-form-data-no-params.js
+++ b/src/targets/javascript/fetch/fixtures/multipart-form-data-no-params.js
@@ -1,6 +1,10 @@
+const url = 'http://mockbin.com/har';
 const options = {method: 'POST', headers: {'Content-Type': 'multipart/form-data'}};
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/multipart-form-data.js
+++ b/src/targets/javascript/fetch/fixtures/multipart-form-data.js
@@ -1,3 +1,4 @@
+const url = 'http://mockbin.com/har';
 const form = new FormData();
 form.append('foo', 'bar');
 
@@ -5,7 +6,10 @@ const options = {method: 'POST'};
 
 options.body = form;
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/nested.js
+++ b/src/targets/javascript/fetch/fixtures/nested.js
@@ -1,6 +1,10 @@
+const url = 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value';
 const options = {method: 'GET'};
 
-fetch('http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/query.js
+++ b/src/targets/javascript/fetch/fixtures/query.js
@@ -1,6 +1,10 @@
+const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
 const options = {method: 'GET'};
 
-fetch('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/short.js
+++ b/src/targets/javascript/fetch/fixtures/short.js
@@ -1,6 +1,10 @@
+const url = 'http://mockbin.com/har';
 const options = {method: 'GET'};
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/javascript/fetch/fixtures/text-plain.js
+++ b/src/targets/javascript/fetch/fixtures/text-plain.js
@@ -1,6 +1,10 @@
+const url = 'http://mockbin.com/har';
 const options = {method: 'POST', headers: {'content-type': 'text/plain'}, body: 'Hello World'};
 
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/client.ts
+++ b/src/targets/node/axios/client.ts
@@ -79,14 +79,12 @@ export const axios: Client = {
     push(`const options = ${stringifiedOptions};`);
     blank();
 
-    push('axios');
-    push('.request(options)', 1);
-    push('.then(function (response) {', 1);
-    push('console.log(response.data);', 2);
-    push('})', 1);
-    push('.catch(function (error) {', 1);
-    push('console.error(error);', 2);
-    push('});', 1);
+    push('try {');
+    push('const { data } = await axios.request(options);', 1);
+    push('console.log(data);', 1);
+    push('} catch (error) {');
+    push('console.error(error);', 1);
+    push('}');
 
     return join();
   },

--- a/src/targets/node/axios/fixtures/application-form-encoded.js
+++ b/src/targets/node/axios/fixtures/application-form-encoded.js
@@ -12,11 +12,9 @@ const options = {
   data: encodedParams,
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/application-json.js
+++ b/src/targets/node/axios/fixtures/application-json.js
@@ -14,11 +14,9 @@ const options = {
   }
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/cookies.js
+++ b/src/targets/node/axios/fixtures/cookies.js
@@ -6,11 +6,9 @@ const options = {
   headers: {cookie: 'foo=bar; bar=baz'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/custom-method.js
+++ b/src/targets/node/axios/fixtures/custom-method.js
@@ -2,11 +2,9 @@ const axios = require('axios').default;
 
 const options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/full.js
+++ b/src/targets/node/axios/fixtures/full.js
@@ -16,11 +16,9 @@ const options = {
   data: encodedParams,
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/headers.js
+++ b/src/targets/node/axios/fixtures/headers.js
@@ -6,11 +6,9 @@ const options = {
   headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/https.js
+++ b/src/targets/node/axios/fixtures/https.js
@@ -2,11 +2,9 @@ const axios = require('axios').default;
 
 const options = {method: 'GET', url: 'https://mockbin.com/har'};
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/jsonObj-multiline.js
+++ b/src/targets/node/axios/fixtures/jsonObj-multiline.js
@@ -7,11 +7,9 @@ const options = {
   data: {foo: 'bar'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/jsonObj-null-value.js
+++ b/src/targets/node/axios/fixtures/jsonObj-null-value.js
@@ -7,11 +7,9 @@ const options = {
   data: {foo: null}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/multipart-data.js
+++ b/src/targets/node/axios/fixtures/multipart-data.js
@@ -7,11 +7,9 @@ const options = {
   data: '-----011000010111000001101001\r\nContent-Disposition: form-data; name="foo"; filename="hello.txt"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001\r\nContent-Disposition: form-data; name="bar"\r\n\r\nBonjour le monde\r\n-----011000010111000001101001--\r\n'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/multipart-file.js
+++ b/src/targets/node/axios/fixtures/multipart-file.js
@@ -7,11 +7,9 @@ const options = {
   data: '-----011000010111000001101001\r\nContent-Disposition: form-data; name="foo"; filename="hello.txt"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/multipart-form-data-no-params.js
+++ b/src/targets/node/axios/fixtures/multipart-form-data-no-params.js
@@ -6,11 +6,9 @@ const options = {
   headers: {'Content-Type': 'multipart/form-data'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/multipart-form-data.js
+++ b/src/targets/node/axios/fixtures/multipart-form-data.js
@@ -7,11 +7,9 @@ const options = {
   data: '-----011000010111000001101001\r\nContent-Disposition: form-data; name="foo"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/nested.js
+++ b/src/targets/node/axios/fixtures/nested.js
@@ -6,11 +6,9 @@ const options = {
   params: {'foo[bar]': 'baz,zap', fiz: 'buz', key: 'value'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/query.js
+++ b/src/targets/node/axios/fixtures/query.js
@@ -6,11 +6,9 @@ const options = {
   params: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/short.js
+++ b/src/targets/node/axios/fixtures/short.js
@@ -2,11 +2,9 @@ const axios = require('axios').default;
 
 const options = {method: 'GET', url: 'http://mockbin.com/har'};
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/axios/fixtures/text-plain.js
+++ b/src/targets/node/axios/fixtures/text-plain.js
@@ -7,11 +7,9 @@ const options = {
   data: 'Hello World'
 };
 
-axios
-  .request(options)
-  .then(function (response) {
-    console.log(response.data);
-  })
-  .catch(function (error) {
-    console.error(error);
-  });
+try {
+  const { data } = await axios.request(options);
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/application-form-encoded.js
+++ b/src/targets/node/fetch/fixtures/application-form-encoded.js
@@ -1,7 +1,7 @@
 const { URLSearchParams } = require('url');
 const fetch = require('node-fetch');
-const encodedParams = new URLSearchParams();
 
+const encodedParams = new URLSearchParams();
 encodedParams.set('foo', 'bar');
 encodedParams.set('hello', 'world');
 
@@ -12,7 +12,10 @@ const options = {
   body: encodedParams
 };
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/application-json.js
+++ b/src/targets/node/fetch/fixtures/application-json.js
@@ -7,7 +7,10 @@ const options = {
   body: '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'
 };
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/cookies.js
+++ b/src/targets/node/fetch/fixtures/cookies.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har';
 const options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz'}};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/custom-method.js
+++ b/src/targets/node/fetch/fixtures/custom-method.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har';
 const options = {method: 'PROPFIND'};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/full.js
+++ b/src/targets/node/fetch/fixtures/full.js
@@ -1,7 +1,7 @@
 const { URLSearchParams } = require('url');
 const fetch = require('node-fetch');
-const encodedParams = new URLSearchParams();
 
+const encodedParams = new URLSearchParams();
 encodedParams.set('foo', 'bar');
 
 const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
@@ -15,7 +15,10 @@ const options = {
   body: encodedParams
 };
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/headers.js
+++ b/src/targets/node/fetch/fixtures/headers.js
@@ -6,7 +6,10 @@ const options = {
   headers: {accept: 'application/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/https.js
+++ b/src/targets/node/fetch/fixtures/https.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'https://mockbin.com/har';
 const options = {method: 'GET'};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/jsonObj-multiline.js
+++ b/src/targets/node/fetch/fixtures/jsonObj-multiline.js
@@ -7,7 +7,10 @@ const options = {
   body: '{"foo":"bar"}'
 };
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/jsonObj-null-value.js
+++ b/src/targets/node/fetch/fixtures/jsonObj-null-value.js
@@ -7,7 +7,10 @@ const options = {
   body: '{"foo":null}'
 };
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/multipart-data.js
+++ b/src/targets/node/fetch/fixtures/multipart-data.js
@@ -1,17 +1,19 @@
 const fs = require('fs');
 const FormData = require('form-data');
 const fetch = require('node-fetch');
-const formData = new FormData();
 
+const formData = new FormData();
 formData.append('foo', fs.createReadStream('hello.txt'));
 formData.append('bar', 'Bonjour le monde');
 
 const url = 'http://mockbin.com/har';
 const options = {method: 'POST'};
-
 options.body = formData;
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/multipart-file.js
+++ b/src/targets/node/fetch/fixtures/multipart-file.js
@@ -1,16 +1,18 @@
 const fs = require('fs');
 const FormData = require('form-data');
 const fetch = require('node-fetch');
-const formData = new FormData();
 
+const formData = new FormData();
 formData.append('foo', fs.createReadStream('test/fixtures/files/hello.txt'));
 
 const url = 'http://mockbin.com/har';
 const options = {method: 'POST'};
-
 options.body = formData;
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/multipart-form-data-no-params.js
+++ b/src/targets/node/fetch/fixtures/multipart-form-data-no-params.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har';
 const options = {method: 'POST', headers: {'Content-Type': 'multipart/form-data'}};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/multipart-form-data.js
+++ b/src/targets/node/fetch/fixtures/multipart-form-data.js
@@ -1,15 +1,17 @@
 const FormData = require('form-data');
 const fetch = require('node-fetch');
-const formData = new FormData();
 
+const formData = new FormData();
 formData.append('foo', 'bar');
 
 const url = 'http://mockbin.com/har';
 const options = {method: 'POST'};
-
 options.body = formData;
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/nested.js
+++ b/src/targets/node/fetch/fixtures/nested.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value';
 const options = {method: 'GET'};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/query.js
+++ b/src/targets/node/fetch/fixtures/query.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
 const options = {method: 'GET'};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/short.js
+++ b/src/targets/node/fetch/fixtures/short.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har';
 const options = {method: 'GET'};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}

--- a/src/targets/node/fetch/fixtures/text-plain.js
+++ b/src/targets/node/fetch/fixtures/text-plain.js
@@ -3,7 +3,10 @@ const fetch = require('node-fetch');
 const url = 'http://mockbin.com/har';
 const options = {method: 'POST', headers: {'content-type': 'text/plain'}, body: 'Hello World'};
 
-fetch(url, options)
-  .then(res => res.json())
-  .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));
+try {
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+} catch (error) {
+  console.error(error);
+}


### PR DESCRIPTION
closes: #209

This requires top-level-await (https://v8.dev/features/top-level-await) which was added in [Node 14.8 "unflagged"](https://www.stefanjudis.com/today-i-learned/top-level-await-is-available-in-node-js-modules/#top-level-%60await%60-is-available-%22unflagged%22-in-node.js-since-%60v14.8%60). 

This project supports a minimum of 14.18 as of the time of writing, so we're good to go to have this.