### PR TITLE
chore: revert last 2 commits

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
-# Ignore everything by default
-# NOTE: NPM publish will never ignore package.json, package-lock.json, README, LICENSE, CHANGELOG
-# https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html
-*
 
-# Don't ignore dist folder
-!dist/**
+# Originally this repo ignored everything except the !dist folder.
+# However, this is a fork and we are not publishing an actual package.
+# The code will be installed directly in package.json like this:
+# "httpsnippet": "git+https://github.com/jci-metasys/httpsnippet.git#v3.0.9-jci1",
+# Due to this, all ignores are removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "httpsnippet",
-  "version": "3.0.9",
+  "version": "3.0.9-jci1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "httpsnippet",
-      "version": "3.0.9",
+      "version": "3.0.9-jci1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -43,7 +43,7 @@
         "typescript": "^4.6.3"
       },
       "engines": {
-        "node": "^14.19.1 || ^16.14.2 || ^18.0.0 || ^20.0.0"
+        "node": "^14.19.1 || ^16.14.2 || ^18.0.0 || ^20.0.0 || ^24.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.9",
+  "version": "3.0.9-jci1",
   "name": "httpsnippet",
   "description": "HTTP Request snippet generator for *most* languages",
   "author": "Kong <office@konghq.com>",
@@ -41,7 +41,7 @@
     "xmlhttprequest"
   ],
   "engines": {
-    "node": "^14.19.1 || ^16.14.2 || ^18.0.0 || ^20.0.0"
+    "node": "^14.19.1 || ^16.14.2 || ^18.0.0 || ^20.0.0 || ^24.0.0"
   },
   "repository": "Kong/httpsnippet",
   "bugs": {


### PR DESCRIPTION
We are going to publish a package of httpsnippet under jci-metasys. Reverting the previous 2 commits so we can set things up the right way.