### PR TITLE
Update http snippets for restsharp 107+

### DIFF
--- a/src/targets/csharp/restsharp/client.ts
+++ b/src/targets/csharp/restsharp/client.ts
@@ -3,6 +3,10 @@ import { escapeForDoubleQuotes } from '../../../helpers/escape';
 import { getHeader } from '../../../helpers/headers';
 import { Client } from '../../targets';
 
+function title(s: string): string {
+  return s[0].toUpperCase() + s.slice(1).toLowerCase();
+}
+
 export const restsharp: Client = {
   info: {
     key: 'restsharp',
@@ -10,7 +14,7 @@ export const restsharp: Client = {
     link: 'http://restsharp.org/',
     description: 'Simple REST and HTTP API Client for .NET',
   },
-  convert: ({ allHeaders, method, fullUrl, headersObj, cookies, postData }) => {
+  convert: ({ allHeaders, method, fullUrl, headersObj, cookies, postData, uriObj }) => {
     const { push, join } = new CodeBuilder();
     const isSupportedMethod = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].includes(
       method.toUpperCase(),
@@ -20,26 +24,32 @@ export const restsharp: Client = {
       return 'Method not supported';
     }
 
-    push(`var client = new RestClient("${fullUrl}");`);
-    push(`var request = new RestRequest(Method.${method.toUpperCase()});`);
+    push(`var options = new RestClientOptions("${fullUrl}");`);
+    push(`var client = new RestClient(options);`);
+
+    // The first argument is the sub-path to the base URL, given as the
+    // constructor to RestClient; for our purposes we're just giving the entire
+    // URL as the base path so it can be an empty string
+    push(`var request = new RestRequest("");`);
 
     // Add headers, including the cookies
-
     Object.keys(headersObj).forEach(key => {
       push(`request.AddHeader("${key}", "${escapeForDoubleQuotes(headersObj[key])}");`);
     });
 
     cookies.forEach(({ name, value }) => {
-      push(`request.AddCookie("${name}", "${value}");`);
+      push(`request.AddCookie("${name}", "${value}", "${uriObj.pathname}", "${uriObj.host}");`);
     });
 
+    // here we're just assuming that the text is a JSON post, and that content
+    // type is application/json. Improvements welcome to support multipart or
+    // form-urlencoded
     if (postData.text) {
-      const header = getHeader(allHeaders, 'content-type');
       const text = JSON.stringify(postData.text);
-      push(`request.AddParameter("${header}", ${text}, ParameterType.RequestBody);`);
+      push(`request.AddJsonBody(${text}, false);`);
     }
 
-    push('IRestResponse response = client.Execute(request);');
+    push(`var response = await client.${title(method)}Async(request);`);
     return join();
   },
 };

--- a/src/targets/csharp/restsharp/client.ts
+++ b/src/targets/csharp/restsharp/client.ts
@@ -1,6 +1,5 @@
 import { CodeBuilder } from '../../../helpers/code-builder';
 import { escapeForDoubleQuotes } from '../../../helpers/escape';
-import { getHeader } from '../../../helpers/headers';
 import { Client } from '../../targets';
 
 function title(s: string): string {
@@ -14,7 +13,7 @@ export const restsharp: Client = {
     link: 'http://restsharp.org/',
     description: 'Simple REST and HTTP API Client for .NET',
   },
-  convert: ({ allHeaders, method, fullUrl, headersObj, cookies, postData, uriObj }) => {
+  convert: ({ method, fullUrl, headersObj, cookies, postData, uriObj }) => {
     const { push, join } = new CodeBuilder();
     const isSupportedMethod = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].includes(
       method.toUpperCase(),

--- a/src/targets/csharp/restsharp/fixtures/application-form-encoded.cs
+++ b/src/targets/csharp/restsharp/fixtures/application-form-encoded.cs
@@ -1,6 +1,6 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "application/x-www-form-urlencoded");
-request.AddJsonBody("foo=bar&hello=world", false);
-var response = await client.PostAsync(request);
+request.AddParameter("foo", "bar");
+request.AddParameter("hello", "world");
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/application-form-encoded.cs
+++ b/src/targets/csharp/restsharp/fixtures/application-form-encoded.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("content-type", "application/x-www-form-urlencoded");
-request.AddParameter("application/x-www-form-urlencoded", "foo=bar&hello=world", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("foo=bar&hello=world", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/application-json.cs
+++ b/src/targets/csharp/restsharp/fixtures/application-json.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("content-type", "application/json");
-request.AddParameter("application/json", "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/application-json.cs
+++ b/src/targets/csharp/restsharp/fixtures/application-json.cs
@@ -1,6 +1,5 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "application/json");
 request.AddJsonBody("{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}", false);
-var response = await client.PostAsync(request);
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/cookies.cs
+++ b/src/targets/csharp/restsharp/fixtures/cookies.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
-request.AddCookie("foo", "bar");
-request.AddCookie("bar", "baz");
-IRestResponse response = client.Execute(request);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
+request.AddCookie("foo", "bar", "/har", "mockbin.com");
+request.AddCookie("bar", "baz", "/har", "mockbin.com");
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/cookies.cs
+++ b/src/targets/csharp/restsharp/fixtures/cookies.cs
@@ -3,4 +3,4 @@ var client = new RestClient(options);
 var request = new RestRequest("");
 request.AddCookie("foo", "bar", "/har", "mockbin.com");
 request.AddCookie("bar", "baz", "/har", "mockbin.com");
-var response = await client.PostAsync(request);
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/full.cs
+++ b/src/targets/csharp/restsharp/fixtures/full.cs
@@ -1,8 +1,9 @@
-var client = new RestClient("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("accept", "application/json");
 request.AddHeader("content-type", "application/x-www-form-urlencoded");
-request.AddCookie("foo", "bar");
-request.AddCookie("bar", "baz");
-request.AddParameter("application/x-www-form-urlencoded", "foo=bar", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddCookie("foo", "bar", "/har", "mockbin.com");
+request.AddCookie("bar", "baz", "/har", "mockbin.com");
+request.AddJsonBody("foo=bar", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/full.cs
+++ b/src/targets/csharp/restsharp/fixtures/full.cs
@@ -2,8 +2,7 @@ var options = new RestClientOptions("http://mockbin.com/har?foo=bar&foo=baz&baz=
 var client = new RestClient(options);
 var request = new RestRequest("");
 request.AddHeader("accept", "application/json");
-request.AddHeader("content-type", "application/x-www-form-urlencoded");
 request.AddCookie("foo", "bar", "/har", "mockbin.com");
 request.AddCookie("bar", "baz", "/har", "mockbin.com");
-request.AddJsonBody("foo=bar", false);
-var response = await client.PostAsync(request);
+request.AddParameter("foo", "bar");
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/headers.cs
+++ b/src/targets/csharp/restsharp/fixtures/headers.cs
@@ -4,4 +4,4 @@ var request = new RestRequest("");
 request.AddHeader("accept", "application/json");
 request.AddHeader("x-foo", "Bar");
 request.AddHeader("quoted-value", "\"quoted\" 'string'");
-var response = await client.GetAsync(request);
+var response = await client.GetAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/headers.cs
+++ b/src/targets/csharp/restsharp/fixtures/headers.cs
@@ -1,6 +1,7 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.GET);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("accept", "application/json");
 request.AddHeader("x-foo", "Bar");
 request.AddHeader("quoted-value", "\"quoted\" 'string'");
-IRestResponse response = client.Execute(request);
+var response = await client.GetAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/https.cs
+++ b/src/targets/csharp/restsharp/fixtures/https.cs
@@ -1,3 +1,4 @@
-var client = new RestClient("https://mockbin.com/har");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var options = new RestClientOptions("https://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
+var response = await client.GetAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/https.cs
+++ b/src/targets/csharp/restsharp/fixtures/https.cs
@@ -1,4 +1,4 @@
 var options = new RestClientOptions("https://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-var response = await client.GetAsync(request);
+var response = await client.GetAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/jsonObj-multiline.cs
+++ b/src/targets/csharp/restsharp/fixtures/jsonObj-multiline.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("content-type", "application/json");
-request.AddParameter("application/json", "{\n  \"foo\": \"bar\"\n}", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("{\n  \"foo\": \"bar\"\n}", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/jsonObj-multiline.cs
+++ b/src/targets/csharp/restsharp/fixtures/jsonObj-multiline.cs
@@ -1,6 +1,5 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "application/json");
 request.AddJsonBody("{\n  \"foo\": \"bar\"\n}", false);
-var response = await client.PostAsync(request);
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/jsonObj-null-value.cs
+++ b/src/targets/csharp/restsharp/fixtures/jsonObj-null-value.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("content-type", "application/json");
-request.AddParameter("application/json", "{\"foo\":null}", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("{\"foo\":null}", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/jsonObj-null-value.cs
+++ b/src/targets/csharp/restsharp/fixtures/jsonObj-null-value.cs
@@ -1,6 +1,5 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "application/json");
 request.AddJsonBody("{\"foo\":null}", false);
-var response = await client.PostAsync(request);
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/multipart-data.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-data.cs
@@ -1,6 +1,8 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001");
-request.AddJsonBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"bar\"\r\n\r\nBonjour le monde\r\n-----011000010111000001101001--\r\n", false);
-var response = await client.PostAsync(request);
+request.AlwaysMultipartFormData = true;
+request.FormBoundary = "---011000010111000001101001";
+request.AddFile("foo", "hello.txt");
+request.AddParameter("bar", "Bonjour le monde");
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/multipart-data.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-data.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001");
-request.AddParameter("multipart/form-data; boundary=---011000010111000001101001", "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"bar\"\r\n\r\nBonjour le monde\r\n-----011000010111000001101001--\r\n", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"bar\"\r\n\r\nBonjour le monde\r\n-----011000010111000001101001--\r\n", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-file.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-file.cs
@@ -1,6 +1,7 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001");
-request.AddJsonBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n", false);
-var response = await client.PostAsync(request);
+request.AlwaysMultipartFormData = true;
+request.FormBoundary = "---011000010111000001101001";
+request.AddFile("foo", "test/fixtures/files/hello.txt");
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/multipart-file.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-file.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001");
-request.AddParameter("multipart/form-data; boundary=---011000010111000001101001", "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-form-data-no-params.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-form-data-no-params.cs
@@ -1,5 +1,5 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("Content-Type", "multipart/form-data");
-var response = await client.PostAsync(request);
+request.AlwaysMultipartFormData = true;
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/multipart-form-data-no-params.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-form-data-no-params.cs
@@ -1,4 +1,5 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("Content-Type", "multipart/form-data");
-IRestResponse response = client.Execute(request);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-form-data.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-form-data.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("Content-Type", "multipart/form-data; boundary=---011000010111000001101001");
-request.AddParameter("multipart/form-data; boundary=---011000010111000001101001", "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n", false);
+var response = await client.PostAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-form-data.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-form-data.cs
@@ -1,6 +1,7 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("Content-Type", "multipart/form-data; boundary=---011000010111000001101001");
-request.AddJsonBody("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n", false);
-var response = await client.PostAsync(request);
+request.AlwaysMultipartFormData = true;
+request.FormBoundary = "---011000010111000001101001";
+request.AddParameter("foo", "bar");
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/nested.cs
+++ b/src/targets/csharp/restsharp/fixtures/nested.cs
@@ -1,3 +1,4 @@
-var client = new RestClient("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var options = new RestClientOptions("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value");
+var client = new RestClient(options);
+var request = new RestRequest("");
+var response = await client.GetAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/nested.cs
+++ b/src/targets/csharp/restsharp/fixtures/nested.cs
@@ -1,4 +1,4 @@
 var options = new RestClientOptions("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value");
 var client = new RestClient(options);
 var request = new RestRequest("");
-var response = await client.GetAsync(request);
+var response = await client.GetAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/query.cs
+++ b/src/targets/csharp/restsharp/fixtures/query.cs
@@ -1,3 +1,4 @@
-var client = new RestClient("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var options = new RestClientOptions("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value");
+var client = new RestClient(options);
+var request = new RestRequest("");
+var response = await client.GetAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/query.cs
+++ b/src/targets/csharp/restsharp/fixtures/query.cs
@@ -1,4 +1,4 @@
 var options = new RestClientOptions("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value");
 var client = new RestClient(options);
 var request = new RestRequest("");
-var response = await client.GetAsync(request);
+var response = await client.GetAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/short.cs
+++ b/src/targets/csharp/restsharp/fixtures/short.cs
@@ -1,4 +1,4 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-var response = await client.GetAsync(request);
+var response = await client.GetAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/short.cs
+++ b/src/targets/csharp/restsharp/fixtures/short.cs
@@ -1,3 +1,4 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
+var response = await client.GetAsync(request);

--- a/src/targets/csharp/restsharp/fixtures/text-plain.cs
+++ b/src/targets/csharp/restsharp/fixtures/text-plain.cs
@@ -1,6 +1,5 @@
 var options = new RestClientOptions("http://mockbin.com/har");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "text/plain");
-request.AddJsonBody("Hello World", false);
-var response = await client.PostAsync(request);
+request.AddStringBody("Hello World", "text/plain");
+var response = await client.PostAsync(request); 

--- a/src/targets/csharp/restsharp/fixtures/text-plain.cs
+++ b/src/targets/csharp/restsharp/fixtures/text-plain.cs
@@ -1,5 +1,6 @@
-var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var options = new RestClientOptions("http://mockbin.com/har");
+var client = new RestClient(options);
+var request = new RestRequest("");
 request.AddHeader("content-type", "text/plain");
-request.AddParameter("text/plain", "Hello World", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+request.AddJsonBody("Hello World", false);
+var response = await client.PostAsync(request);


### PR DESCRIPTION
a whack at fixing #312

To test this, I:
- generated all new fixtures with `OVERWRITE_EVERYTHING=true npm run test`
- generated a C# hello world project with `dotnet new console -o HelloWorld -f net7.0`
- installed RestSharp into it with `dotnet add package RestSharp`]
- ran this script and looked for significant differences between csharp and bash:

```bash
#!/usr/bin/env bash
set -euxo pipefail
file=Program.cs
mkdir -p fixtures
# for the multipart tests
printf "hello" > hello.txt
for fixture in ~/readme/kong-httpsnippet/src/targets/csharp/restsharp/fixtures/*; do
    rm -f $file

    # the custom method isn't supported
    if [[ $fixture == *custom-method* ]]; then continue; fi

    printf "using RestSharp;\n\n" > $file
    sed 's,test/fixtures/files/hello.txt,hello.txt,' "$fixture" >> $file
    printf 'Console.WriteLine("{0}", response.Content);' >> $file

    dotnet run $file > "fixtures/$(basename "$fixture".out)"
done
#
# now run the bash fixtures for comparison
for fixture in ~/readme/kong-httpsnippet/src/targets/shell/curl/fixtures/*; do
    # the curl for custom-indentation does not work properly, so we need to add
    # || true
    sed 's,test/fixtures/files/hello.txt,hello.txt,' "$fixture" |
        bash > "fixtures/$(basename "$fixture".out)" || true
done

# then, compare the outputs
for fixture in ~/readme/kong-httpsnippet/kong-httpsnippet/src/targets/http/http1.1/fixtures/*; do
    base=$(basename "$fixture")
    cs="fixtures/$base.cs.out"
    sh="fixtures/$base.sh.out"

    if [[ ! -e $cs ]]; then printf "Unable to find fixture %s\n" "$cs"; continue; fi
    if [[ ! -e $cs ]]; then printf "Unable to find fixture %s\n" "$sh"; continue; fi

    git diff "fixtures/$base.cs.out" "fixtures/$base.sh.out" || true
done
```