### PR TITLE
Fix crash when building nsurlsession snippets for empty params

### DIFF
--- a/src/targets/objc/nsurlsession/client.ts
+++ b/src/targets/objc/nsurlsession/client.ts
@@ -53,7 +53,7 @@ export const nsurlsession: Client<NsurlsessionOptions> = {
 
       switch (postData.mimeType) {
         case 'application/x-www-form-urlencoded':
-          if (postData.params) {
+          if (postData.params?.length) {
             // By appending parameters one by one in the resulting snippet,
             // we make it easier for the user to edit it according to his or her needs after pasting.
             // The user can just add/remove lines adding/removing body parameters.

--- a/src/targets/swift/nsurlsession/client.ts
+++ b/src/targets/swift/nsurlsession/client.ts
@@ -58,7 +58,7 @@ export const nsurlsession: Client<NsurlsessionOptions> = {
           // we make it easier for the user to edit it according to his or her needs after pasting.
           // The user can just add/remove lines adding/removing body parameters.
           blank();
-          if (postData.params) {
+          if (postData.params?.length) {
             const [head, ...tail] = postData.params;
             push(
               `let postData = NSMutableData(data: "${head.name}=${head.value}".data(using: String.Encoding.utf8)!)`,


### PR DESCRIPTION
Fixes #161

As discussed there: this is usually a sign of a bad HTTP request, but the HAR is perfectly valid - it's correct and not that unusual to have an empty list of params if you have a form data request/response that doesn't actually contain any data, or which contained unparseable data.

TypeScript can't guard against this unfortunately, because while it does check that the list is defined, it can't check that you're not going to read past the end of the list, and if the list has zero items then the `head` here is doing exactly that.

I think there might be more general solutions to this in the `HTTPSnippet.prepare()` function, e.g. we could remove `.params` entirely if it's empty, but that's more likely to run into side effects and unexpected output changes, while this is a simple quick fix. It would probably be good in that case to define what should happen instead, e.g. do we fall back to using the text data, to properly handle the case where a HAR contains a request that sends invalid form data. A problem for later imo, best to just stop this crashing entirely first.