### PR TITLE
chore: fix latest tag on npmjs [no-ticket]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,6 @@ jobs:
         run: npm run build
 
       - name: Publish to NPM
-        run: npm publish --no-git-checks --provenance --tag ${{ github.sha }}
+        run: npm publish --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
npmjs is acting weird - `3.0.1` shows up as latest

not sure if removing the `--tag` will wreck the provenance part @saisatishkarra 

![image](https://github.com/user-attachments/assets/073b8e7e-786a-4f9d-af76-b3ba4da6339f)
