### PR TITLE
Put argument for --output-document on the same line

### DIFF
--- a/src/targets/shell/wget/client.ts
+++ b/src/targets/shell/wget/client.ts
@@ -55,8 +55,8 @@ export const wget: Client<WgetOptions> = {
       push(`--body-data ${escape(quote(postData.text))}`);
     }
 
-    push(opts.short ? '-O' : '--output-document');
-    push(`- ${quote(fullUrl)}`);
+    push((opts.short ? '-O' : '--output-document') + ' -');
+    push(quote(fullUrl));
 
     return join();
   },


### PR DESCRIPTION
`--output-document -` tells Wget to print the output instead of saving it to a file, i.e. so that it acts like curl. It doesn't make sense to put the `-` on the same line as the URL.