### PR TITLE
correct RestSharp snippets (return type and Method enum)

### DIFF
--- a/src/targets/csharp/restsharp/client.ts
+++ b/src/targets/csharp/restsharp/client.ts
@@ -20,8 +20,15 @@ export const restsharp: Client = {
       return 'Method not supported';
     }
 
+    function toPascalCase(str: string): string {
+      return str.replace(
+        /\w+/g,
+        word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+      );
+    }
+
     push(`var client = new RestClient("${fullUrl}");`);
-    push(`var request = new RestRequest(Method.${method.toUpperCase()});`);
+    push(`var request = new RestRequest("", Method.${toPascalCase(method)});`);
 
     // Add headers, including the cookies
 
@@ -39,7 +46,7 @@ export const restsharp: Client = {
       push(`request.AddParameter("${header}", ${text}, ParameterType.RequestBody);`);
     }
 
-    push('IRestResponse response = client.Execute(request);');
+    push('var response = client.Execute(request);');
     return join();
   },
 };

--- a/src/targets/csharp/restsharp/fixtures/application-form-encoded.cs
+++ b/src/targets/csharp/restsharp/fixtures/application-form-encoded.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("content-type", "application/x-www-form-urlencoded");
 request.AddParameter("application/x-www-form-urlencoded", "foo=bar&hello=world", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/application-json.cs
+++ b/src/targets/csharp/restsharp/fixtures/application-json.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("content-type", "application/json");
 request.AddParameter("application/json", "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/cookies.cs
+++ b/src/targets/csharp/restsharp/fixtures/cookies.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddCookie("foo", "bar");
 request.AddCookie("bar", "baz");
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/full.cs
+++ b/src/targets/csharp/restsharp/fixtures/full.cs
@@ -1,8 +1,8 @@
 var client = new RestClient("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("accept", "application/json");
 request.AddHeader("content-type", "application/x-www-form-urlencoded");
 request.AddCookie("foo", "bar");
 request.AddCookie("bar", "baz");
 request.AddParameter("application/x-www-form-urlencoded", "foo=bar", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/headers.cs
+++ b/src/targets/csharp/restsharp/fixtures/headers.cs
@@ -1,6 +1,6 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.GET);
+var request = new RestRequest("", Method.Get);
 request.AddHeader("accept", "application/json");
 request.AddHeader("x-foo", "Bar");
 request.AddHeader("quoted-value", "\"quoted\" 'string'");
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/https.cs
+++ b/src/targets/csharp/restsharp/fixtures/https.cs
@@ -1,3 +1,3 @@
 var client = new RestClient("https://mockbin.com/har");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var request = new RestRequest("", Method.Get);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/jsonObj-multiline.cs
+++ b/src/targets/csharp/restsharp/fixtures/jsonObj-multiline.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("content-type", "application/json");
 request.AddParameter("application/json", "{\n  \"foo\": \"bar\"\n}", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/jsonObj-null-value.cs
+++ b/src/targets/csharp/restsharp/fixtures/jsonObj-null-value.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("content-type", "application/json");
 request.AddParameter("application/json", "{\"foo\":null}", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-data.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-data.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001");
 request.AddParameter("multipart/form-data; boundary=---011000010111000001101001", "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"bar\"\r\n\r\nBonjour le monde\r\n-----011000010111000001101001--\r\n", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-file.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-file.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("content-type", "multipart/form-data; boundary=---011000010111000001101001");
 request.AddParameter("multipart/form-data; boundary=---011000010111000001101001", "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-form-data-no-params.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-form-data-no-params.cs
@@ -1,4 +1,4 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("Content-Type", "multipart/form-data");
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/multipart-form-data.cs
+++ b/src/targets/csharp/restsharp/fixtures/multipart-form-data.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("Content-Type", "multipart/form-data; boundary=---011000010111000001101001");
 request.AddParameter("multipart/form-data; boundary=---011000010111000001101001", "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/nested.cs
+++ b/src/targets/csharp/restsharp/fixtures/nested.cs
@@ -1,3 +1,3 @@
 var client = new RestClient("http://mockbin.com/har?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var request = new RestRequest("", Method.Get);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/query.cs
+++ b/src/targets/csharp/restsharp/fixtures/query.cs
@@ -1,3 +1,3 @@
 var client = new RestClient("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var request = new RestRequest("", Method.Get);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/short.cs
+++ b/src/targets/csharp/restsharp/fixtures/short.cs
@@ -1,3 +1,3 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.GET);
-IRestResponse response = client.Execute(request);
+var request = new RestRequest("", Method.Get);
+var response = client.Execute(request);

--- a/src/targets/csharp/restsharp/fixtures/text-plain.cs
+++ b/src/targets/csharp/restsharp/fixtures/text-plain.cs
@@ -1,5 +1,5 @@
 var client = new RestClient("http://mockbin.com/har");
-var request = new RestRequest(Method.POST);
+var request = new RestRequest("", Method.Post);
 request.AddHeader("content-type", "text/plain");
 request.AddParameter("text/plain", "Hello World", ParameterType.RequestBody);
-IRestResponse response = client.Execute(request);
+var response = client.Execute(request);


### PR DESCRIPTION
Ensure that code snippets use enum members that are pascal cased and not upper cased. For example use `Method.Get` instead of `Method.GET` to ensure the snippets can compile.

Also removes usage of unknown type `IRestResponse`

fixes #365 #367 #312