### PR TITLE
Go client: deprecated package ioutil -> io

### DIFF
--- a/src/targets/go/native/client.ts
+++ b/src/targets/go/native/client.ts
@@ -72,7 +72,7 @@ export const native: Client<GoNativeOptions> = {
       push('"net/http"', indent);
 
       if (printBody) {
-        push('"io/ioutil"', indent);
+        push('"io"', indent);
       }
 
       push(')');
@@ -140,7 +140,7 @@ export const native: Client<GoNativeOptions> = {
     if (printBody) {
       blank();
       push('defer res.Body.Close()', indent);
-      push(`body, ${errorPlaceholder} := ioutil.ReadAll(res.Body)`, indent);
+      push(`body, ${errorPlaceholder} := io.ReadAll(res.Body)`, indent);
       errorCheck();
     }
 

--- a/src/targets/go/native/fixtures/application-form-encoded.go
+++ b/src/targets/go/native/fixtures/application-form-encoded.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/application-json.go
+++ b/src/targets/go/native/fixtures/application-json.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/boilerplate-option.go
+++ b/src/targets/go/native/fixtures/boilerplate-option.go
@@ -11,7 +11,7 @@ req.Header.Add("content-type", "application/x-www-form-urlencoded")
 res, _ := http.DefaultClient.Do(req)
 
 defer res.Body.Close()
-body, _ := ioutil.ReadAll(res.Body)
+body, _ := io.ReadAll(res.Body)
 
 fmt.Println(res)
 fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/check-errors-option.go
+++ b/src/targets/go/native/fixtures/check-errors-option.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/src/targets/go/native/fixtures/cookies.go
+++ b/src/targets/go/native/fixtures/cookies.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -17,7 +17,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/custom-method.go
+++ b/src/targets/go/native/fixtures/custom-method.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -15,7 +15,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/full.go
+++ b/src/targets/go/native/fixtures/full.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -22,7 +22,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/headers.go
+++ b/src/targets/go/native/fixtures/headers.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -19,7 +19,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/https.go
+++ b/src/targets/go/native/fixtures/https.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -15,7 +15,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/insecure-skip-verify.go
+++ b/src/targets/go/native/fixtures/insecure-skip-verify.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -29,7 +29,7 @@ func main() {
 	res, _ := client.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/jsonObj-multiline.go
+++ b/src/targets/go/native/fixtures/jsonObj-multiline.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/jsonObj-null-value.go
+++ b/src/targets/go/native/fixtures/jsonObj-null-value.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/multipart-data.go
+++ b/src/targets/go/native/fixtures/multipart-data.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/multipart-file.go
+++ b/src/targets/go/native/fixtures/multipart-file.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/multipart-form-data-no-params.go
+++ b/src/targets/go/native/fixtures/multipart-form-data-no-params.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -17,7 +17,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/multipart-form-data.go
+++ b/src/targets/go/native/fixtures/multipart-form-data.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/nested.go
+++ b/src/targets/go/native/fixtures/nested.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -15,7 +15,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/query.go
+++ b/src/targets/go/native/fixtures/query.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -15,7 +15,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/short.go
+++ b/src/targets/go/native/fixtures/short.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -15,7 +15,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/text-plain.go
+++ b/src/targets/go/native/fixtures/text-plain.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 	res, _ := http.DefaultClient.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))

--- a/src/targets/go/native/fixtures/timeout-option.go
+++ b/src/targets/go/native/fixtures/timeout-option.go
@@ -5,7 +5,7 @@ import (
 	"time"
 	"strings"
 	"net/http"
-	"io/ioutil"
+	"io"
 )
 
 func main() {
@@ -27,7 +27,7 @@ func main() {
 	res, _ := client.Do(req)
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	fmt.Println(res)
 	fmt.Println(string(body))


### PR DESCRIPTION
The package `io/ioutil` is deprecated since version 1.16 in Go.
Generating code based on that version ensures broader backwards compatibility but results in a warning for more recent versions of the language.

A quick Google search

Release | Released | Supported
-- | -- | --
1.19 | 02 Aug 2022 | Yes
1.18 | 15 Mar 2022 | Yes
1.17 | 16 Aug 2021 | No (since 02 Aug 2022)
1.16 | 16 Feb 2021 | No

Although I think backwards compatibility is a desired feature, generating new code that results in a warning to be backwards compatible with a version that has no support anymore seems not in the spirit of the language.

This PR is pretty much just a search + replace (see following list) since the functions moved to the `io` package.

* `io/ioutil` -> `io`
* `ioutil.ReadAll` -> `io.ReadAll`