### PR TITLE
Fix TypeError by making postData field optional in HarRequest type

### DIFF
--- a/src/httpsnippet.ts
+++ b/src/httpsnippet.ts
@@ -31,7 +31,7 @@ type PostDataBase = PostDataCommon & {
   params?: Param[];
 };
 
-export type HarRequest = Omit<NpmHarRequest, 'postData'> & { postData: PostDataBase };
+export type HarRequest = Omit<NpmHarRequest, 'postData'> & { postData?: PostDataBase };
 
 export interface RequestExtras {
   postData: PostDataBase & {


### PR DESCRIPTION
## Related Issue

The change is addressing the TypeScript error occurred when an object of type `{ method: any; url: any; headers: any; }` is assigned to a parameter of type `HarRequest | HarEntry`. The error happens because the `postData` field is required in the `HarRequest` type but it does not exist in the given object. By making `postData` field optional, we can avoid the error and allow the assignment to proceed when `postData` field is not present.