### PR TITLE
Converted to standard URL

### DIFF
--- a/src/httpsnippet.test.ts
+++ b/src/httpsnippet.test.ts
@@ -106,31 +106,27 @@ describe('hTTPSnippet', () => {
         const snippet = new HTTPSnippet(query as Request);
         const request = snippet.requests[0];
 
-        expect(request.uriObj).toMatchObject({
-          auth: null,
-          hash: null,
-          host: 'mockbin.com',
-          hostname: 'mockbin.com',
-          href: 'http://mockbin.com/har?key=value',
-          path: '/har?foo=bar&foo=baz&baz=abc&key=value',
-          pathname: '/har',
-          port: null,
-          protocol: 'http:',
-          query: {
-            baz: 'abc',
-            key: 'value',
-            foo: ['bar', 'baz'],
-          },
-          search: 'foo=bar&foo=baz&baz=abc&key=value',
-          slashes: true,
-        });
+        expect(request.uriObj.host).toBe('mockbin.com');
+        expect(request.uriObj.hostname).toBe('mockbin.com');
+        expect(request.uriObj.hash).toBe('');
+        expect(request.uriObj.href).toBe(
+          'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value',
+        );
+        expect(request.uriObj.pathname).toBe('/har');
+        expect(request.uriObj.port).toBe('');
+        expect(request.uriObj.protocol).toBe('http:');
+        expect(request.uriObj.search).toBe('?foo=bar&foo=baz&baz=abc&key=value');
+        expect(request.uriObj.searchParams.get('baz')).toBe('abc');
+        expect(request.uriObj.searchParams.get('key')).toBe('value');
+        expect(request.uriObj.searchParams.get('foo')).toBe('bar');
       });
 
       it('should fix the `path` property of uriObj to match queryString', () => {
         const snippet = new HTTPSnippet(query as Request);
         const request = snippet.requests[0];
 
-        expect(request.uriObj.path).toBe('/har?foo=bar&foo=baz&baz=abc&key=value');
+        expect(request.uriObj.pathname).toBe('/har');
+        expect(request.uriObj.search).toBe('?foo=bar&foo=baz&baz=abc&key=value');
       });
     });
 

--- a/src/targets/http/http1.1/client.ts
+++ b/src/targets/http/http1.1/client.ts
@@ -47,7 +47,11 @@ export const http11: Client<Http11Options> = {
     // RFC 7230 Section 5.3. Request Target
     // Determines if the Request-Line should use 'absolute-form' or 'origin-form'.
     // Basically it means whether the "http://domain.com" will prepend the full url.
-    const requestUrl = opts.absoluteURI ? fullUrl : uriObj.path;
+    const requestUrl = opts.absoluteURI
+      ? fullUrl
+      : uriObj.search
+      ? `${uriObj.pathname}${url.search}`
+      : uriObj.pathname;
 
     // RFC 7230 Section 3.1.1. Request-Line
     push(`${method} ${requestUrl} ${httpVersion}`);

--- a/src/targets/node/native/client.ts
+++ b/src/targets/node/native/client.ts
@@ -31,13 +31,12 @@ export const native: Client<NodeNativeOptions> = {
     const reqOpts = {
       method,
       hostname: uriObj.hostname,
-      port: uriObj.port,
-      path: uriObj.path,
+      port: uriObj.port === '' ? null : uriObj.port,
+      path: uriObj.search ? `${uriObj.pathname}${url.search}` : uriObj.pathname,
       headers: allHeaders,
       ...(insecureSkipVerify ? { rejectUnauthorized: false } : {}),
     };
 
-    // @ts-expect-error TODO seems like a legit error
     push(`const http = require('${uriObj.protocol.replace(':', '')}');`);
 
     blank();

--- a/src/targets/php/curl/client.ts
+++ b/src/targets/php/curl/client.ts
@@ -56,7 +56,7 @@ export const curl: Client<CurlOptions> = {
       {
         escape: true,
         name: 'CURLOPT_PORT',
-        value: uriObj.port,
+        value: uriObj.port === '' ? undefined : uriObj.port,
       },
       {
         escape: true,

--- a/src/targets/python/python3/client.ts
+++ b/src/targets/python/python3/client.ts
@@ -22,7 +22,12 @@ export const python3: Client<Python3Options> = {
     link: 'https://docs.python.org/3/library/http.client.html',
     description: 'Python3 HTTP Client',
   },
-  convert: ({ uriObj: { path, protocol, host }, postData, allHeaders, method }, options = {}) => {
+  convert: (
+    { uriObj: { pathname, search, protocol, host }, postData, allHeaders, method },
+    options = {},
+  ) => {
+    const path = search ? `${pathname}${search}` : pathname;
+
     const { insecureSkipVerify = false } = options;
 
     const { push, blank, join } = new CodeBuilder();

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,8 @@
     "strict": true,
     "esModuleInterop": true,
     "downlevelIteration": true,
-    "lib": ["ESNext"]
+    "lib": ["ESNext"],
+    "declaration": true
   },
   "include": ["src", "package.json"],
   "exclude": ["dist", "**/*.test.ts"]


### PR DESCRIPTION
This PR removes the node.js legacy URL apis in favor of standard ones. This means the library can be used in the browser (or in other places like Deno) without polyfills which reduces the complexity when using in apps (i.e. CRA) and reduces the file size.


Specific changes
- Removes the use of Node.js specific querystring and url API in favor or whatwg standard APIs (`URL`, `URLSearchParams`)
- Adds `declarations` to tsconfig to ship type defs with the library

