### PR TITLE
removes `require 'openssl'` from ruby target (no longer needed)

### DIFF
--- a/src/targets/ruby/native/client.ts
+++ b/src/targets/ruby/native/client.ts
@@ -19,11 +19,6 @@ export const native: Client<RubyNativeOptions> = {
 
     push("require 'uri'");
     push("require 'net/http'");
-
-    if (uriObj.protocol === 'https:') {
-      push("require 'openssl'");
-    }
-
     blank();
 
     // To support custom methods we check for the supported methods

--- a/src/targets/ruby/native/fixtures/https.rb
+++ b/src/targets/ruby/native/fixtures/https.rb
@@ -1,6 +1,5 @@
 require 'uri'
 require 'net/http'
-require 'openssl'
 
 url = URI("https://mockbin.com/har")
 

--- a/src/targets/ruby/native/fixtures/insecure-skip-verify.rb
+++ b/src/targets/ruby/native/fixtures/insecure-skip-verify.rb
@@ -1,6 +1,5 @@
 require 'uri'
 require 'net/http'
-require 'openssl'
 
 url = URI("https://mockbin.com/har")
 


### PR DESCRIPTION
according to https://github.com/Kong/httpsnippet/issues/76#issuecomment-1006619671 we can now remove this line as of ruby 2.6