### PR TITLE
Make axios client output compatible with axios v1

### DIFF
--- a/src/targets/node/axios/client.ts
+++ b/src/targets/node/axios/client.ts
@@ -27,7 +27,7 @@ export const axios: Client = {
     };
     const { blank, join, push, addPostProcessor } = new CodeBuilder({ indent: opts.indent });
 
-    push("const axios = require('axios').default;");
+    push("const axios = require('axios');");
 
     const reqOpts: Record<string, any> = {
       method,

--- a/src/targets/node/axios/fixtures/application-form-encoded.js
+++ b/src/targets/node/axios/fixtures/application-form-encoded.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 const { URLSearchParams } = require('url');
 
 const encodedParams = new URLSearchParams();

--- a/src/targets/node/axios/fixtures/application-json.js
+++ b/src/targets/node/axios/fixtures/application-json.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/cookies.js
+++ b/src/targets/node/axios/fixtures/cookies.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/custom-method.js
+++ b/src/targets/node/axios/fixtures/custom-method.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {method: 'PROPFIND', url: 'http://mockbin.com/har'};
 

--- a/src/targets/node/axios/fixtures/full.js
+++ b/src/targets/node/axios/fixtures/full.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 const { URLSearchParams } = require('url');
 
 const encodedParams = new URLSearchParams();

--- a/src/targets/node/axios/fixtures/headers.js
+++ b/src/targets/node/axios/fixtures/headers.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'GET',

--- a/src/targets/node/axios/fixtures/https.js
+++ b/src/targets/node/axios/fixtures/https.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {method: 'GET', url: 'https://mockbin.com/har'};
 

--- a/src/targets/node/axios/fixtures/jsonObj-multiline.js
+++ b/src/targets/node/axios/fixtures/jsonObj-multiline.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/jsonObj-null-value.js
+++ b/src/targets/node/axios/fixtures/jsonObj-null-value.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/multipart-data.js
+++ b/src/targets/node/axios/fixtures/multipart-data.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/multipart-file.js
+++ b/src/targets/node/axios/fixtures/multipart-file.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/multipart-form-data-no-params.js
+++ b/src/targets/node/axios/fixtures/multipart-form-data-no-params.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/multipart-form-data.js
+++ b/src/targets/node/axios/fixtures/multipart-form-data.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',

--- a/src/targets/node/axios/fixtures/nested.js
+++ b/src/targets/node/axios/fixtures/nested.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'GET',

--- a/src/targets/node/axios/fixtures/query.js
+++ b/src/targets/node/axios/fixtures/query.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'GET',

--- a/src/targets/node/axios/fixtures/short.js
+++ b/src/targets/node/axios/fixtures/short.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {method: 'GET', url: 'http://mockbin.com/har'};
 

--- a/src/targets/node/axios/fixtures/text-plain.js
+++ b/src/targets/node/axios/fixtures/text-plain.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 
 const options = {
   method: 'POST',


### PR DESCRIPTION
axios has recently [released v1](https://github.com/axios/axios/releases/tag/v1.0.0). Their documentation now states:
> If you use require for importing, only default export is available
> `const axios = require('axios');`

HTTPSnippet generates code samples with `var axios = require("axios").default;`. This is compatible with axios v0, but not v1.

`var axios = require("axios");` is compatible with both axios v0 and v1.

Steps to reproduce:
1. Create an empty project `npm init -y`
2. Install axios v0 `npm i axios@0`
3. Generate a code sample with HTTPSnippet

<details>
<summary>Example</summary>
  
```
import HTTPSnippet from 'httpsnippet';

const snippet = new HTTPSnippet({
  method: 'GET',
  url: 'http://mockbin.com/request',
});

const options = { indent: '\t' };
const output = snippet.convert('node', 'axios', options);
console.log(output);
```
</details>


5. Copy the output into a new file

<details>
<summary>Example</summary>

```
var axios = require("axios").default;

var options = {method: 'GET', url: 'http://mockbin.com/request'};

axios.request(options).then(function (response) {
        console.log(response.data);
}).catch(function (error) {
        console.error(error);
});
```
</details>

5. Run sample `node ./sample.js` - Note success
6. Install axios v1 `npm i axios@1`
7. Run sample `node ./sample.js` - Note failure with
> axios.request(options).then(function (response) {
>TypeError: Cannot read properties of undefined (reading 'request')
8. Change `require("axios").default` to `require("axios")`
9. Run sample `node ./sample.js` - Note success
10. Revert back to axios v0 `npm i axios@0`
11. Run sample `node ./sample.js` - Note success