### PR TITLE
Fix setting default value of request.PostData of HarEntry

### DIFF
--- a/src/httpsnippet.ts
+++ b/src/httpsnippet.ts
@@ -164,7 +164,7 @@ export class HTTPSnippet {
       request.allHeaders.cookie = cookies.join('; ');
     }
 
-    switch (request.postData.mimeType) {
+    switch (request?.postData.mimeType) {
       case 'multipart/mixed':
       case 'multipart/related':
       case 'multipart/form-data':

--- a/src/httpsnippet.ts
+++ b/src/httpsnippet.ts
@@ -100,10 +100,10 @@ export class HTTPSnippet {
         cookies: [],
         httpVersion: 'HTTP/1.1',
         queryString: [],
-        postData: {
+        ...request,
+        postData: request?.postData || {
           mimeType: request.postData?.mimeType || 'application/octet-stream',
         },
-        ...request,
       };
 
       if (validateHarRequest(req)) {


### PR DESCRIPTION
since har entry is of type [[src](https://github.com/Kong/httpsnippet/blob/master/src/httpsnippet.ts#L36-L54)] 
```
interface Entry {
  request: Partial<HarRequest>;
}
```

so `request.postData` could have the value `undefined`

The [current approach](https://github.com/Kong/httpsnippet/blob/master/src/httpsnippet.ts#L103-L107) of setting the default value for this key will fail when `postData` is `undefined`

This then breaks the [switch case inside the prepare method](https://github.com/Kong/httpsnippet/blob/master/src/httpsnippet.ts#L167) because there is no optional chaining

This PR is broken into two commits. If only either one feels sufficient, the changes can be cherry-picked or both can be squashed.