### PR TITLE
fix(CI): add pat for triggering releases [no-ticket]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           git tag ${{ env.TAG }}
           git push origin ${{ env.TAG }}
-        
+
       - name: Create Tag and Release
         uses: ncipollo/release-action@v1
         id: core_tag_and_release
@@ -40,4 +40,4 @@ jobs:
           prerelease: false
           draft: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_INSOMNIA_INFRA }}


### PR DESCRIPTION
adds a release PAT secret to trigger the SAST workflow from this one https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow