### PR TITLE
Support Node v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18]
+        node-version: [16, 18, 20]
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "xmlhttprequest"
   ],
   "engines": {
-    "node": "^14.19.1 || ^16.14.2 || ^18.0.0"
+    "node": "^14.19.1 || ^16.14.2 || ^18.0.0 || ^20.0.0"
   },
   "repository": "Kong/httpsnippet",
   "bugs": {


### PR DESCRIPTION
Node v20.10.0 is the latest LTS, many projected that use this as dependency is blocked by the limitation of the node engine to v18 and below.

In this PR I'm adding the needed support for node v20 as it is supported out of the box.