### PR TITLE
Exclude package.json from build to fix output paths

### DIFF
--- a/bin/httpsnippet
+++ b/bin/httpsnippet
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../dist/src/cli.js').go();
+require('../dist/cli.js').go();

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "prebuild": "npm run clean",
     "lint": "prettier --write . && eslint . --ext ts,d.ts,test.ts --fix",
     "build": "tsc --build tsconfig.build.json",
-    "build:cli": "tsc --build tsconfig.cli.json",
     "test": "jest"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,9 @@ import path from 'path';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 
-import packageJson from '../package.json';
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- require() to avoid package.json being included in build output.
+const packageJson = require('../package.json');
+
 import { extname, HarRequest, HTTPSnippet } from './httpsnippet';
 import { ClientId, TargetId, targets } from './targets/targets';
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "allowJs": true,
     "resolveJsonModule": true,
     "strict": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": ".",
     "allowJs": true,
     "resolveJsonModule": true,
     "strict": true,
@@ -9,6 +8,6 @@
     "downlevelIteration": true,
     "lib": ["ESNext"]
   },
-  "include": ["src", "package.json"],
+  "include": ["src"],
   "exclude": ["dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
HTTPSnippet's TS setup is currently subtly broken, and if you publish the package as it is it will be unusable. Repro:

```bash
git clone git@github.com:Kong/httpsnippet.git
cd httpsnippet
npm install
npm run build
node
> require('.')
Uncaught:
Error: Cannot find module '/tmp/tmp.Ch6arMsPtm/httpsnippet/dist/httpsnippet.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (internal/modules/cjs/loader.js:321:19)
    at Function.Module._findPath (internal/modules/cjs/loader.js:534:18)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:888:27)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18) {
  code: 'MODULE_NOT_FOUND',
  path: '/tmp/tmp.Ch6arMsPtm/httpsnippet/package.json',
  requestPath: '.'
}
```

The problem is that tsconfig.build.ts includes package.json and uses the project root as the source root, which means that the compile output looks like:

* dist/
  * package.json/
  * src/
    * httpsnippet.js

The `main` field in package.json expects `dist/httpsnippet.js` to be the package entry point, but in this structure that doesn't exist.

It would be possible to make that structure work (just change `main`) if you really want, but it's unnecessarily copying the package.json into the build output, and it's generally a bit weird, so unless there's a specific reason that's useful I don't think it's a good idea.

AFAIK there's two possible solutions: you can exclude `package.json` from your build entirely, and treat it as an external resource, or you can create a composite TS project, with a separate tsconfig for `src` and for just `package.json`. I've done the former here, because it's much much simpler and package.json is barely used in the codebase here. I'd suggest starting with that regardless, but if you want the latter there's detailed instructions here: https://stackoverflow.com/a/61467483/68051.