### PR TITLE
fix(form-data): fix ssr error due to window object access

### DIFF
--- a/src/httpsnippet.ts
+++ b/src/httpsnippet.ts
@@ -13,10 +13,12 @@ import { ClientId, TargetId, targets } from './targets/targets';
 export { availableTargets, extname } from './helpers/utils';
 export { addTarget, addTargetClient } from './targets/targets';
 
-// @ts-ignore — we're implementing the logic for which FormData object ourselves
+// We're implementing the logic for which FormData object to use, ourselves.
 // This allows us to use the native FormData object in the browser and the `form-data` module in Node,
 // instead of relying on the package entrypoint to handle that.
-const resolveFormData = typeof window !== 'undefined' && window.FormData ? window.FormData : FormData;
+const resolveFormData =
+  // @ts-expect-error — we're only using window.FormData if it exists
+  typeof window !== 'undefined' && window.FormData ? window.FormData : FormData;
 
 const DEBUG_MODE = false;
 

--- a/src/httpsnippet.ts
+++ b/src/httpsnippet.ts
@@ -1,5 +1,5 @@
 import { map as eventStreamMap } from 'event-stream';
-import FormData from 'form-data';
+import FormData from 'form-data/lib/form_data';
 import { Param, PostDataCommon, Request as NpmHarRequest } from 'har-format';
 import { validateRequest } from 'har-validator-compiled';
 import { stringify as queryStringify } from 'querystring';
@@ -12,6 +12,11 @@ import { ClientId, TargetId, targets } from './targets/targets';
 
 export { availableTargets, extname } from './helpers/utils';
 export { addTarget, addTargetClient } from './targets/targets';
+
+// @ts-ignore — we're implementing the logic for which FormData object ourselves
+// This allows us to use the native FormData object in the browser and the `form-data` module in Node,
+// instead of relying on the package entrypoint to handle that.
+const resolveFormData = typeof window !== 'undefined' && window.FormData ? window.FormData : FormData;
 
 const DEBUG_MODE = false;
 
@@ -174,7 +179,7 @@ export class HTTPSnippet {
         request.postData.mimeType = 'multipart/form-data';
 
         if (request.postData?.params) {
-          const form = new FormData();
+          const form = new resolveFormData();
 
           // The `form-data` module returns one of two things: a native FormData object, or its own polyfill
           // Since the polyfill does not support the full API of the native FormData object, when this library is running in a browser environment it'll fail on two things:
@@ -186,7 +191,6 @@ export class HTTPSnippet {
           // Since the native FormData object is iterable, we easily detect what version of `form-data` we're working with here to allow `multipart/form-data` requests to be compiled under both browser and Node environments.
           //
           // This hack is pretty awful but it's the only way we can use this library in the browser as if we code this against just the native FormData object, we can't polyfill that back into Node because Blob and File objects, which something like `formdata-polyfill` requires, don't exist there.
-          // @ts-expect-error TODO
           const isNativeFormData = typeof form[Symbol.iterator] === 'function';
 
           // TODO: THIS ABSOLUTELY MUST BE REMOVED.
@@ -194,7 +198,6 @@ export class HTTPSnippet {
           // easter egg
           const boundary = '---011000010111000001101001'; // this is binary for "api". yep.
           if (!isNativeFormData) {
-            // @ts-expect-error THIS IS WRONG.  VERY WRONG.
             form._boundary = boundary;
           }
 
@@ -205,16 +208,13 @@ export class HTTPSnippet {
 
             if (isNativeFormData) {
               if (isBlob(value)) {
-                // @ts-expect-error TODO
                 form.append(name, value, filename);
               } else {
                 form.append(name, value);
               }
             } else {
               form.append(name, value, {
-                // @ts-expect-error TODO
                 filename,
-                // @ts-expect-error TODO
                 contentType: param.contentType || null,
               });
             }

--- a/src/types/form-data.d.ts
+++ b/src/types/form-data.d.ts
@@ -1,0 +1,4 @@
+declare module 'form-data/lib/form_data' {
+    import FormData from 'form-data';
+  export default FormData;
+}

--- a/src/types/form-data.d.ts
+++ b/src/types/form-data.d.ts
@@ -1,4 +1,4 @@
 declare module 'form-data/lib/form_data' {
-    import FormData from 'form-data';
+  import FormData from 'form-data';
   export default FormData;
 }


### PR DESCRIPTION
## Background

The `form-data` package exports two entry points:
```json
"main": "./lib/form_data",
"browser": "./lib/browser",
```

The browser entry point is supposed to be used only in browser environment, which is why it accesses the `window` object:
```js
module.exports = typeof self == 'object' ? self.FormData : window.FormData;
```

However, a lot of build tools (e.g. Vite) prefer the browser entrypoint during SSR. Due to this, we end up accessing the `window` object during SSR, which breaks rendering.

This was reported in #212 previously, but the upstream package [form-data](https://github.com/form-data/form-data) doesn't have a fix for it.
I tried to revive the [conversation about adding a fix](https://github.com/form-data/form-data/pull/496#issuecomment-2411288429) for SSR failure in form-data, but don't think there'll be a fix from their side.

## Fix

When we import from the package root like this `import FormData from 'form-data'`, we depend on the bundler for resolving the entry point correctly. This is why we can end up importing from the `browser.js` entrypoint instead of the `form_data` entrypoint.
This can be fixed by directly importing from `form_data.js`, like this: `import FormData from 'form-data/lib/form_data'`. For TypeScript support, I added a module declaration in the `form-data.d.ts` file that re-exports the types from the library.
Also added a check to fallback to the browser's `FormData` in case the `window` object is not defined.